### PR TITLE
Add terraform drift detector

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -1,0 +1,66 @@
+name: Verify Infrastructure
+
+on:
+  schedule:
+    # cron format: 'minute hour dayofmonth month dayofweek'
+    # this will run at noon UTC every day (7am EST / 8am EDT)
+    - cron: '0 12 * * *'
+
+jobs:
+  check_staging_drift:
+    runs-on: ubuntu-latest
+    name: Check for drift of staging terraform configuration
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check for drift
+        uses: dflook/terraform-check@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+          TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+          TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+        with:
+          path: terraform/staging
+
+  check_demo_drift:
+    runs-on: ubuntu-latest
+    name: Check for drift of demo terraform configuration
+    environment: demo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: 'production'
+
+      - name: Check for drift
+        uses: dflook/terraform-check@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+          TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+          TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+        with:
+          path: terraform/demo
+
+  # check_prod_drift:
+  #   runs-on: ubuntu-latest
+  #   name: Check for drift of production terraform configuration
+  #   environment: production
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: 'production'
+
+  #     - name: Check for drift
+  #       uses: dflook/terraform-check@v1
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+  #         TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+  #         TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+  #       with:
+  #         path: terraform/production


### PR DESCRIPTION
This workflow will run each morning to ensure that terraform knows about all infrastructure changes.

In support of control CM-6.1

Production check should be uncommented once it exists.