### PR TITLE
Address moderate & low OWASP findings on Admin

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -154,35 +154,27 @@ def _csp(config):
             "'self'",
             asset_domain
         ],
+        "frame-ancestors": "'none'",
+        "form-action": "'self'",
         "script-src": [
             "'self'",
-            "'unsafe-eval'",
             asset_domain,
-            "*.google-analytics.com",
+            "'unsafe-eval'",
             "https://js-agent.newrelic.com",
-            "https://*.nr-data.net",
-            "data:"
+            "https://gov-bam.nr-data.net",
         ],
         "connect-src": [
             "'self'",
-            "*.google-analytics.com",
-            "https://*.nr-data.net"
+            "https://gov-bam.nr-data.net"
         ],
         "style-src": [
             "'self'",
             asset_domain
         ],
-        "font-src": [
-            "'self'",
-            asset_domain,
-            "data:"
-        ],
         "img-src": [
             "'self'",
             asset_domain,
-            logo_domain,
-            "*.google-analytics.com",
-            "data:"
+            logo_domain
         ]
     }
 
@@ -245,6 +237,22 @@ def create_app(application):
         application,
         content_security_policy=_csp(application.config),
         content_security_policy_nonce_in=['style-src', 'script-src'],
+        permissions_policy={
+            'accelerometer': '()',
+            'ambient-light-sensor': '()',
+            'autoplay': '()',
+            'battery': '()',
+            'camera': '()',
+            'document-domain': '()',
+            'geolocation': '()',
+            'gyroscope': '()',
+            'local-fonts': '()',
+            'magnetometer': '()',
+            'microphone': '()',
+            'midi': '()',
+            'payment': '()',
+            'screen-wake-lock': '()'
+        },
         frame_options='deny',
         force_https=(application.config['HTTP_PROTOCOL'] == 'https')
     )

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -14,11 +14,12 @@ def test_owasp_useful_headers_set(
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
     csp = response.headers['Content-Security-Policy']
     assert search(r"default-src 'self' static\.example\.com;", csp)
+    assert search(r"frame-ancestors 'none';", csp)
+    assert search(r"form-action 'self';", csp)
     assert search(
-        r"script-src 'self' 'unsafe-eval' static\.example\.com \*\.google-analytics\.com https:\/\/js-agent\.newrelic\.com https:\/\/\*\.nr-data\.net data: 'nonce-.*';", # noqa e501
+        r"script-src 'self' static\.example\.com 'unsafe-eval' https:\/\/js-agent\.newrelic\.com https:\/\/gov-bam\.nr-data\.net 'nonce-.*';", # noqa e501
         csp
     )
-    assert search(r"connect-src 'self' \*\.google-analytics\.com https:\/\/\*.nr-data\.net;", csp)
+    assert search(r"connect-src 'self' https:\/\/gov-bam.nr-data\.net;", csp)
     assert search(r"style-src 'self' static\.example\.com 'nonce-.*';", csp)
-    assert search(r"font-src 'self' static\.example\.com data:;", csp)
-    assert search(r"img-src 'self' static\.example\.com static-logos\.test\.com \*\.google-analytics\.com data:", csp)
+    assert search(r"img-src 'self' static\.example\.com static-logos\.test\.com", csp)


### PR DESCRIPTION
* Clean up CSP header and add `frame-ancestors` and `form-action` directives that don't inherit from `default-src`
* add Permissions-Policy header. I tried to disable as many things as I could while leaving out any that I thought could theoretically impact accessibility devices. The `()` is the syntax for "not allowed by anyone"

closes #461 