### PR TITLE
Tweak tail & jq usage to parse cf-cli@8 output

### DIFF
--- a/terraform/create_service_account.sh
+++ b/terraform/create_service_account.sh
@@ -67,7 +67,7 @@ cf create-service cloud-gov-service-account $role $service 1>&2
 cf create-service-key $service service-account-key 1>&2
 
 # output service key to stdout in secrets.auto.tfvars format
-creds=`cf service-key $service service-account-key | tail -n 4`
+creds=`cf service-key $service service-account-key | tail -n +2 | jq '.credentials'`
 username=`echo $creds | jq -r '.username'`
 password=`echo $creds | jq -r '.password'`
 

--- a/terraform/create_service_account.sh
+++ b/terraform/create_service_account.sh
@@ -18,8 +18,15 @@ Options:
 -o <ORG NAME>: configure the organization to act on. Default: $org
 
 Notes:
-OrgManager is required for terraform to create <env>-egress spaces
+* OrgManager is required for terraform to create <env>-egress spaces
+* Requires cf-cli@8
 "
+
+cf_version=`cf --version | cut -d " " -f 3`
+if [[ $cf_version != 8.* ]]; then
+  echo "$usage"
+  exit 1
+fi
 
 set -e
 set -o pipefail


### PR DESCRIPTION
Slight tweak for the cf-cli output format.

I had to update to 8 for the ssb work, so keeping it all in sync. Day-to-day 7 should still work fine if you're not using this script.