### PR TITLE
Remove direct use of aws creds from deployed environments

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -48,8 +48,6 @@ jobs:
         env:
           DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
           REDIS_ENABLED: ${{ secrets.REDIS_ENABLED }}
@@ -63,8 +61,6 @@ jobs:
             --vars-file deploy-config/demo.yml
             --var DANGEROUS_SALT="$DANGEROUS_SALT"
             --var SECRET_KEY="$SECRET_KEY"
-            --var AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-            --var AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
             --var REDIS_ENABLED="$REDIS_ENABLED"
             --var ADMIN_CLIENT_USERNAME="notify-admin"
             --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,6 @@ jobs:
         env:
           DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
           REDIS_ENABLED: ${{ secrets.REDIS_ENABLED }}
@@ -68,8 +66,6 @@ jobs:
             --vars-file deploy-config/staging.yml
             --var DANGEROUS_SALT="$DANGEROUS_SALT"
             --var SECRET_KEY="$SECRET_KEY"
-            --var AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-            --var AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
             --var REDIS_ENABLED="$REDIS_ENABLED"
             --var ADMIN_CLIENT_USERNAME="notify-admin"
             --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,5 @@
 import json
-import os
+from os import getenv
 
 import pytz
 
@@ -8,31 +8,31 @@ from app.cloudfoundry_config import cloud_config
 
 class Config(object):
     NOTIFY_APP_NAME = 'admin'
-    NOTIFY_ENVIRONMENT = os.environ.get('NOTIFY_ENVIRONMENT', 'development')
-    API_HOST_NAME = os.environ.get('API_HOST_NAME', 'localhost')
-    ADMIN_BASE_URL = os.environ.get('ADMIN_BASE_URL', 'http://localhost:6012')
+    NOTIFY_ENVIRONMENT = getenv('NOTIFY_ENVIRONMENT', 'development')
+    API_HOST_NAME = getenv('API_HOST_NAME', 'localhost')
+    ADMIN_BASE_URL = getenv('ADMIN_BASE_URL', 'http://localhost:6012')
     HEADER_COLOUR = '#81878b'  # mix(govuk-colour("dark-grey"), govuk-colour("mid-grey"))
     LOGO_CDN_DOMAIN = 'static-logos.notifications.service.gov.uk'  # TODO use our own CDN
     ASSETS_DEBUG = False
-    TIMEZONE = os.environ.get('TIMEZONE', 'America/New_York')
+    TIMEZONE = getenv('TIMEZONE', 'America/New_York')
     PY_TIMEZONE = pytz.timezone(TIMEZONE)
 
     # Credentials
-    ADMIN_CLIENT_SECRET = os.environ.get('ADMIN_CLIENT_SECRET')
-    ADMIN_CLIENT_USER_NAME = os.environ.get('ADMIN_CLIENT_USERNAME')
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    DANGEROUS_SALT = os.environ.get('DANGEROUS_SALT')
-    # ZENDESK_API_KEY = os.environ.get('ZENDESK_API_KEY')
-    ROUTE_SECRET_KEY_1 = os.environ.get('ROUTE_SECRET_KEY_1', 'dev-route-secret-key-1')
-    ROUTE_SECRET_KEY_2 = os.environ.get('ROUTE_SECRET_KEY_2', 'dev-route-secret-key-2')
-    BASIC_AUTH_USERNAME = os.environ.get('BASIC_AUTH_USERNAME')
-    BASIC_AUTH_PASSWORD = os.environ.get('BASIC_AUTH_PASSWORD')
+    ADMIN_CLIENT_SECRET = getenv('ADMIN_CLIENT_SECRET')
+    ADMIN_CLIENT_USER_NAME = getenv('ADMIN_CLIENT_USERNAME')
+    SECRET_KEY = getenv('SECRET_KEY')
+    DANGEROUS_SALT = getenv('DANGEROUS_SALT')
+    # ZENDESK_API_KEY = getenv('ZENDESK_API_KEY')
+    ROUTE_SECRET_KEY_1 = getenv('ROUTE_SECRET_KEY_1', 'dev-route-secret-key-1')
+    ROUTE_SECRET_KEY_2 = getenv('ROUTE_SECRET_KEY_2', 'dev-route-secret-key-2')
+    BASIC_AUTH_USERNAME = getenv('BASIC_AUTH_USERNAME')
+    BASIC_AUTH_PASSWORD = getenv('BASIC_AUTH_PASSWORD')
 
-    TEMPLATE_PREVIEW_API_HOST = os.environ.get('TEMPLATE_PREVIEW_API_HOST', 'http://localhost:9999')
-    TEMPLATE_PREVIEW_API_KEY = os.environ.get('TEMPLATE_PREVIEW_API_KEY', 'my-secret-key')
+    TEMPLATE_PREVIEW_API_HOST = getenv('TEMPLATE_PREVIEW_API_HOST', 'http://localhost:9999')
+    TEMPLATE_PREVIEW_API_KEY = getenv('TEMPLATE_PREVIEW_API_KEY', 'my-secret-key')
 
     # Logging
-    NOTIFY_LOG_LEVEL = os.environ.get('NOTIFY_LOG_LEVEL', 'INFO')
+    NOTIFY_LOG_LEVEL = getenv('NOTIFY_LOG_LEVEL', 'INFO')
 
     DEFAULT_SERVICE_LIMIT = 50
 
@@ -54,16 +54,14 @@ class Config(object):
     WTF_CSRF_TIME_LIMIT = None
     CHECK_PROXY_HEADER = False
 
-    AWS_REGION = os.environ.get('AWS_REGION')
-
     REDIS_URL = cloud_config.redis_url
-    REDIS_ENABLED = os.environ.get('REDIS_ENABLED', '1') == '1'
+    REDIS_ENABLED = getenv('REDIS_ENABLED', '1') == '1'
 
     # TODO: reassign this
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
 
     NOTIFY_BILLING_DETAILS = json.loads(
-        os.environ.get('NOTIFY_BILLING_DETAILS') or 'null'
+        getenv('NOTIFY_BILLING_DETAILS') or 'null'
     ) or {
         'account_number': '98765432',
         'sort_code': '01-23-45',
@@ -79,9 +77,9 @@ class Config(object):
 def _default_s3_credentials(bucket_name):
     return {
         'bucket': bucket_name,
-        'access_key_id': os.environ.get('AWS_ACCESS_KEY_ID'),
-        'secret_access_key': os.environ.get('AWS_SECRET_ACCESS_KEY'),
-        'region': os.environ.get('AWS_REGION')
+        'access_key_id': getenv('AWS_ACCESS_KEY_ID'),
+        'secret_access_key': getenv('AWS_SECRET_ACCESS_KEY'),
+        'region': getenv('AWS_REGION')
     }
 
 
@@ -133,11 +131,11 @@ class Production(Config):
 
     # buckets
     CSV_UPLOAD_BUCKET = cloud_config.s3_credentials(
-        f"notify-api-csv-upload-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
+        f"notify-api-csv-upload-bucket-{getenv('NOTIFY_ENVIRONMENT')}")
     CONTACT_LIST_BUCKET = cloud_config.s3_credentials(
-        f"notify-api-contact-list-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
+        f"notify-api-contact-list-bucket-{getenv('NOTIFY_ENVIRONMENT')}")
     LOGO_UPLOAD_BUCKET = cloud_config.s3_credentials(
-        f"notify-admin-logo-upload-bucket-{os.environ['NOTIFY_ENVIRONMENT']}")
+        f"notify-admin-logo-upload-bucket-{getenv('NOTIFY_ENVIRONMENT')}")
 
 
 class Staging(Production):

--- a/app/s3_client/__init__.py
+++ b/app/s3_client/__init__.py
@@ -1,20 +1,14 @@
-import os
-
 import botocore
 from boto3 import Session
 from flask import current_app
-
-default_access_key = os.environ.get('AWS_ACCESS_KEY_ID')
-default_secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-default_region = os.environ.get('AWS_REGION')
 
 
 def get_s3_object(
     bucket_name,
     filename,
-    access_key=default_access_key,
-    secret_key=default_secret_key,
-    region=default_region,
+    access_key,
+    secret_key,
+    region,
 ):
     # To inspect contents: obj.get()['Body'].read().decode('utf-8')
     session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key, region_name=region)

--- a/manifest.yml
+++ b/manifest.yml
@@ -39,10 +39,6 @@ applications:
       BASIC_AUTH_PASSWORD: ((BASIC_AUTH_PASSWORD))
       NEW_RELIC_LICENSE_KEY: ((NEW_RELIC_LICENSE_KEY))
 
-      AWS_REGION: us-west-2
-      AWS_ACCESS_KEY_ID: ((AWS_ACCESS_KEY_ID))
-      AWS_SECRET_ACCESS_KEY: ((AWS_SECRET_ACCESS_KEY))
-
       NOTIFY_BILLING_DETAILS: '[]'
 
       REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -1,5 +1,6 @@
 import uuid
 from io import BytesIO
+from os import getenv
 from unittest.mock import ANY
 
 import pytest
@@ -7,7 +8,6 @@ from flask import url_for
 from freezegun import freeze_time
 
 from app.formatters import normalize_spaces
-from app.s3_client import default_access_key, default_secret_key
 from tests import contact_list_json
 from tests.conftest import SERVICE_ONE_ID
 
@@ -210,8 +210,8 @@ def test_upload_csv_file_shows_error_banner(
         region='us-west-2',
         bucket_name='test-contact-list',
         file_location=f"service-{SERVICE_ONE_ID}-notify/{fake_uuid}.csv",
-        access_key=default_access_key,
-        secret_key=default_secret_key,
+        access_key=getenv('AWS_ACCESS_KEY_ID'),
+        secret_key=getenv('AWS_SECRET_ACCESS_KEY'),
     )
     mock_set_metadata.assert_called_once_with(
         ANY,

--- a/tests/app/s3_client/test_s3_logo_client.py
+++ b/tests/app/s3_client/test_s3_logo_client.py
@@ -1,9 +1,9 @@
 from collections import namedtuple
+from os import getenv
 from unittest.mock import call
 
 import pytest
 
-from app.s3_client import default_access_key, default_region, default_secret_key
 from app.s3_client.s3_logo_client import (
     EMAIL_LOGO_LOCATION_STRUCTURE,
     TEMP_TAG,
@@ -14,6 +14,9 @@ from app.s3_client.s3_logo_client import (
     upload_email_logo,
 )
 
+default_access_key = getenv('AWS_ACCESS_KEY_ID')
+default_secret_key = getenv('AWS_SECRET_ACCESS_KEY')
+default_region = getenv('AWS_REGION')
 bucket = 'test_bucket'
 bucket_credentials = {
     'bucket': bucket,


### PR DESCRIPTION
`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` are only directly used for development and test s3 buckets currently, so lets stop sending them to cloud.gov.