### PR TITLE
Hide letters in non-admin UI

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1674,7 +1674,7 @@ class SupportRedirect(StripWhitespaceForm):
     who = GovukRadiosField(
         'What do you need help with?',
         choices=[
-            ('public-sector', 'I work in the public sector and need to send emails, text messages or letters'),
+            ('public-sector', 'I work in the public sector and need to send emails or text messages'),
             ('public', 'I’m a member of the public with a question for the government'),
         ],
         param_extensions={

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -12,10 +12,10 @@ def features_nav():
                     "name": "Text messages",
                     "link": "main.features_sms",
                 },
-                {
-                    "name": "Letters",
-                    "link": "main.features_letters",
-                },
+                # {
+                #     "name": "Letters",
+                #     "link": "main.features_letters",
+                # },
             ]
         },
         {
@@ -84,14 +84,14 @@ def using_notify_nav():
                     "name": "Send files by email",
                     "link": "main.send_files_by_email",
                 },
-                {
-                    "name": "Upload a letter",
-                    "link": "main.upload_a_letter",
-                },
-                {
-                    "name": "Letter specification",
-                    "link": "main.letter_specification",
-                },
+                # {
+                #     "name": "Upload a letter",
+                #     "link": "main.upload_a_letter",
+                # },
+                # {
+                #     "name": "Letter specification",
+                #     "link": "main.letter_specification",
+                # },
             ]
         },
         {

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -16,7 +16,7 @@
       <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
     {% endif %}
     {% if not current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }} demo-tooltip" data-demo-tooltip="⚠️ This feature is not available in demo mode" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Letters</a></li>
+      <!-- <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }} demo-tooltip" data-demo-tooltip="⚠️ This feature is not available in demo mode" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Letters</a></li> -->
     {% endif %}
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     {% if current_user.has_permissions('manage_service', allow_org_user=True) and not current_service.has_permission('broadcast') %}

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -2,7 +2,7 @@
 
 <div class="ajax-block-container">
   <div class="govuk-grid-row">
-    <div id="total-email" class="govuk-grid-column-one-third">
+    <div id="total-email" class="govuk-grid-column-one-half">
       {{ big_number_with_status(
         statistics['email']['requested'],
         statistics['email']['requested']|message_count_label('email', suffix='sent'),
@@ -14,7 +14,7 @@
         smaller=True,
       ) }}
     </div>
-    <div id="total-sms" class="govuk-grid-column-one-third">
+    <div id="total-sms" class="govuk-grid-column-one-half">
       {{ big_number_with_status(
         statistics['sms']['requested'],
         statistics['sms']['requested']|message_count_label('sms', suffix='sent'),
@@ -26,7 +26,7 @@
         smaller=True,
       ) }}
     </div>
-    <div id="total-letters" class="govuk-grid-column-one-third">
+    <!-- <div id="total-letters" class="govuk-grid-column-one-third">
       {{ big_number_with_status(
         statistics['letter']['requested'],
         statistics['letter']['requested']|message_count_label('letter', suffix='sent'),
@@ -37,6 +37,6 @@
         link=url_for(".view_notifications", service_id=service_id, message_type='letter', status=''),
         smaller=True,
       ) }}
-    </div>
+    </div> -->
   </div>
 </div>

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,12 +1,12 @@
 {% from "components/big-number.html" import big_number %}
 
 <div class='govuk-grid-row ajax-block-container'>
-  <div class='govuk-grid-column-one-third'>
+  <div class='govuk-grid-column-one-half'>
     <div class="keyline-block">
       {{ big_number("Unlimited", 'free email allowance', smaller=True) }}
     </div>
   </div>
-  <div class='govuk-grid-column-one-third'>
+  <div class='govuk-grid-column-one-half'>
     <div class="keyline-block">
       {% if sms_cost %}
         {{ big_number(
@@ -20,7 +20,7 @@
       {% endif %}
     </div>
   </div>
-  <div class='govuk-grid-column-one-third'>
+  <!-- <div class='govuk-grid-column-one-third'>
     <div class="keyline-block">
       {{ big_number(
         letter_cost,
@@ -29,5 +29,5 @@
         smaller=True
       ) }}
     </div>
-  </div>
+  </div> -->
 </div>

--- a/app/templates/views/dashboard/write-first-messages.html
+++ b/app/templates/views/dashboard/write-first-messages.html
@@ -2,10 +2,10 @@
 
 <nav>
   <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.choose_template', service_id=current_service.id) }}">
-    {% if 'letter' in current_service.permissions %}
+    <!-- {% if 'letter' in current_service.permissions %}
       Write an email, text message or letter
-    {% else %}
+    {% else %} -->
       Write an email or text message
-    {% endif %}
+    <!-- {% endif %} -->
   </a>
 </nav>

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -14,7 +14,7 @@
 <ul class="list list-bullet">
   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_email') }}">emails</a></li>
   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_sms') }}">text messages</a></li>
-  <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_letters') }}">letters</a></li>
+  <!-- <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_letters') }}">letters</a></li> -->
 </ul>
 <p class="govuk-body">You do not need any technical knowledge to use Notify.</p>
 {% if not current_user.is_authenticated %}
@@ -22,7 +22,7 @@
 {% endif %}
 
 <h2 class="heading-medium" id="templates">Reusable message templates</h2>
-<p class="govuk-body">To send an email, text or letter with Notify, you need to create a reusable message template first.</p>
+<p class="govuk-body">To send an email or text with Notify, you need to create a reusable message template first.</p>
 <p class="govuk-body">Templates let you send the same thing to lots of people, as often as you need to, without writing a new message each time.</p>
 
 <h2 class="heading-medium" id="personalised-messages">Personalised content</h2>
@@ -53,10 +53,10 @@
 <p class="govuk-body">Notify commits to:</p>
 <ul class="list list-bullet">
   <li>sending 95% of emails and text messages within 10 seconds</li>
-  <li>printing and posting letters by 3pm the next working day (if you send them to us before 5:30pm)</li>
+  <!-- <li>printing and posting letters by 3pm the next working day (if you send them to us before 5:30pm)</li> -->
 </ul>
 
-<p class="govuk-body">We send messages through several different providers. If one provider fails, Notify switches to another so that your messages are not affected.</p>
+<!-- <p class="govuk-body">We send messages through several different providers. If one provider fails, Notify switches to another so that your messages are not affected.</p> -->
 
 <p class="govuk-body">Visit our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.performance') }}">performance data</a> page to see how Notify is performing.</p>
 

--- a/app/templates/views/guidance/index.html
+++ b/app/templates/views/guidance/index.html
@@ -10,7 +10,7 @@
 
   <h1 class="heading-large">Guidance</h1>
 
-  <p class="govuk-body">This guidance is for teams using US Notify to send emails, text messages and letters.</p>
+  <p class="govuk-body">This guidance is for teams using US Notify to send emails and text messages.</p>
 
   <p class="govuk-body">It explains how to:</p>
 
@@ -18,16 +18,16 @@
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages') }}">edit and format messages</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation') }}">add branding and customisation</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.send_files_by_email') }}">send files by email</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter') }}">upload a letter</a></li>
+    <!-- <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter') }}">upload a letter</a></li> -->
   </ul>
 
   <h2 class="heading-medium">More information</h2>
 
-  <p class="govuk-body">The US NotifyService Manual has advice on:</p>
+  <p class="govuk-body">The US Notify Service Manual has advice on:</p>
 
   <ul class="list list-bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">planning and writing text messages and emails</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/writing-effective-letters">writing effective letters</a></li>
+    <!-- <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/writing-effective-letters">writing effective letters</a></li> -->
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/technology/how-to-email-your-users">sending emails from your service domain</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/technology/sending-text-messages-securely">sending text messages securely</a></li>
   </ul>

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -33,7 +33,7 @@
         {{ big_number(
           total_sms_cost,
           'spent',
-          currency="£",
+          currency="$",
           smaller=True
         ) }}
       </div>
@@ -44,7 +44,7 @@
         {{ big_number(
           total_letter_cost,
           'spent',
-          currency="£",
+          currency="$",
           smaller=True
         ) }}
       </div>
@@ -70,19 +70,19 @@
         <a href="{{ url_for('main.usage', service_id=service.service_id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.service_name  }}</a>
       </h3>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
+        <div class="govuk-grid-column-one-third">
           {{ big_number(
             service.emails_sent,
             label=service.emails_sent|message_count_label('email'),
             smallest=True
           ) }}
         </div>
-        <div class="govuk-grid-column-one-half">
+        <div class="govuk-grid-column-one-third">
           {% if service.sms_cost %}
             {{ big_number(
               service.sms_cost,
               'spent on text messages',
-              currency="£",
+              currency="$",
               smallest=True
             ) }}
           {% else %}
@@ -93,14 +93,14 @@
             ) }}
           {% endif %}
         </div>
-        <!-- <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-one-third">
           {{ big_number(
             service.letter_cost,
             'spent on letters',
-            currency="£",
+            currency="$",
             smallest=True
           ) }}
-        </div> -->
+        </div>
       </div>
     </div>
   {% endfor %}

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -70,14 +70,14 @@
         <a href="{{ url_for('main.usage', service_id=service.service_id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.service_name  }}</a>
       </h3>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-one-half">
           {{ big_number(
             service.emails_sent,
             label=service.emails_sent|message_count_label('email'),
             smallest=True
           ) }}
         </div>
-        <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-one-half">
           {% if service.sms_cost %}
             {{ big_number(
               service.sms_cost,
@@ -93,14 +93,14 @@
             ) }}
           {% endif %}
         </div>
-        <div class="govuk-grid-column-one-third">
+        <!-- <div class="govuk-grid-column-one-third">
           {{ big_number(
             service.letter_cost,
             'spent on letters',
             currency="£",
             smallest=True
           ) }}
-        </div>
+        </div> -->
       </div>
     </div>
   {% endfor %}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -109,7 +109,7 @@
           )
         }}
       {% endcall %}
-      {% call row() %}
+      <!-- {% call row() %}
         {{ text_field('Default letter branding') }}
         {{ optional_text_field(
           current_org.letter_branding.name,
@@ -121,7 +121,7 @@
             suffix='default letter branding for the organisation'
           )
         }}
-      {% endcall %}
+      {% endcall %} -->
       {% call row() %}
         {{ text_field('Known email domains') }}
         {{ optional_text_field(current_org.domains or None, default='None') }}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -22,10 +22,10 @@
   <p class="govuk-body">US Notify is free to use unless you:</p>
   <ul class="list list-bullet">
     <li>exceed your <a class="govuk-link govuk-link--no-visited-state" href="#text-messages">free text message allowance</a></li>
-    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#letters">letters</a></li>
+    <!-- <li>send <a class="govuk-link govuk-link--no-visited-state" href="#letters">letters</a></li> -->
   </ul>
 
-  <p class="govuk-body">You’ll only pay for the additional text messages or letters that you send. There’s no monthly charge, no setup fee and no procurement cost.</p>
+  <p class="govuk-body">You’ll only pay for the additional text messages that you send. There’s no monthly charge, no setup fee and no procurement cost.</p>
 
   <p class="govuk-body">
     {% if not current_user.is_authenticated %}
@@ -229,7 +229,7 @@
     "html": smsIntRates
   }) }}
 
-  <h2 class="heading-medium" id="letters">Letters</h2>
+  <!-- <h2 class="heading-medium" id="letters">Letters</h2>
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>
@@ -238,9 +238,9 @@
      <li>postage</li>
      <li>double-sided colour printing</li>
      <li>C5 size envelopes with an address window</li>
-  </ul>
+  </ul> -->
 
-  <div>
+  <!-- <div>
     {% call mapping_table(
       caption='Letter pricing',
       field_headings=['Paper', 'Second class', 'First class', 'International'],
@@ -262,6 +262,6 @@
         {% endcall %}
       {% endfor %}
     {% endcall %}
-  </div>
+  </div> -->
 
 {% endblock %}

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -19,7 +19,7 @@
 
     <h2 class="heading-medium" id="who-we-are">Who we are</h2>
 
-    <p class="govuk-body">US Notify is a service that lets public service teams in the UK send emails, text messages, and letters
+    <p class="govuk-body">US Notify is a service that lets public service teams in the United States send text messages
       to users of their service.</p>
 
     <p class="govuk-body">US Notify is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.</p>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -201,7 +201,7 @@
 
         {% endcall %}
 
-        {% call mapping_table(
+        <!-- {% call mapping_table(
           caption='Letter settings',
           field_headings=['Label', 'Value', 'Action'],
           field_headings_visible=False,
@@ -269,7 +269,7 @@
             )}}
           {% endcall %}
 
-        {% endcall %}
+        {% endcall %} -->
       {% endif %}
     </div>
 

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -2,7 +2,7 @@
 {% from "components/button/macro.njk" import govukButton %}
 
 {% block meta %}
-  <meta name="description" content="US Notify lets you send emails, text messages and letters to your users. Try it now if you work in federal, state or local government.">
+  <meta name="description" content="US Notify lets you send text messages and email to your users. Try it now if you work in federal, state or local government.">
 {% endblock %}
 
 {% block pageTitle %}
@@ -26,7 +26,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1>
-            Send emails, text messages and letters to your users
+            Send text messages and email to your users
           </h1>
           <p class="govuk-body">
             Try US Notify now if you work in federal, state or local government.
@@ -116,16 +116,6 @@
     </div>
   </div>
   <div class="product-page-section">
-    <h2 class="with-keyline">
-      Introducing US Notify
-    </h2>
-    <div class="responsive-embed responsive-embed--16by9 responsive-embed--bordered bottom-gutter-2">
-      <div class="responsive-embed__wrapper">
-        <iframe title="US Notify introduction video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/_90cv1YgQo4" frameborder="0" allowfullscreen></iframe>
-      </div>
-    </div>
-  </div>
-  <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2" id="whos-using-notify">
       <h2>Who’s using US Notify</h2>
       <div class="govuk-grid-row bottom-gutter">
@@ -147,7 +137,7 @@
       </p>
     </div>
   </div>
-  <div class="product-page-section">
+  <!-- <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2">
       <h2>Pricing</h2>
       <div class="govuk-grid-row bottom-gutter">
@@ -176,7 +166,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </div> -->
   <div class="product-page-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -13,7 +13,7 @@
     <ul class="list list-bullet">
      <li>send 50 text messages and emails per day</li>
       <li>send messages to yourself and other people in your team</li>
-     <li>create letter templates, but not send them</li>
+     <!-- <li>create letter templates, but not send them</li> -->
    </ul>
 
     {% if current_service and current_service.trial_mode %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -18,14 +18,14 @@
     </div>
     <div id='pill-selected-item'>
       <div class='govuk-grid-row'>
-        <div class='govuk-grid-column-one-third'>
+        <div class='govuk-grid-column-one-half'>
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
             {{ big_number(emails_sent, 'sent', smaller=True) }}
             {{ big_number("Unlimited", 'free allowance', smaller=True) }}
           </div>
         </div>
-        <div class='govuk-grid-column-one-third'>
+        <div class='govuk-grid-column-one-half'>
           <h2 class='heading-small'>Text messages</h2>
           <div class="keyline-block">
             {{ big_number(sms_sent, 'sent', smaller=True) }}
@@ -44,21 +44,21 @@
             {% endfor %}
           </div>
         </div>
-        <div class='govuk-grid-column-one-third'>
+        <!-- <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Letters</h2>
           <div class="keyline-block">
             {{ big_number(letter_sent, 'sent', smaller=True) }}
           </div>
-        </div>
+        </div> -->
       </div>
 
       <div class='govuk-grid-row'>
-        <div class='govuk-grid-column-one-third'>
+        <div class='govuk-grid-column-one-half'>
           <div class="keyline-block">
             &nbsp;
           </div>
         </div>
-        <div class='govuk-grid-column-one-third'>
+        <div class='govuk-grid-column-one-half'>
           <div class="keyline-block">
             {{ big_number(
               sms_cost,
@@ -68,7 +68,7 @@
             ) }}
           </div>
         </div>
-        <div class='govuk-grid-column-one-third'>
+        <!-- <div class='govuk-grid-column-one-third'>
           <div class="keyline-block">
             {{ big_number(
                 letter_cost,
@@ -77,7 +77,7 @@
                 smaller=True
               ) }}
           </div>
-        </div>
+        </div> -->
 
       </div>
 
@@ -111,12 +111,12 @@
                   <li class="tabular-numbers">{{ sms.charged_units|message_count('sms') }} at
                   {{- ' {:.2f}p'.format(sms.rate * 100) }}</li>
               {% endfor %}
-              {% for letter in item.letter_breakdown %}
+              <!-- {% for letter in item.letter_breakdown %}
                 {% if letter.sent %}
                   <li class="tabular-numbers">{{ "{:,} {}".format(letter.sent, letter.postage_description) }} {{ letter.sent|message_count_label('letter', suffix='') }} at
                   {{ letter.rate | format_number_in_pounds_as_currency }}</li>
                 {% endif %}
-              {% endfor %}
+              {% endfor %} -->
               {% if not (item.sms_free_allowance_used or item.sms_cost or item.letter_breakdown) %}
                 <li aria-hidden="true">–</li>
               {% endif %}

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -126,7 +126,6 @@ def test_service_navigation_for_org_user(
         (
             'Send messages',
             'Sent messages',
-            'Letters',
             'Team members',
         ),
         403,
@@ -136,7 +135,6 @@ def test_service_navigation_for_org_user(
         (
             'Send messages',
             'Sent messages',
-            'Letters',
             'Team members',
             'Usage',
         ),

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -326,7 +326,7 @@ def test_should_show_back_to_service_if_user_belongs_to_service(
         ''
         'Dashboard '
         'Send messages '
-        'Letters '
+        # 'Letters '
         'Team members'
     )  # TODO: set sidebar variables in common test module
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -469,8 +469,8 @@ def test_organisation_services_shows_live_services_and_usage(
 
     # Totals
     assert normalize_spaces(usage_rows[0].text) == "Emails 33,000 sent"
-    assert normalize_spaces(usage_rows[1].text) == "Text messages £42.00 spent"
-    assert normalize_spaces(usage_rows[2].text) == "Letters £30.50 spent"
+    assert normalize_spaces(usage_rows[1].text) == "Text messages $42.00 spent"
+    assert normalize_spaces(usage_rows[2].text) == "Letters $30.50 spent"
 
     assert normalize_spaces(services[0].text) == '1'
     assert normalize_spaces(services[1].text) == '5'
@@ -478,11 +478,11 @@ def test_organisation_services_shows_live_services_and_usage(
 
     assert normalize_spaces(usage_rows[3].text) == "13,000 emails sent"
     assert normalize_spaces(usage_rows[4].text) == "122 free text messages sent"
-    assert normalize_spaces(usage_rows[5].text) == "£30.50 spent on letters"
+    assert normalize_spaces(usage_rows[5].text) == "$30.50 spent on letters"
     assert services[1].find('a')['href'] == url_for('main.usage', service_id=SERVICE_TWO_ID)
     assert normalize_spaces(usage_rows[6].text) == "20,000 emails sent"
-    assert normalize_spaces(usage_rows[7].text) == "£42.00 spent on text messages"
-    assert normalize_spaces(usage_rows[8].text) == "£0.00 spent on letters"
+    assert normalize_spaces(usage_rows[7].text) == "$42.00 spent on text messages"
+    assert normalize_spaces(usage_rows[8].text) == "$0.00 spent on letters"
 
     # Ensure there’s no ‘this org has no services message’
     assert not page.select('.govuk-hint')
@@ -512,12 +512,12 @@ def test_organisation_services_shows_live_services_and_usage_with_count_of_1(
 
     # Totals
     assert normalize_spaces(usage_rows[0].text) == "Emails 1 sent"
-    assert normalize_spaces(usage_rows[1].text) == "Text messages £0.00 spent"
-    assert normalize_spaces(usage_rows[2].text) == "Letters £0.00 spent"
+    assert normalize_spaces(usage_rows[1].text) == "Text messages $0.00 spent"
+    assert normalize_spaces(usage_rows[2].text) == "Letters $0.00 spent"
 
     assert normalize_spaces(usage_rows[3].text) == "1 email sent"
     assert normalize_spaces(usage_rows[4].text) == "1 free text message sent"
-    assert normalize_spaces(usage_rows[5].text) == "£0.00 spent on letters"
+    assert normalize_spaces(usage_rows[5].text) == "$0.00 spent on letters"
 
 
 @freeze_time("2020-02-20 20:20")
@@ -938,7 +938,7 @@ def test_organisation_settings_for_platform_admin(
         'Billing details None Change billing details for the organisation',
         'Notes None Change the notes for the organisation',
         'Default email branding GOV.UK Change default email branding for the organisation',
-        'Default letter branding No branding Change default letter branding for the organisation',
+        # 'Default letter branding No branding Change default letter branding for the organisation',
         'Known email domains None Change known email domains for the organisation',
     ]
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2104,7 +2104,8 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
         "Reply-to email addresses test@example.com …and 2 more Manage reply-to email addresses"
     assert get_row(page, 'Text message senders') == \
         "Text message senders Example …and 2 more Manage text message senders"
-    # assert get_row(page, 'Sender addresses') == "Sender addresses 1 Example Street …and 2 more Manage sender addresses"
+    # assert get_row(page, 'Sender addresses') == \
+    #     "Sender addresses 1 Example Street …and 2 more Manage sender addresses"
 
 
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -74,8 +74,8 @@ def mock_get_service_settings_page_common(
         'Send international text messages Off Change your settings for sending international text messages',
         'Receive text messages Off Change your settings for receiving text messages',
 
-        'Label Value Action',
-        'Send letters Off Change your settings for sending letters',
+        # 'Label Value Action',
+        # 'Send letters Off Change your settings for sending letters',
 
     ]),
     (create_platform_admin_user(), [
@@ -97,8 +97,8 @@ def mock_get_service_settings_page_common(
         'Send international text messages Off Change your settings for sending international text messages',
         'Receive text messages Off Change your settings for receiving text messages',
 
-        'Label Value Action',
-        'Send letters Off Change your settings for sending letters',
+        # 'Label Value Action',
+        # 'Send letters Off Change your settings for sending letters',
 
         'Label Value Action',
         'Live Off Change service status',
@@ -344,8 +344,8 @@ def test_send_files_by_email_row_on_settings_page(
         'Send international text messages On Change your settings for sending international text messages',
         'Receive text messages On Change your settings for receiving text messages',
 
-        'Label Value Action',
-        'Send letters Off Change your settings for sending letters',
+        # 'Label Value Action',
+        # 'Send letters Off Change your settings for sending letters',
 
     ]),
     (['email', 'sms', 'email_auth'], [
@@ -366,28 +366,28 @@ def test_send_files_by_email_row_on_settings_page(
         'Send international text messages Off Change your settings for sending international text messages',
         'Receive text messages Off Change your settings for receiving text messages',
 
-        'Label Value Action',
-        'Send letters Off Change your settings for sending letters',
+        # 'Label Value Action',
+        # 'Send letters Off Change your settings for sending letters',
 
     ]),
-    (['letter'], [
+    # (['letter'], [
 
-        'Service name service one Change service name',
-        'Sign-in method Text message code Change sign-in method',
+    #     'Service name service one Change service name',
+    #     'Sign-in method Text message code Change sign-in method',
 
-        'Label Value Action',
-        'Send emails Off Change your settings for sending emails',
+    #     'Label Value Action',
+    #     'Send emails Off Change your settings for sending emails',
 
-        'Label Value Action',
-        'Send text messages Off Change your settings for sending text messages',
+    #     'Label Value Action',
+    #     'Send text messages Off Change your settings for sending text messages',
 
-        'Label Value Action',
-        'Send letters On Change your settings for sending letters',
-        'Send international letters Off Change',
-        'Sender addresses 1 Example Street Manage sender addresses',
-        'Letter branding Not set Change letter branding',
+    #     'Label Value Action',
+    #     'Send letters On Change your settings for sending letters',
+    #     'Send international letters Off Change',
+    #     'Sender addresses 1 Example Street Manage sender addresses',
+    #     'Letter branding Not set Change letter branding',
 
-    ]),
+    # ]),
     (['broadcast'], [
 
         'Service name service one Change service name',
@@ -418,6 +418,7 @@ def test_should_show_overview_for_service_with_more_things_set(
         assert row == " ".join(page.find_all('tr')[index + 1].text.split())
 
 
+@pytest.mark.skip(reason="Skipping letter-specific test")
 def test_if_cant_send_letters_then_cant_see_letter_contact_block(
         client_request,
         service_one,
@@ -430,6 +431,7 @@ def test_if_cant_send_letters_then_cant_see_letter_contact_block(
     assert 'Letter contact block' not in response
 
 
+@pytest.mark.skip(reason="Skipping letter-specific test")
 def test_letter_contact_block_shows_none_if_not_set(
     client_request,
     service_one,
@@ -449,6 +451,7 @@ def test_letter_contact_block_shows_none_if_not_set(
     assert 'default' in div.attrs['class'][0]
 
 
+@pytest.mark.skip(reason="Skipping letter-specific test")
 def test_escapes_letter_contact_block(
     client_request,
     service_one,
@@ -2085,7 +2088,7 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
         multiple_sms_senders,
         mock_get_service_settings_page_common,
 ):
-    service_one['permissions'] = ['email', 'sms', 'letter']
+    service_one['permissions'] = ['email', 'sms']
 
     page = client_request.get(
         'main.service_settings',
@@ -2101,7 +2104,7 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
         "Reply-to email addresses test@example.com …and 2 more Manage reply-to email addresses"
     assert get_row(page, 'Text message senders') == \
         "Text message senders Example …and 2 more Manage text message senders"
-    assert get_row(page, 'Sender addresses') == "Sender addresses 1 Example Street …and 2 more Manage sender addresses"
+    # assert get_row(page, 'Sender addresses') == "Sender addresses 1 Example Street …and 2 more Manage sender addresses"
 
 
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [
@@ -4755,6 +4758,7 @@ def test_service_settings_links_to_branding_request_page_for_emails(
     assert len(page.find_all('a', attrs={'href': expected_href})) == 1
 
 
+@pytest.mark.skip(reason="Skipping letter-specific test")
 def test_service_settings_links_to_branding_request_page_for_letters(
     mocker,
     service_one,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1028,6 +1028,7 @@ def test_usage_page(
     # assert '100 sent' in letter_column
     # assert '$30.00 spent' in letter_column
 
+
 @freeze_time("2012-03-31 12:12:12")
 def test_usage_page_no_sms_spend(
     mocker,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -904,21 +904,21 @@ def test_should_not_show_upcoming_jobs_on_dashboard_if_service_has_no_jobs(
 
 @pytest.mark.parametrize('permissions', (
     ['email', 'sms'],
-    ['email', 'sms', 'letter'],
+    # ['email', 'sms', 'letter'],
 ))
 @pytest.mark.parametrize('totals', [
     (
         {
             'email': {'requested': 0, 'delivered': 0, 'failed': 0},
             'sms': {'requested': 99999, 'delivered': 0, 'failed': 0},
-            'letter': {'requested': 99999, 'delivered': 0, 'failed': 0}
+            # 'letter': {'requested': 99999, 'delivered': 0, 'failed': 0}
         },
     ),
     (
         {
             'email': {'requested': 0, 'delivered': 0, 'failed': 0},
             'sms': {'requested': 0, 'delivered': 0, 'failed': 0},
-            'letter': {'requested': 100000, 'delivered': 0, 'failed': 0},
+            # 'letter': {'requested': 100000, 'delivered': 0, 'failed': 0},
         },
     ),
 ])
@@ -950,12 +950,12 @@ def test_correct_font_size_for_big_numbers(
     )
 
     assert (
-        len(page.select_one('[data-key=totals]').select('.govuk-grid-column-one-third'))
+        len(page.select_one('[data-key=totals]').select('.govuk-grid-column-one-half'))
     ) == (
-        len(page.select_one('[data-key=usage]').select('.govuk-grid-column-one-third'))
+        len(page.select_one('[data-key=usage]').select('.govuk-grid-column-one-half'))
     ) == (
         len(page.select('.big-number-with-status .big-number-smaller'))
-    ) == 3
+    ) == 2
 
 
 def test_should_not_show_jobs_on_dashboard_for_users_with_uploads_page(
@@ -1007,14 +1007,14 @@ def test_usage_page(
     assert normalize_spaces(unselected_nav_links[0].text) == '2010 to 2011 financial year'
     assert normalize_spaces(unselected_nav_links[1].text) == '2009 to 2010 financial year'
 
-    annual_usage = page.find_all('div', {'class': 'govuk-grid-column-one-third'})
+    annual_usage = page.find_all('div', {'class': 'govuk-grid-column-one-half'})
 
     # annual stats are shown in two rows, each with three column; email is col 1
-    email_column = normalize_spaces(annual_usage[0].text + annual_usage[3].text)
+    email_column = normalize_spaces(annual_usage[0].text + annual_usage[2].text)
     assert 'Emails' in email_column
     assert '1,000 sent' in email_column
 
-    sms_column = normalize_spaces(annual_usage[1].text + annual_usage[4].text)
+    sms_column = normalize_spaces(annual_usage[1].text + annual_usage[3].text)
     assert 'Text messages' in sms_column
     assert '251,800 sent' in sms_column
     assert '250,000 free allowance' in sms_column
@@ -1023,10 +1023,10 @@ def test_usage_page(
     assert '1,500 at 1.65 pence' in sms_column
     assert '300 at 1.70 pence' in sms_column
 
-    letter_column = normalize_spaces(annual_usage[2].text + annual_usage[5].text)
-    assert 'Letters' in letter_column
-    assert '100 sent' in letter_column
-    assert '£30.00 spent' in letter_column
+    # letter_column = normalize_spaces(annual_usage[2].text + annual_usage[5].text)
+    # assert 'Letters' in letter_column
+    # assert '100 sent' in letter_column
+    # assert '£30.00 spent' in letter_column
 
 
 @freeze_time("2012-03-31 12:12:12")
@@ -1051,8 +1051,8 @@ def test_usage_page_no_sms_spend(
         service_id=SERVICE_ONE_ID,
     )
 
-    annual_usage = page.find_all('div', {'class': 'govuk-grid-column-one-third'})
-    sms_column = normalize_spaces(annual_usage[1].text + annual_usage[4].text)
+    annual_usage = page.find_all('div', {'class': 'govuk-grid-column-one-half'})
+    sms_column = normalize_spaces(annual_usage[1].text + annual_usage[3].text)
     assert 'Text messages' in sms_column
     assert '250,000 free allowance' in sms_column
     assert '249,000 free allowance remaining' in sms_column
@@ -1079,10 +1079,10 @@ def test_usage_page_monthly_breakdown(
     assert '140 free text messages' in monthly_breakdown
     assert '960 text messages at 1.65p' in monthly_breakdown
     assert '33 text messages at 1.70p' in monthly_breakdown
-    assert '5 first class letters at 33p' in monthly_breakdown
-    assert '10 second class letters at 31p' in monthly_breakdown
-    assert '3 international letters at 55p' in monthly_breakdown
-    assert '7 international letters at 84p' in monthly_breakdown
+    # assert '5 first class letters at 33p' in monthly_breakdown
+    # assert '10 second class letters at 31p' in monthly_breakdown
+    # assert '3 international letters at 55p' in monthly_breakdown
+    # assert '7 international letters at 84p' in monthly_breakdown
 
     assert 'March' in monthly_breakdown
     assert '£20.91' in monthly_breakdown
@@ -1110,6 +1110,7 @@ def test_usage_page_monthly_breakdown_shows_months_so_far(
         assert len(rows) == expected_number_of_months
 
 
+@pytest.mark.skip(reason="Skipping letter-specific test")
 @freeze_time("2012-03-31 12:12:12")
 def test_usage_page_letter_breakdown_ordered_by_postage_and_rate(
     client_request,
@@ -1144,7 +1145,7 @@ def test_usage_page_with_0_free_allowance(
         year=2020,
     )
 
-    annual_usage = page.select('main .govuk-grid-column-one-third')
+    annual_usage = page.select('main .govuk-grid-column-one-half')
     sms_column = normalize_spaces(annual_usage[1].text)
 
     assert '0 free allowance' in sms_column
@@ -1705,7 +1706,7 @@ def test_breadcrumb_shows_if_service_is_suspended(
 
 @pytest.mark.parametrize('permissions', (
     ['email', 'sms'],
-    ['email', 'sms', 'letter'],
+    # ['email', 'sms', 'letter'],
 ))
 def test_service_dashboard_shows_usage(
     client_request,
@@ -1727,9 +1728,9 @@ def test_service_dashboard_shows_usage(
         'Unlimited '
         'free email allowance '
         '£29.85 '
-        'spent on text messages '
-        '£30.00 '
-        'spent on letters'
+        'spent on text messages'
+        # '£30.00 '
+        # 'spent on letters'
     )
 
 

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -51,7 +51,7 @@ def test_get_support_index_page_when_signed_out(
     assert normalize_spaces(
         page.select_one('form label[for=who-0]').text
     ) == (
-        'I work in the public sector and need to send emails, text messages or letters'
+        'I work in the public sector and need to send emails or text messages'
     )
     assert page.select_one('form input#who-0')['value'] == 'public-sector'
     assert normalize_spaces(

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -17,7 +17,7 @@ def test_non_logged_in_user_can_see_homepage(
     page = client_request.get('main.index', _test_page_title=False)
 
     assert page.h1.text.strip() == (
-        'Send emails, text messages and letters to your users'
+        'Send text messages and email to your users'
     )
 
     assert page.select_one('a[role=button][draggable=false]')['href'] == url_for(
@@ -25,7 +25,7 @@ def test_non_logged_in_user_can_see_homepage(
     )
 
     assert page.select_one('meta[name=description]')['content'].strip() == (
-        'US Notify lets you send emails, text messages and letters '
+        'US Notify lets you send text messages and email '
         'to your users. Try it now if you work in federal, state or local government.'
     )
 
@@ -360,6 +360,7 @@ def test_font_preload(
 @pytest.mark.parametrize('current_date, expected_rate', (
     ('2022-05-01', '1.72'),
 ))
+@pytest.mark.skip(reason="Currently hidden for TTS")
 def test_sms_price(
     client_request,
     mock_get_service_and_organisation_counts,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -514,7 +514,7 @@ def test_navigation_urls(
     ] == [
         '/services/{}'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
-        '/services/{}/uploads'.format(SERVICE_ONE_ID),
+        # '/services/{}/uploads'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),
         '/services/{}/usage'.format(SERVICE_ONE_ID),
         '/services/{}/service-settings'.format(SERVICE_ONE_ID),
@@ -593,7 +593,7 @@ def test_caseworkers_get_caseworking_navigation(
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('header + .govuk-width-container nav').text) == (
-        'Send messages Sent messages Letters Team members'
+        'Send messages Sent messages Team members'
     )
 
 
@@ -612,5 +612,5 @@ def test_caseworkers_see_jobs_nav_if_jobs_exist(
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('header + .govuk-width-container nav').text) == (
-        'Send messages Sent messages Letters Team members'
+        'Send messages Sent messages Team members'
     )


### PR DESCRIPTION
This PR removed the UI elements about letters for non-admin users. Because the letters stuff is still active in the API (though not hooked up to actually mail anything), I elected to leave the admin UI as-is to keep platform admin's ability to see all platform functions.

I looked through the code and as walked through as many UI elements as I could, but I still might have missed something. If I did, just let me know!