### PR TITLE
Remove PY_TIMEZONE references

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,6 @@ import json
 from os import getenv
 
 import newrelic.agent
-import pytz
 
 from app.cloudfoundry_config import cloud_config
 
@@ -15,7 +14,6 @@ class Config(object):
     HEADER_COLOUR = '#81878b'  # mix(govuk-colour("dark-grey"), govuk-colour("mid-grey"))
     LOGO_CDN_DOMAIN = 'static-logos.notifications.service.gov.uk'  # TODO use our own CDN
     ASSETS_DEBUG = False
-    PY_TIMEZONE = pytz.utc
 
     # Credentials
     ADMIN_CLIENT_SECRET = getenv('ADMIN_CLIENT_SECRET')

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -10,7 +10,6 @@ import ago
 import dateutil
 import humanize
 import pytz
-
 from flask import Markup, url_for
 from notifications_utils.field import Field
 from notifications_utils.formatters import make_quotes_smart

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -9,7 +9,9 @@ from numbers import Number
 import ago
 import dateutil
 import humanize
-from flask import Markup, current_app, url_for
+import pytz
+
+from flask import Markup, url_for
 from notifications_utils.field import Field
 from notifications_utils.formatters import make_quotes_smart
 from notifications_utils.formatters import nl2br as utils_nl2br
@@ -89,7 +91,7 @@ def get_human_day(time, date_prefix=''):
     #  Add 1 minute to transform 00:00 into ‘midnight today’ instead of ‘midnight tomorrow’
     time = parse_naive_dt(time)
     date = (time - timedelta(minutes=1)).date()
-    now = datetime.now(current_app.config['PY_TIMEZONE'])
+    now = datetime.now(pytz.utc)
 
     if date == (now + timedelta(days=1)).date():
         return 'tomorrow'

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,10 +1,12 @@
 import weakref
+
 from datetime import datetime, timedelta
 from itertools import chain
 from numbers import Number
 
 import pytz
-from flask import Markup, current_app, render_template, request
+
+from flask import Markup, render_template, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed
@@ -74,8 +76,8 @@ def get_time_value_and_label(future_time):
     return (
         future_time.astimezone(pytz.utc).replace(tzinfo=None).isoformat(),
         '{} at {} UTC'.format(
-            get_human_day(future_time.astimezone(current_app.config['PY_TIMEZONE'])),
-            get_human_time(future_time.astimezone(current_app.config['PY_TIMEZONE']))
+            get_human_day(future_time.astimezone(pytz.utc)),
+            get_human_time(future_time.astimezone(pytz.utc))
         )
     )
 
@@ -93,20 +95,20 @@ def get_human_time(time):
 def get_human_day(time, prefix_today_with='T'):
     #  Add 1 hour to get ‘midnight today’ instead of ‘midnight tomorrow’
     time = (time - timedelta(hours=1)).strftime('%A')
-    if time == datetime.now(current_app.config['PY_TIMEZONE']).strftime('%A'):
+    if time == datetime.now(pytz.utc).strftime('%A'):
         return '{}oday'.format(prefix_today_with)
-    if time == (datetime.now(current_app.config['PY_TIMEZONE']) + timedelta(days=1)).strftime('%A'):
+    if time == (datetime.now(pytz.utc) + timedelta(days=1)).strftime('%A'):
         return 'Tomorrow'
     return time
 
 
 def get_furthest_possible_scheduled_time():
     # We want local time to find date boundaries
-    return (datetime.now(current_app.config['PY_TIMEZONE']) + timedelta(days=4)).replace(hour=0)
+    return (datetime.now(pytz.utc) + timedelta(days=4)).replace(hour=0)
 
 
 def get_next_hours_until(until):
-    now = datetime.now(current_app.config['PY_TIMEZONE'])
+    now = datetime.now(pytz.utc)
     hours = int((until - now).total_seconds() / (60 * 60))
     return [
         (now + timedelta(hours=i)).replace(minute=0, second=0, microsecond=0)
@@ -115,7 +117,7 @@ def get_next_hours_until(until):
 
 
 def get_next_days_until(until):
-    now = datetime.now(current_app.config['PY_TIMEZONE'])
+    now = datetime.now(pytz.utc)
     days = int((until - now).total_seconds() / (60 * 60 * 24))
     return [
         get_human_day(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,11 +1,9 @@
 import weakref
-
 from datetime import datetime, timedelta
 from itertools import chain
 from numbers import Number
 
 import pytz
-
 from flask import Markup, render_template, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as Form

--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -4,7 +4,6 @@ from operator import itemgetter
 from statistics import mean
 
 import pytz
-
 from flask import render_template
 
 from app import performance_dashboard_api_client, status_api_client

--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -3,7 +3,9 @@ from itertools import groupby
 from operator import itemgetter
 from statistics import mean
 
-from flask import current_app, render_template
+import pytz
+
+from flask import render_template
 
 from app import performance_dashboard_api_client, status_api_client
 from app.main import main
@@ -12,8 +14,8 @@ from app.main import main
 @main.route("/performance")
 def performance():
     stats = performance_dashboard_api_client.get_performance_dashboard_stats(
-        start_date=(datetime.now(current_app.config['PY_TIMEZONE']) - timedelta(days=7)).date(),
-        end_date=datetime.now(current_app.config['PY_TIMEZONE']).date(),
+        start_date=(datetime.now(pytz.utc) - timedelta(days=7)).date(),
+        end_date=datetime.now(pytz.utc).date(),
     )
     stats['organisations_using_notify'] = sorted(
         [

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
 import pytz
+
 from dateutil import parser
-from flask import current_app
 
 
 def get_current_financial_year():
-    now = datetime.now(current_app.config['PY_TIMEZONE'])
+    now = datetime.now(pytz.utc)
     current_month = int(now.strftime('%-m'))
     current_year = int(now.strftime('%Y'))
     return current_year if current_month > 9 else current_year - 1

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import pytz
-
 from dateutil import parser
 
 


### PR DESCRIPTION
Addresses #545

This changeset removes the `PY_TIMEZONE` configuration variable and updates all references to it to refer directly to [`pytz.utc`](https://pythonhosted.org/pytz/) instead.  It also cleans up a few of the `import` statements and removes those that are no longer needed (like the `current_app` reference from Flask).

## Security Considerations

- None