### PR TITLE
Swap dollar symbols for pound symbols

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -300,6 +300,7 @@ def nl2br(value):
     return ''
 
 
+# this formatter appears to only be used in the letter module
 def format_number_in_pounds_as_currency(number):
     if number >= 1:
         return f"£{number:,.2f}"

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -182,8 +182,8 @@ def download_organisation_usage_report(org_id):
     ])
 
     monetary_column_names = OrderedDict([
-        ('sms_cost', 'Spent on text messages (£)'),
-        ('letter_cost', 'Spent on letters (£)')
+        ('sms_cost', 'Spent on text messages ($)'),
+        ('letter_cost', 'Spent on letters ($)')
     ])
 
     org_usage_data = [

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -12,7 +12,7 @@
         {{ big_number(
           sms_cost,
           'spent on text messages',
-          currency="£",
+          currency="$",
           smaller=True
         ) }}
       {% else %}
@@ -25,7 +25,7 @@
       {{ big_number(
         letter_cost,
         'spent on letters',
-        currency="£",
+        currency="$",
         smaller=True
       ) }}
     </div>

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -33,7 +33,7 @@
         {{ big_number(
           total_sms_cost,
           'spent',
-          currency="£",
+          currency="$",
           smaller=True
         ) }}
       </div>
@@ -44,7 +44,7 @@
         {{ big_number(
           total_letter_cost,
           'spent',
-          currency="£",
+          currency="$",
           smaller=True
         ) }}
       </div>
@@ -82,7 +82,7 @@
             {{ big_number(
               service.sms_cost,
               'spent on text messages',
-              currency="£",
+              currency="$",
               smallest=True
             ) }}
           {% else %}
@@ -97,7 +97,7 @@
           {{ big_number(
             service.letter_cost,
             'spent on letters',
-            currency="£",
+            currency="$",
             smallest=True
           ) }}
         </div>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -63,7 +63,7 @@
             {{ big_number(
               sms_cost,
               'spent',
-              currency="£",
+              currency="$",
               smaller=True
             ) }}
           </div>
@@ -73,7 +73,7 @@
             {{ big_number(
                 letter_cost,
                 'spent',
-                currency="£",
+                currency="$",
                 smaller=True
               ) }}
           </div>
@@ -100,7 +100,7 @@
             {% call field(align='left') %}
               {{ big_number(
                 item.sms_cost + item.letter_cost,
-                currency="£",
+                currency="$",
                 smallest=True
               ) }}
               <ul>

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -469,8 +469,8 @@ def test_organisation_services_shows_live_services_and_usage(
 
     # Totals
     assert normalize_spaces(usage_rows[0].text) == "Emails 33,000 sent"
-    assert normalize_spaces(usage_rows[1].text) == "Text messages £42.00 spent"
-    assert normalize_spaces(usage_rows[2].text) == "Letters £30.50 spent"
+    assert normalize_spaces(usage_rows[1].text) == "Text messages $42.00 spent"
+    assert normalize_spaces(usage_rows[2].text) == "Letters $30.50 spent"
 
     assert normalize_spaces(services[0].text) == '1'
     assert normalize_spaces(services[1].text) == '5'
@@ -478,11 +478,11 @@ def test_organisation_services_shows_live_services_and_usage(
 
     assert normalize_spaces(usage_rows[3].text) == "13,000 emails sent"
     assert normalize_spaces(usage_rows[4].text) == "122 free text messages sent"
-    assert normalize_spaces(usage_rows[5].text) == "£30.50 spent on letters"
+    assert normalize_spaces(usage_rows[5].text) == "$30.50 spent on letters"
     assert services[1].find('a')['href'] == url_for('main.usage', service_id=SERVICE_TWO_ID)
     assert normalize_spaces(usage_rows[6].text) == "20,000 emails sent"
-    assert normalize_spaces(usage_rows[7].text) == "£42.00 spent on text messages"
-    assert normalize_spaces(usage_rows[8].text) == "£0.00 spent on letters"
+    assert normalize_spaces(usage_rows[7].text) == "$42.00 spent on text messages"
+    assert normalize_spaces(usage_rows[8].text) == "$0.00 spent on letters"
 
     # Ensure there’s no ‘this org has no services message’
     assert not page.select('.govuk-hint')
@@ -512,12 +512,12 @@ def test_organisation_services_shows_live_services_and_usage_with_count_of_1(
 
     # Totals
     assert normalize_spaces(usage_rows[0].text) == "Emails 1 sent"
-    assert normalize_spaces(usage_rows[1].text) == "Text messages £0.00 spent"
-    assert normalize_spaces(usage_rows[2].text) == "Letters £0.00 spent"
+    assert normalize_spaces(usage_rows[1].text) == "Text messages $0.00 spent"
+    assert normalize_spaces(usage_rows[2].text) == "Letters $0.00 spent"
 
     assert normalize_spaces(usage_rows[3].text) == "1 email sent"
     assert normalize_spaces(usage_rows[4].text) == "1 free text message sent"
-    assert normalize_spaces(usage_rows[5].text) == "£0.00 spent on letters"
+    assert normalize_spaces(usage_rows[5].text) == "$0.00 spent on letters"
 
 
 @freeze_time("2020-02-20 20:20")
@@ -716,7 +716,7 @@ def test_download_organisation_usage_report(
 
     assert csv_report.string == (
         "Service ID,Service Name,Emails sent,Free text message allowance remaining,"
-        "Spent on text messages (£),Spent on letters (£)"
+        "Spent on text messages ($),Spent on letters ($)"
         "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,0,1.93,30.50"
         "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,0,3.94,60.50\r\n"
     )

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1019,14 +1019,14 @@ def test_usage_page(
     assert '251,800 sent' in sms_column
     assert '250,000 free allowance' in sms_column
     assert '0 free allowance remaining' in sms_column
-    assert '£29.85 spent' in sms_column
+    assert '$29.85 spent' in sms_column
     assert '1,500 at 1.65 pence' in sms_column
     assert '300 at 1.70 pence' in sms_column
 
     letter_column = normalize_spaces(annual_usage[2].text + annual_usage[5].text)
     assert 'Letters' in letter_column
     assert '100 sent' in letter_column
-    assert '£30.00 spent' in letter_column
+    assert '$30.00 spent' in letter_column
 
 
 @freeze_time("2012-03-31 12:12:12")
@@ -1056,7 +1056,7 @@ def test_usage_page_no_sms_spend(
     assert 'Text messages' in sms_column
     assert '250,000 free allowance' in sms_column
     assert '249,000 free allowance remaining' in sms_column
-    assert '£0.00 spent' in sms_column
+    assert '$0.00 spent' in sms_column
     assert 'pence per message' not in sms_column
 
 
@@ -1075,7 +1075,7 @@ def test_usage_page_monthly_breakdown(
     assert '249,860 free text messages' in monthly_breakdown
 
     assert 'February' in monthly_breakdown
-    assert '£29.55' in monthly_breakdown
+    assert '$29.55' in monthly_breakdown
     assert '140 free text messages' in monthly_breakdown
     assert '960 text messages at 1.65p' in monthly_breakdown
     assert '33 text messages at 1.70p' in monthly_breakdown
@@ -1085,7 +1085,7 @@ def test_usage_page_monthly_breakdown(
     assert '7 international letters at 84p' in monthly_breakdown
 
     assert 'March' in monthly_breakdown
-    assert '£20.91' in monthly_breakdown
+    assert '$20.91' in monthly_breakdown
     assert '1,230 text messages at 1.70p' in monthly_breakdown
 
 
@@ -1726,9 +1726,9 @@ def test_service_dashboard_shows_usage(
     ) == (
         'Unlimited '
         'free email allowance '
-        '£29.85 '
+        '$29.85 '
         'spent on text messages '
-        '£30.00 '
+        '$30.00 '
         'spent on letters'
     )
 


### PR DESCRIPTION
This is pretty simple, just putting `$` where `£` used to be.

I changed the symbols in the UI, but left them for letter rates and some currently-unreachable pages. The thinking there is that the info wouldn't be accurate, so it's helpful to have the `£` as a clear indicator of a stale page/function.