### PR TITLE
Access the API endpiont over internal interfaces

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -33,7 +33,7 @@ applications:
       ADMIN_CLIENT_SECRET: ((ADMIN_CLIENT_SECRET))
       ADMIN_CLIENT_USERNAME: ((ADMIN_CLIENT_USERNAME))
       ADMIN_BASE_URL: https://notifications-admin.app.cloud.gov
-      API_HOST_NAME: https://notifications-api.app.cloud.gov
+      API_HOST_NAME: https://notifications-api-((env)).apps.internal:61443
       DANGEROUS_SALT: ((DANGEROUS_SALT))
       SECRET_KEY: ((SECRET_KEY))
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -30,7 +30,24 @@ module "logo_upload_bucket" {
   s3_service_name  = "${local.app_name}-logo-upload-bucket-${local.env}"
 }
 
+# ##########################################################################
+# The following lines need to be commented out for the initial `terraform apply`
+# It can be re-enabled after:
+# 1) the api app has first been deployed
+# 2) the admin app has first been deployed
 ###########################################################################
+# module "api_network_route" {
+#   source = "../shared/container_networking"
+#
+#   cf_user              = var.cf_user
+#   cf_password          = var.cf_password
+#   cf_org_name          = local.cf_org_name
+#   cf_space_name        = local.cf_space_name
+#   source_app_name      = "${local.app_name}-${local.env}"
+#   destination_app_name = "notifications-api-${local.env}"
+# }
+
+# ##########################################################################
 # The following lines need to be commented out for the initial `terraform apply`
 # It can be re-enabled after:
 # 1) the app has first been deployed

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -1,2 +1,5 @@
-variable "cf_password" {}
+variable "cf_password" {
+  type      = string
+  sensitive = true
+}
 variable "cf_user" {}

--- a/terraform/shared/container_networking/main.tf
+++ b/terraform/shared/container_networking/main.tf
@@ -1,0 +1,22 @@
+data "cloudfoundry_space" "space" {
+  org_name = var.cf_org_name
+  name     = var.cf_space_name
+}
+
+data "cloudfoundry_app" "source_app" {
+  name_or_id = var.source_app_name
+  space      = data.cloudfoundry_space.space.id
+}
+
+data "cloudfoundry_app" "destination_app" {
+  name_or_id = var.destination_app_name
+  space      = data.cloudfoundry_space.space.id
+}
+
+resource "cloudfoundry_network_policy" "internal_route" {
+  policy {
+    source_app      = data.cloudfoundry_app.source_app.id
+    destination_app = data.cloudfoundry_app.destination_app.id
+    port            = var.destination_port
+  }
+}

--- a/terraform/shared/container_networking/providers.tf
+++ b/terraform/shared/container_networking/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "~> 0.15"
+    }
+  }
+}
+
+provider "cloudfoundry" {
+  api_url      = "https://api.fr.cloud.gov"
+  user         = var.cf_user
+  password     = var.cf_password
+  app_logs_max = 30
+}

--- a/terraform/shared/container_networking/variables.tf
+++ b/terraform/shared/container_networking/variables.tf
@@ -9,5 +9,7 @@ variable "source_app_name" {}
 variable "destination_app_name" {}
 variable "destination_port" {
   type    = string
+  # 61443 is the port to use to enable automatic TLS termination as specified at
+  # https://cloud.gov/docs/management/container-to-container/#configuring-secure-container-to-container-networking
   default = "61443"
 }

--- a/terraform/shared/container_networking/variables.tf
+++ b/terraform/shared/container_networking/variables.tf
@@ -1,0 +1,13 @@
+variable "cf_password" {
+  type      = string
+  sensitive = true
+}
+variable "cf_user" {}
+variable "cf_org_name" {}
+variable "cf_space_name" {}
+variable "source_app_name" {}
+variable "destination_app_name" {}
+variable "destination_port" {
+  type    = string
+  default = "61443"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -29,3 +29,14 @@ module "logo_upload_bucket" {
   recursive_delete = local.recursive_delete
   s3_service_name  = "${local.app_name}-logo-upload-bucket-${local.env}"
 }
+
+module "api_network_route" {
+  source = "../shared/container_networking"
+
+  cf_user              = var.cf_user
+  cf_password          = var.cf_password
+  cf_org_name          = local.cf_org_name
+  cf_space_name        = local.cf_space_name
+  source_app_name      = "${local.app_name}-${local.env}"
+  destination_app_name = "notifications-api-${local.env}"
+}

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,2 +1,5 @@
-variable "cf_password" {}
+variable "cf_password" {
+  type      = string
+  sensitive = true
+}
 variable "cf_user" {}


### PR DESCRIPTION
Small change for the admin app to access the API over internal container-to-container networking, rather than going back through the public internet routes.

I am _pretty_ sure that all admin webapp traffic is proxied through the admin app before going to the API, but if that is wrong then this will break the admin app.