### PR TITLE
Update services for post-sign-up tour

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1191,50 +1191,6 @@ class RenameOrganisationForm(StripWhitespaceForm):
         ])
 
 
-class AddGPOrganisationForm(StripWhitespaceForm):
-
-    def __init__(self, *args, service_name='unknown', **kwargs):
-        super().__init__(*args, **kwargs)
-        self.same_as_service_name.label.text = 'Is your GP practice called ‘{}’?'.format(service_name)
-        self.service_name = service_name
-
-    def get_organisation_name(self):
-        if self.same_as_service_name.data:
-            return self.service_name
-        return self.name.data
-
-    same_as_service_name = OnOffField(
-        'Is your GP practice called the same name as your service?',
-        choices=(
-            (True, 'Yes'),
-            (False, 'No'),
-        ),
-    )
-
-    name = GovukTextInputField(
-        'What’s your practice called?',
-    )
-
-    def validate_name(self, field):
-        if self.same_as_service_name.data is False:
-            if not field.data:
-                raise ValidationError('Cannot be empty')
-        else:
-            field.data = ''
-
-
-class AddNHSLocalOrganisationForm(StripWhitespaceForm):
-
-    def __init__(self, *args, organisation_choices=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.organisations.choices = organisation_choices
-
-    organisations = GovukRadiosField(
-        'Which NHS Trust or Clinical Commissioning Group do you work for?',
-        thing='an NHS Trust or Clinical Commissioning Group'
-    )
-
-
 class OrganisationOrganisationTypeForm(StripWhitespaceForm):
     organisation_type = OrganisationTypeField('What type of organisation is this?')
 
@@ -1298,7 +1254,7 @@ class CreateServiceForm(StripWhitespaceForm):
             MustContainAlphanumericCharacters(),
             Length(max=255, message='Service name must be 255 characters or fewer')
         ])
-    # organisation_type = OrganisationTypeField('Who runs this service?')
+    organisation_type = OrganisationTypeField('Where is this service run?')
 
 
 class AdminNewOrganisationForm(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1298,14 +1298,7 @@ class CreateServiceForm(StripWhitespaceForm):
             MustContainAlphanumericCharacters(),
             Length(max=255, message='Service name must be 255 characters or fewer')
         ])
-    organisation_type = OrganisationTypeField('Who runs this service?')
-
-
-class CreateNhsServiceForm(CreateServiceForm):
-    organisation_type = OrganisationTypeField(
-        'Who runs this service?',
-        include_only={'nhs_central', 'nhs_local', 'nhs_gp'},
-    )
+    # organisation_type = OrganisationTypeField('Who runs this service?')
 
 
 class AdminNewOrganisationForm(

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -5,7 +5,7 @@ from notifications_python_client.errors import HTTPError
 from app import service_api_client
 from app.formatters import email_safe
 from app.main import main
-from app.main.forms import CreateNhsServiceForm, CreateServiceForm
+from app.main.forms import CreateServiceForm
 from app.utils.user import user_is_gov_user, user_is_logged_in
 
 
@@ -45,14 +45,11 @@ def _create_example_template(service_id):
 @user_is_logged_in
 @user_is_gov_user
 def add_service():
-    default_organisation_type = current_user.default_organisation_type
-    if default_organisation_type == 'nhs':
-        form = CreateNhsServiceForm()
-        default_organisation_type = None
-    else:
-        form = CreateServiceForm(
-            organisation_type=default_organisation_type
-        )
+    # default_organisation_type = current_user.default_organisation_type
+    default_organisation_type = 'central'
+    form = CreateServiceForm(
+        organisation_type=default_organisation_type
+    )
 
     if form.validate_on_submit():
         email_from = email_safe(form.name.data)

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -45,10 +45,9 @@ def _create_example_template(service_id):
 @user_is_logged_in
 @user_is_gov_user
 def add_service():
-    # default_organisation_type = current_user.default_organisation_type
-    default_organisation_type = 'central'
+    default_organisation_type = current_user.default_organisation_type
     form = CreateServiceForm(
-        organisation_type=default_organisation_type
+        # organisation_type=default_organisation_type
     )
 
     if form.validate_on_submit():

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -17,8 +17,6 @@ from app import (
 )
 from app.main import main
 from app.main.forms import (
-    AddGPOrganisationForm,
-    AddNHSLocalOrganisationForm,
     AdminBillingDetailsForm,
     AdminNewOrganisationForm,
     AdminNotesForm,
@@ -78,62 +76,6 @@ def add_organisation():
     return render_template(
         'views/organisations/add-organisation.html',
         form=form
-    )
-
-
-@main.route('/services/<uuid:service_id>/add-gp-organisation', methods=['GET', 'POST'])
-@user_has_permissions('manage_service')
-def add_organisation_from_gp_service(service_id):
-    if (not current_service.organisation_type == Organisation.TYPE_NHS_GP) or current_service.organisation:
-        abort(403)
-
-    form = AddGPOrganisationForm(service_name=current_service.name)
-
-    if form.validate_on_submit():
-        Organisation.create(
-            form.get_organisation_name(),
-            crown=False,
-            organisation_type='nhs_gp',
-            agreement_signed=False,
-        ).associate_service(
-            service_id
-        )
-        return redirect(url_for(
-            '.service_agreement',
-            service_id=service_id,
-        ))
-
-    return render_template(
-        'views/organisations/add-gp-organisation.html',
-        form=form
-    )
-
-
-@main.route('/services/<uuid:service_id>/add-nhs-local-organisation', methods=['GET', 'POST'])
-@user_has_permissions('manage_service')
-def add_organisation_from_nhs_local_service(service_id):
-    if (not current_service.organisation_type == Organisation.TYPE_NHS_LOCAL) or current_service.organisation:
-        abort(403)
-
-    form = AddNHSLocalOrganisationForm(organisation_choices=[
-        (organisation.id, organisation.name)
-        for organisation in sorted(AllOrganisations())
-        if organisation.organisation_type == Organisation.TYPE_NHS_LOCAL
-    ])
-
-    search_form = SearchByNameForm()
-
-    if form.validate_on_submit():
-        Organisation.from_id(form.organisations.data).associate_service(service_id)
-        return redirect(url_for(
-            '.service_agreement',
-            service_id=service_id,
-        ))
-
-    return render_template(
-        'views/organisations/add-nhs-local-organisation.html',
-        form=form,
-        search_form=search_form,
     )
 
 

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -16,30 +16,36 @@ from app.notify_client.organisations_api_client import organisations_client
 
 class Organisation(JSONModel, SortByNameMixin):
 
-    TYPE_CENTRAL = 'central'
-    TYPE_LOCAL = 'local'
-    TYPE_NHS_CENTRAL = 'nhs_central'
-    TYPE_NHS_LOCAL = 'nhs_local'
-    TYPE_NHS_GP = 'nhs_gp'
-    TYPE_EMERGENCY_SERVICE = 'emergency_service'
-    TYPE_SCHOOL_OR_COLLEGE = 'school_or_college'
-    TYPE_OTHER = 'other'
+    TYPE_FEDERAL = 'federal'
+    TYPE_STATE = 'state'
 
-    NHS_TYPES = (
-        TYPE_NHS_CENTRAL,
-        TYPE_NHS_LOCAL,
-        TYPE_NHS_GP,
-    )
+    # TYPE_CENTRAL = 'central'
+    # TYPE_LOCAL = 'local'
+    # TYPE_NHS_CENTRAL = 'nhs_central'
+    # TYPE_NHS_LOCAL = 'nhs_local'
+    # TYPE_NHS_GP = 'nhs_gp'
+    # TYPE_EMERGENCY_SERVICE = 'emergency_service'
+    # TYPE_SCHOOL_OR_COLLEGE = 'school_or_college'
+    # TYPE_OTHER = 'other'
+
+    # NHS_TYPES = (
+    #     TYPE_NHS_CENTRAL,
+    #     TYPE_NHS_LOCAL,
+    #     TYPE_NHS_GP,
+    # )
 
     TYPE_LABELS = OrderedDict([
-        (TYPE_CENTRAL, 'Central government'),
-        (TYPE_LOCAL, 'Local government'),
-        (TYPE_NHS_CENTRAL, 'NHS – central government agency or public body'),
-        (TYPE_NHS_LOCAL, 'NHS Trust or Clinical Commissioning Group'),
-        (TYPE_NHS_GP, 'GP practice'),
-        (TYPE_EMERGENCY_SERVICE, 'Emergency service'),
-        (TYPE_SCHOOL_OR_COLLEGE, 'School or college'),
-        (TYPE_OTHER, 'Other'),
+        (TYPE_FEDERAL, 'Federal government'),
+        (TYPE_STATE, 'State government')
+
+        # (TYPE_CENTRAL, 'Central government'),
+        # (TYPE_LOCAL, 'Local government'),
+        # (TYPE_NHS_CENTRAL, 'NHS – central government agency or public body'),
+        # (TYPE_NHS_LOCAL, 'NHS Trust or Clinical Commissioning Group'),
+        # (TYPE_NHS_GP, 'GP practice'),
+        # (TYPE_EMERGENCY_SERVICE, 'Emergency service'),
+        # (TYPE_SCHOOL_OR_COLLEGE, 'School or college'),
+        # (TYPE_OTHER, 'Other'),
     ])
 
     ALLOWED_PROPERTIES = {


### PR DESCRIPTION
This swaps out the UK org types for "federal" and "state".

On the API side, this needs those values added to the DB. It looks like the existing ones are inserted by migration, but I couldn't manage to write a migration that Flask liked (and the official docs don't help at all). I just ran `INSERT INTO organisation_types VALUES ('state','f','250000'),('federal','f','250000');`.

I'm guessing we want that migration before merging.