### PR TITLE
Only run pip-audit on runtime dependencies in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - uses: trailofbits/gh-action-pip-audit@v1.0.0
         with:
-          inputs: requirements.txt requirements_for_test.txt
+          inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237
       - name: Run npm audit
         run: make npm-audit

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: ./.github/actions/setup-project
     - uses: trailofbits/gh-action-pip-audit@v1.0.0
       with:
-        inputs: requirements.txt requirements_for_test.txt
+        inputs: requirements.txt
         ignore-vulns: PYSEC-2022-237
     - name: Run npm audit
       run: make npm-audit

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ freeze-requirements: ## create static requirements.txt
 .PHONY: pip-audit
 pip-audit:
 	pip install --upgrade pip-audit
-	pip-audit -r requirements.txt -r requirements_for_test.txt -l --ignore-vuln PYSEC-2022-237
+	pip-audit -r requirements.txt -l --ignore-vuln PYSEC-2022-237
+	-pip-audit -r requirements_for_test.txt -l
 
 .PHONY: audit
 audit: npm-audit pip-audit

--- a/devcontainer-admin/scripts/notify-admin-entrypoint.sh
+++ b/devcontainer-admin/scripts/notify-admin-entrypoint.sh
@@ -20,14 +20,14 @@ echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
 
 cd /workspace
 
-# Warm up git index prior to display status in prompt else it will
-# be quite slow on every invocation of starship.
-git status
-
 pip3 install -r requirements.txt
 make bootstrap
 
 # run flask
 # make run
+
+# Warm up git index prior to display status in prompt else it will
+# be quite slow on every invocation of starship.
+git status
 
 echo "FINISHED ENTRYPOINT SCRIPT"


### PR DESCRIPTION
`make audit` will still run against test dependencies, but CI/CD should only care about things that are installed on the server.