### PR TITLE
Tell requests to use the system ca certificates bundle

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -44,3 +44,5 @@ applications:
       BASIC_AUTH_PASSWORD: ((BASIC_AUTH_PASSWORD))
 
       NOTIFY_BILLING_DETAILS: []
+
+      REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
This allows requests to find the certs for container-to-container networking