### PR TITLE
change error message to show total message limit

### DIFF
--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -12,7 +12,7 @@
   </p>
   {% if job.status == 'sending limits exceeded'%}
     <p class="govuk-error-message">
-        Notify cannot send these messages because you have reached your daily limit. You can only send {{ current_service.message_limit|format_thousands }} messages per day.
+        Notify cannot send these messages because you have reached a limit. You can only send {{ current_service.message_limit|format_thousands }} messages per day and {{ 250000|format_thousands }} messages in total.
     </p>
     <p class="govuk-error-message govuk-!-margin-bottom-6">
         Upload this spreadsheet again tomorrow or <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the U.S. Notify team</a> to raise the limit.

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -230,7 +230,7 @@ def test_should_show_job_with_sending_limit_exceeded_status(
     )
 
     assert normalize_spaces(page.select('main p')[1].text) == (
-        "Notify cannot send these messages because you have reached your daily limit. You can only send 1,000 messages per day."  # noqa
+        "Notify cannot send these messages because you have reached a limit. You can only send 1,000 messages per day and 250,000 messages in total."  # noqa
     )
     assert normalize_spaces(page.select('main p')[2].text) == (
         "Upload this spreadsheet again tomorrow or contact the U.S. Notify team to raise the limit."


### PR DESCRIPTION
Just change the error message to indicate the user may have violated the daily message limit or the total message limit.  See related PRs for notify-300 in notifications-api and notifications-util.