### PR TITLE
get rid of test skips

### DIFF
--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -267,7 +267,7 @@ def test_choose_account_should_not_show_back_to_service_link_if_not_signed_in(
 
 @pytest.mark.parametrize('active', (
     False,
-    pytest.param(True, marks=pytest.mark.xfail(raises=AssertionError)),
+    pytest.param(True),
 ))
 def test_choose_account_should_not_show_back_to_service_link_if_service_archived(
     client_request,
@@ -283,7 +283,10 @@ def test_choose_account_should_not_show_back_to_service_link_if_service_archived
     page = client_request.get('main.choose_account')
 
     assert normalize_spaces(page.select_one('h1').text) == 'Choose service'
-    assert page.select_one('.navigation-service a') is None
+    if active:
+        assert page.select_one('.navigation-service a') is not None
+    else:
+        assert page.select_one('.navigation-service a') is None
 
 
 def test_should_not_show_back_to_service_if_user_doesnt_belong_to_service(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -398,33 +398,6 @@ def test_validation_of_gps_creating_organisations(
     assert expected_error in page.select_one('.govuk-error-message, .error-message').text
 
 
-@pytest.mark.g(reason='Update for TTS')
-def test_nhs_local_assigns_to_selected_organisation(
-    client_request,
-    mocker,
-    service_one,
-    mock_get_organisation,
-    mock_update_service_organisation,
-):
-    mocker.patch(
-        'app.models.organisation.AllOrganisations.client_method',
-        return_value=[
-            organisation_json(ORGANISATION_ID, 'Trust 1', organisation_type='nhs_local'),
-        ],
-    )
-    service_one['organisation_type'] = 'nhs_local'
-
-    client_request.post(
-        '.add_organisation_from_nhs_local_service',
-        service_id=SERVICE_ONE_ID,
-        _data={
-            'organisations': ORGANISATION_ID,
-        },
-        _expected_status=302,
-    )
-    mock_update_service_organisation.assert_called_once_with(SERVICE_ONE_ID, ORGANISATION_ID)
-
-
 @freeze_time("2020-02-20 20:20")
 def test_organisation_services_shows_live_services_and_usage(
     client_request,

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -398,7 +398,7 @@ def test_validation_of_gps_creating_organisations(
     assert expected_error in page.select_one('.govuk-error-message, .error-message').text
 
 
-@pytest.mark.skip(reason='Update for TTS')
+@pytest.mark.g(reason='Update for TTS')
 def test_nhs_local_assigns_to_selected_organisation(
     client_request,
     mocker,

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -6,7 +6,6 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
 )
 
-from app.utils.branding import NHS_EMAIL_BRANDING_ID
 from tests import sample_uuid
 from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, normalize_spaces
 
@@ -77,7 +76,6 @@ def test_email_branding_request_page_shows_branding_if_set(
     assert page.find('iframe')['src'] == url_for('main.email_template', branding_style='some-random-branding')
 
 
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_request_page_back_link(
     client_request,
 ):
@@ -106,20 +104,12 @@ def test_email_branding_request_page_back_link(
     ),
     (
         {
-            'options': 'organisation',
-        },
-        'federal',
-        'main.email_branding_organisation',
-    ),
-    (
-        {
             'options': 'something_else',
         },
         'federal',
         'main.email_branding_something_else',
     ),
 ))
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_request_submit(
     client_request,
     service_one,
@@ -151,7 +141,6 @@ def test_email_branding_request_submit(
     )
 
 
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_request_submit_when_no_radio_button_is_selected(
     client_request,
     service_one,
@@ -170,9 +159,7 @@ def test_email_branding_request_submit_when_no_radio_button_is_selected(
 
 @pytest.mark.parametrize('endpoint, expected_heading', [
     ('main.email_branding_govuk_and_org', 'Before you request new branding'),
-    ('main.email_branding_organisation', 'When you request new branding'),
 ])
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_description_pages_for_org_branding(
     client_request,
     mocker,
@@ -250,7 +237,6 @@ def test_email_branding_something_else_page(client_request, service_one):
     )
 
 
-@pytest.mark.skip(reason='Update for TTS')
 def test_get_email_branding_something_else_page_is_only_option(client_request, service_one):
     # should only have a "something else" option
     # so back button goes back to settings page
@@ -268,7 +254,6 @@ def test_get_email_branding_something_else_page_is_only_option(client_request, s
 @pytest.mark.parametrize('endpoint', [
     ('main.email_branding_govuk'),
     ('main.email_branding_govuk_and_org'),
-    # ('main.email_branding_nhs'),
     ('main.email_branding_organisation'),
 ])
 def test_email_branding_pages_give_404_if_selected_branding_not_allowed(
@@ -284,7 +269,6 @@ def test_email_branding_pages_give_404_if_selected_branding_not_allowed(
     )
 
 
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_govuk_submit(
     mocker,
     client_request,
@@ -380,34 +364,6 @@ def test_email_branding_govuk_and_org_submit(
 
 
 @pytest.mark.skip(reason='Update for TTS')
-def test_email_branding_nhs_submit(
-    mocker,
-    client_request,
-    service_one,
-    organisation_one,
-    no_reply_to_email_addresses,
-    mock_get_email_branding,
-    single_sms_sender,
-    mock_update_service,
-):
-    service_one['email_branding'] = sample_uuid()
-    service_one['organisation_type'] = 'nhs_local'
-
-    page = client_request.post(
-        '.email_branding_nhs',
-        service_id=SERVICE_ONE_ID,
-        _follow_redirects=True,
-    )
-
-    mock_update_service.assert_called_once_with(
-        SERVICE_ONE_ID,
-        email_branding=NHS_EMAIL_BRANDING_ID,
-    )
-    assert page.h1.text == 'Settings'
-    assert normalize_spaces(page.select_one('.banner-default').text) == 'You’ve updated your email branding'
-
-
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_organisation_submit(
     mocker,
     client_request,
@@ -466,7 +422,6 @@ def test_email_branding_organisation_submit(
     )
 
 
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_something_else_submit(
     client_request,
     mocker,
@@ -518,7 +473,6 @@ def test_email_branding_something_else_submit(
     )
 
 
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_something_else_submit_shows_error_if_textbox_is_empty(
     client_request,
 ):

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -11,15 +11,10 @@ from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, normalize_spaces
 
 
 @pytest.mark.parametrize('organisation_type, expected_options', (
-    ('nhs_central', [
-        ('nhs', 'NHS'),
-        ('something_else', 'Something else'),
-    ]),
     ('other', [
         ('something_else', 'Something else'),
-    ])
+    ]),
 ))
-@pytest.mark.skip(reason='Update for TTS')
 def test_email_branding_request_page_when_no_branding_is_set(
     service_one,
     client_request,

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -122,10 +122,6 @@ def test_service_setting_toggles_show(
     ({'active': True}, '.history', 2, 'Service history'),
     ({'active': False}, '.resume_service', 0, 'Resume service'),
     ({'active': False}, '.history', 1, 'Service history'),
-    pytest.param(
-        {'active': False}, '.archive_service', 2, 'Resume service',
-        marks=pytest.mark.xfail(raises=IndexError)
-    )
 ])
 def test_service_setting_link_toggles(
     get_service_settings_page,
@@ -141,6 +137,26 @@ def test_service_setting_link_toggles(
     link = page.select('.page-footer-link a')[index]
     assert normalize_spaces(link.text) == text
     assert link['href'] == link_url
+
+
+@pytest.mark.parametrize('service_fields, endpoint, index, text', [
+    pytest.param(
+        {'active': False}, '.archive_service', 2, 'Resume service',
+    )
+])
+def test_service_setting_link_toggles_index_error(
+    get_service_settings_page,
+    service_one,
+    service_fields,
+    endpoint,
+    index,
+    text,
+):
+    with pytest.raises(expected_exception=IndexError):
+        url_for(endpoint, service_id=service_one['id'])
+        service_one.update(service_fields)
+        page = get_service_settings_page()
+        page.select('.page-footer-link a')[index]
 
 
 @pytest.mark.parametrize('permissions,permissions_text,visible', [

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3452,7 +3452,7 @@ def test_suspend_service_after_confirm_error(
 
 @pytest.mark.parametrize('user', (
     create_platform_admin_user(),
-    pytest.param(create_active_user_with_permissions(), marks=pytest.mark.xfail),
+    pytest.param(create_active_user_with_permissions()),
 ))
 def test_suspend_service_prompts_user(
     client_request,
@@ -3466,6 +3466,12 @@ def test_suspend_service_prompts_user(
     mock_api = mocker.patch('app.service_api_client.post')
 
     client_request.login(user)
+
+    if user['email_address'] != 'platform@admin.gsa.gov':
+        with pytest.raises(expected_exception=AssertionError):
+            client_request.get('main.suspend_service', service_id=service_one['id'])
+        return
+
     page = client_request.get('main.suspend_service', service_id=service_one['id'])
 
     assert 'This will suspend the service and revoke all api keys. Are you sure you want to suspend this service?' in \

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -61,12 +61,6 @@ def mock_get_service_settings_page_common(
         'Start text messages with service name On Change your settings for starting text messages with service name',
         'Send international text messages Off Change your settings for sending international text messages',
 
-        # 'Label Value Action',
-        # 'Send emails On Change your settings for sending emails',
-        # 'Reply-to email addresses Not set Manage reply-to email addresses',
-        # 'Email branding GOV.UK Change email branding',
-        # 'Send files by email contact_us@gsa.gov Manage sending files by email',
-        # 'Receive text messages Off Change your settings for receiving text messages',
     ]),
     (create_platform_admin_user(), [
 
@@ -78,12 +72,6 @@ def mock_get_service_settings_page_common(
         'Start text messages with service name On Change your settings for starting text messages with service name',
         'Send international text messages Off Change your settings for sending international text messages',
 
-        # 'Label Value Action',
-        # 'Send emails On Change your settings for sending emails',
-        # 'Reply-to email addresses Not set Manage reply-to email addresses',
-        # 'Email branding GOV.UK Change email branding',
-        # 'Send files by email contact_us@gsa.gov Manage sending files by email',
-        # 'Receive text messages Off Change your settings for receiving text messages',
 
         'Label Value Action',
         'Live Off Change service status',
@@ -221,12 +209,6 @@ def test_send_files_by_email_row_on_settings_page(
         'Start text messages with service name On Change your settings for starting text messages with service name',
         'Send international text messages On Change your settings for sending international text messages',
 
-        # 'Label Value Action',
-        # 'Send emails On Change your settings for sending emails',
-        # 'Reply-to email addresses test@example.com Manage reply-to email addresses',
-        # 'Email branding Organisation name Change email branding',
-        # 'Send files by email Not set up Manage sending files by email',
-        # 'Receive text messages On Change your settings for receiving text messages',
 
     ]),
     (['email', 'sms', 'email_auth'], [
@@ -238,12 +220,6 @@ def test_send_files_by_email_row_on_settings_page(
         'Start text messages with service name On Change your settings for starting text messages with service name',
         'Send international text messages Off Change your settings for sending international text messages',
 
-        # 'Label Value Action',
-        # 'Send emails On Change your settings for sending emails',
-        # 'Reply-to email addresses test@example.com Manage reply-to email addresses',
-        # 'Email branding Organisation name Change email branding',
-        # 'Send files by email Not set up Manage sending files by email'
-        # 'Receive text messages Off Change your settings for receiving text messages',
 
     ]),
 ])
@@ -1747,8 +1723,6 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
         "Reply-to email addresses test@example.com …and 2 more Manage reply-to email addresses"
     assert get_row(page, 'Text message senders') == \
         "Text message senders Example …and 2 more Manage text message senders"
-    # assert get_row(page, 'Sender addresses') == \
-    #     "Sender addresses 1 Example Street …and 2 more Manage sender addresses"
 
 
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [
@@ -3286,16 +3260,6 @@ def test_archive_service_after_confirm_error(
             _follow_redirects=True,
         )
 
-        # mock_api.assert_called_once_with('/service/{}/archive'.format(SERVICE_ONE_ID), data=None)
-        # mock_event.assert_called_once_with(service_id=SERVICE_ONE_ID, archived_by_id=user['id'])
-
-        # assert normalize_spaces(page.select_one('h1').text) == 'Choose service'
-        # assert normalize_spaces(page.select_one('.banner-default-with-tick').text) == (
-        #     '‘service one’ was deleted'
-        # )
-        # The one user which is part of this service has the sample_uuid as it's user ID
-        # assert call(f"user-{sample_uuid()}") in redis_delete_mock.call_args_list
-
 
 @pytest.mark.parametrize('user, is_trial_service', (
     [create_platform_admin_user(), True],
@@ -3362,23 +3326,6 @@ def test_archive_service_prompts_user_error(
             'main.archive_service',
             service_id=SERVICE_ONE_ID
         )
-        # delete_link = settings_page.select('.page-footer-link a')[0]
-        # assert normalize_spaces(delete_link.text) == 'Delete this service'
-        # assert delete_link['href'] == url_for(
-        #     'main.archive_service',
-        #     service_id=SERVICE_ONE_ID,
-        # )
-        #
-        # delete_page = client_request.get(
-        #     'main.archive_service',
-        #     service_id=SERVICE_ONE_ID,
-        # )
-        # assert normalize_spaces(delete_page.select_one('.banner-dangerous').text) == (
-        #     'Are you sure you want to delete ‘service one’? '
-        #     'There’s no way to undo this. '
-        #     'Yes, delete'
-        # )
-        # assert mock_api.called is False
 
 
 def test_cant_archive_inactive_service(
@@ -3445,9 +3392,6 @@ def test_suspend_service_after_confirm_error(
                 service_id=SERVICE_ONE_ID,
             ),
         )
-
-    # mock_api.assert_called_once_with('/service/{}/suspend'.format(SERVICE_ONE_ID), data=None)
-    # mock_event.assert_called_once_with(service_id=SERVICE_ONE_ID, suspended_by_id=user['id'])
 
 
 @pytest.mark.parametrize('user', (
@@ -3719,20 +3663,6 @@ def test_send_files_by_email_contact_details_does_not_update_invalid_contact_det
 
 
 @pytest.mark.parametrize('endpoint, permissions, expected_p', [
-    # (
-    #     'main.service_set_inbound_sms',
-    #     ['sms'],
-    #     (
-    #         'Contact us if you want to be able to receive text messages from your users.'
-    #     )
-    # ),
-    # (
-    #     'main.service_set_inbound_sms',
-    #     ['sms', 'inbound_sms'],
-    #     (
-    #         'Your service can receive text messages sent to 2028675301.'
-    #     )
-    # ),
     (
         'main.service_set_auth_type',
         [],
@@ -3960,7 +3890,6 @@ def test_update_service_organisation_does_not_update_if_same_value(
 @pytest.mark.skip(reason="Email currently deactivated")
 @pytest.mark.parametrize('single_branding_option, expected_href', [
     (True, f'/services/{SERVICE_ONE_ID}/service-settings/email-branding/something-else'),
-    # (False, f'/services/{SERVICE_ONE_ID}/service-settings/email-branding'),
 ])
 def test_service_settings_links_to_branding_request_page_for_emails(
     service_one,
@@ -3974,10 +3903,6 @@ def test_service_settings_links_to_branding_request_page_for_emails(
         # should only have a "something else" option
         # so we go straight to that form
         service_one['organisation_type'] = 'other'
-    # else:
-    #     # expect to have a "NHS" option as well as the
-    #     # fallback one, so ask user to choose
-    #     service_one['organisation_type'] = 'nhs_central'
 
     page = client_request.get(
         '.service_settings', service_id=SERVICE_ONE_ID

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3500,7 +3500,7 @@ def test_cant_suspend_inactive_service(
 
 @pytest.mark.parametrize('user', (
     create_platform_admin_user(),
-    pytest.param(create_active_user_with_permissions(), marks=pytest.mark.xfail),
+    create_active_user_with_permissions(),
 ))
 def test_resume_service_after_confirm(
     mocker,
@@ -3513,6 +3513,14 @@ def test_resume_service_after_confirm(
     mock_event = mocker.patch('app.main.views.service_settings.create_resume_service_event')
 
     client_request.login(user)
+    if user['email_address'] != "platform@admin.gsa.gov":
+        client_request.post(
+            'main.resume_service',
+            service_id=SERVICE_ONE_ID,
+            _expected_status=403,
+        )
+        return
+
     client_request.post(
         'main.resume_service',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -239,14 +239,13 @@ def test_css_is_served_from_correct_path(client_request):
         ][index])
 
 
-@pytest.mark.skip(reason="Update for TTS")
 def test_resources_that_use_asset_path_variable_have_correct_path(client_request):
 
     page = client_request.get('main.documentation')  # easy static page
 
     logo_svg_fallback = page.select_one('.govuk-header__logotype-fallback-image')
 
-    assert logo_svg_fallback['src'].startswith('https://static.example.com/images/govuk-logotype.png')
+    assert logo_svg_fallback['src'].startswith('https://static.example.com/images/email-template/us-flag.png')
 
 
 @pytest.mark.parametrize('extra_args, email_branding_retrieved', (

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -245,16 +245,20 @@ def test_should_show_job_with_sending_limit_exceeded_status(
     )),
     # Just started
     (datetime(2020, 1, 10, 0, 0, 0), datetime(2020, 1, 10, 0, 0, 1), (
-        'No messages to show yet…'
+       'No messages to show yet…'
     )),
     # Created a while ago, just started
     (datetime(2020, 1, 1, 0, 0, 0), datetime(2020, 1, 10, 0, 0, 1), (
-        'No messages to show yet…'
+       'No messages to show yet…'
     )),
     # Created a while ago, started just within the last 24h
-    (datetime(2020, 1, 1, 0, 0, 0), datetime(2020, 1, 9, 6, 0, 1), (
-        'No messages to show yet…'
-    )),
+    # TODO -- should pass, tech debt due to timezone changes, re-evaluate after UTC changes
+    pytest.param(
+        datetime(2020, 1, 1, 0, 0, 0),
+        datetime(2020, 1, 9, 6, 0, 1),
+        ('No messages to show yet…'),
+        marks=pytest.mark.xfail(raises=AssertionError),
+    ),
     # Created a while ago, started exactly 24h ago
     # ---
     # It doesn’t matter that 24h (1 day) and 7 days (the service’s data

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -252,12 +252,11 @@ def test_should_show_job_with_sending_limit_exceeded_status(
        'No messages to show yet…'
     )),
     # Created a while ago, started just within the last 24h
-    # TODO -- should pass, tech debt due to timezone changes, re-evaluate after UTC changes
+    # TODO -- fails locally, should pass, tech debt due to timezone changes, re-evaluate after UTC changes
     pytest.param(
         datetime(2020, 1, 1, 0, 0, 0),
         datetime(2020, 1, 9, 6, 0, 1),
         ('No messages to show yet…'),
-        marks=pytest.mark.xfail(raises=AssertionError),
     ),
     # Created a while ago, started exactly 24h ago
     # ---

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -191,7 +191,7 @@ def test_should_show_change_details_link(
 
 
 @pytest.mark.parametrize('number_of_users', (
-    pytest.param(7, marks=pytest.mark.xfail),
+    pytest.param(7),
     pytest.param(8),
 ))
 def test_should_show_live_search_if_more_than_7_users(
@@ -212,6 +212,13 @@ def test_should_show_live_search_if_more_than_7_users(
     )
 
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
+
+    if number_of_users == 7:
+        with pytest.raises(expected_exception=TypeError):
+            assert page.select_one('div[data-module=live-search]')['data-targets'] == (
+                ".user-list-item"
+            )
+        return
 
     assert page.select_one('div[data-module=live-search]')['data-targets'] == (
         ".user-list-item"

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -985,14 +985,6 @@ def test_delete_folder(
     pytest.param(
         create_active_user_with_permissions()
     ),
-    pytest.param(
-        create_active_user_view_permissions(),
-        marks=pytest.mark.xfail(raises=AssertionError)
-    ),
-    pytest.param(
-        create_active_caseworking_user(),
-        marks=pytest.mark.xfail(raises=AssertionError)
-    ),
 ])
 def test_should_show_checkboxes_for_selecting_templates(
     client_request,
@@ -1020,6 +1012,43 @@ def test_should_show_checkboxes_for_selecting_templates(
     for index in (1, 2, 3):
         assert checkboxes[index]['value'] != TEMPLATE_ONE_ID
         assert TEMPLATE_ONE_ID not in checkboxes[index]['id']
+
+
+@pytest.mark.parametrize('user', [
+    pytest.param(
+        create_active_user_view_permissions(),
+    ),
+    pytest.param(
+        create_active_caseworking_user(),
+    ),
+])
+def test_should_show_checkboxes_for_selecting_templates_assertion_error(
+    client_request,
+    mocker,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    mock_has_no_jobs,
+    mock_get_no_api_keys,
+    user,
+):
+    with pytest.raises(expected_exception=AssertionError):
+        client_request.login(user)
+
+        page = client_request.get(
+            'main.choose_template',
+            service_id=SERVICE_ONE_ID,
+        )
+        checkboxes = page.select('input[name=templates_and_folders]')
+
+        assert len(checkboxes) == 4
+
+        assert checkboxes[0]['value'] == TEMPLATE_ONE_ID
+        assert checkboxes[0]['id'] == 'templates-or-folder-{}'.format(TEMPLATE_ONE_ID)
+
+        for index in (1, 2, 3):
+            assert checkboxes[index]['value'] != TEMPLATE_ONE_ID
+            assert TEMPLATE_ONE_ID not in checkboxes[index]['id']
 
 
 @pytest.mark.parametrize('user', [

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -352,11 +352,11 @@ def test_all_endpoints_are_covered(navigation_instance):
     navigation_instances,
     ids=(x.__class__.__name__ for x in navigation_instances)
 )
-@pytest.mark.xfail(raises=KeyError)
 def test_raises_on_invalid_navigation_item(
     client_request, navigation_instance
 ):
-    navigation_instance.is_selected('foo')
+    with pytest.raises(expected_exception=KeyError):
+        navigation_instance.is_selected('foo')
 
 
 @pytest.mark.parametrize('endpoint, selected_nav_item', [

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -6,10 +6,6 @@ from app.utils.user import user_has_permissions
 
 
 @pytest.mark.parametrize('permissions', (
-    pytest.param([
-        # Route has a permission which the user doesn’t have
-        'send_messages'
-    ], marks=pytest.mark.xfail(raises=Forbidden)),
     [
         # Route has one of the permissions which the user has
         'manage_service'
@@ -43,6 +39,32 @@ def test_permissions(
         pass
 
     index()
+
+
+@pytest.mark.parametrize('permissions', (
+    [
+        # Route has a permission which the user doesn’t have
+        'send_messages'
+    ],
+))
+def test_permissions_forbidden(
+    client_request,
+    permissions,
+    api_user_active,
+):
+    request.view_args.update({'service_id': 'foo'})
+
+    api_user_active['permissions'] = {'foo': ['manage_users', 'manage_templates', 'manage_settings']}
+    api_user_active['services'] = ['foo', 'bar']
+
+    client_request.login(api_user_active)
+
+    @user_has_permissions(*permissions)
+    def index():
+        pass
+
+    with pytest.raises(expected_exception=Forbidden):
+        index()
 
 
 def test_restrict_admin_usage(


### PR DESCRIPTION
Fix the easy skips and x-fails.  What is left is mostly related to branding and/or nhs.   Probably we should wait until the branding stories are done and then see what remains to fix.