### PR TITLE
Replace old notifications- service prefix with notify-

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cloned from the brilliant work of the team at [GOV.UK Notify](https://github.com/alphagov/notifications-admin), cheers!
 
-US Notify admin application - https://notifications-admin.app.cloud.gov (contact team for access)
+US Notify admin application - https://notify-demo.app.cloud.gov (contact team for access)
 
  - Register and manage users
  - Create and manage services

--- a/app/config.py
+++ b/app/config.py
@@ -136,11 +136,11 @@ class Production(Config):
 
     # buckets
     CSV_UPLOAD_BUCKET = cloud_config.s3_credentials(
-        f"notifications-api-csv-upload-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
+        f"notify-api-csv-upload-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
     CONTACT_LIST_BUCKET = cloud_config.s3_credentials(
-        f"notifications-api-contact-list-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
+        f"notify-api-contact-list-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
     LOGO_UPLOAD_BUCKET = cloud_config.s3_credentials(
-        f"notifications-admin-logo-upload-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
+        f"notify-admin-logo-upload-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
 
 
 class Staging(Production):
@@ -155,7 +155,7 @@ class Demo(Staging):
 class Scanning(Production):
     BASIC_AUTH_FORCE = False
     HTTP_PROTOCOL = 'http'
-    API_HOST_NAME = 'https://notifications-api.app.cloud.gov/'
+    API_HOST_NAME = 'https://notify-api-demo.app.cloud.gov/'
     SECRET_KEY = 'dev-notify-secret-key'  # nosec B105 - only used in development
     ADMIN_CLIENT_USER_NAME = 'notify-admin'
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'  # nosec B105 - only used in development

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -23,7 +23,7 @@ def vcap_services():
         }],
         's3': [
             {
-                'name': 'notifications-api-csv-upload-bucket-test',
+                'name': 'notify-api-csv-upload-bucket-test',
                 'credentials': {
                     'access_key_id': 'csv-access',
                     'bucket': 'csv-upload-bucket',
@@ -32,7 +32,7 @@ def vcap_services():
                 }
             },
             {
-                'name': 'notifications-api-contact-list-bucket-test',
+                'name': 'notify-api-contact-list-bucket-test',
                 'credentials': bucket_credentials
             }
         ],
@@ -56,7 +56,7 @@ def test_redis_url_falls_back_to_REDIS_URL():
 def test_s3_bucket_credentials(vcap_services):
     os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
 
-    assert CloudfoundryConfig().s3_credentials('notifications-api-contact-list-bucket-test') == bucket_credentials
+    assert CloudfoundryConfig().s3_credentials('notify-api-contact-list-bucket-test') == bucket_credentials
 
 
 def test_s3_bucket_credentials_falls_back_to_empty_creds():


### PR DESCRIPTION
Forgotten update from the cloud.gov migration

https://github.com/GSA/notifications-api/issues/109