### PR TITLE
Mark support/general outofscope until zendesk is removed or updated

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+[zap.conf]
+indent_size = 4
+indent_style = tab

--- a/zap.conf
+++ b/zap.conf
@@ -119,3 +119,4 @@
 90030	WARN	(WSDL File Detection - Passive/alpha)
 90033	WARN	(Loosely Scoped Cookie - Passive/release)
 90034	WARN	(Cloud Metadata Potentially Exposed - Active/beta)
+*	OUTOFSCOPE	http://*:6012/support/general


### PR DESCRIPTION
OWASP incorrectly found what it thought was SQL injection on support/general, but it's really just broken due to zendesk not being configured. This PR marks that route as `OUTOFSCOPE` for OWASP, to be removed once #55 is done