### PR TITLE
Tests pinning ubuntu version in Github CI for pa11y-ci.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -85,7 +85,7 @@ jobs:
           cmd_options: "-I"
 
   a11y-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project


### PR DESCRIPTION
Pinning Unbuntu version to `20.04` instead of `latest`. Latest version has issues with `pa11y-ci`.

`Failed to run` is gone.

<img width="499" alt="Screen Shot 2023-04-25 at 9 58 00 AM" src="https://user-images.githubusercontent.com/90117200/234334948-0b9779d3-bfb5-4c4c-ae6d-ddbab251ed45.png">
