### PR TITLE
Form is visible in html/text added for clarification on validation

### DIFF
--- a/app/templates/views/email-link-interstitial.html
+++ b/app/templates/views/email-link-interstitial.html
@@ -3,23 +3,19 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
-  Sign in
+    Click below to complete email re-verification and finish signing in.
 {% endblock %}
 
 {% block maincolumn_content %}
 
-<div class="js-hidden">
+<div>
 
-  {{ page_header('Sign in') }}
+    <h1 class="font-body-2xl margin-bottom-3">Click below to complete email re-verification and finish signing in.</h1>
 
   <form method="post" id="use-email-auth">
-    {{ page_footer('Continue to dashboard') }}
+    {{ page_footer('Verify email') }}
   </form>
 
 </div>
-
-<script type="text/javascript">
-  document.getElementById("use-email-auth").submit();
-</script>
 
 {% endblock %}

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -2,14 +2,14 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
-  Invalid email link
+  This link has expired
 {% endblock %}
 
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="font-body-2xl margin-bottom-3">The link has expired</h1>
+    <h1 class="font-body-2xl margin-bottom-3">This link has expired</h1>
 
     <p>
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in', next=redirect_url) }}">

--- a/app/templates/views/re-validate-email-sent.html
+++ b/app/templates/views/re-validate-email-sent.html
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="font-body-2xl margin-bottom-3">{{ title }}</h1>
     <p>For security, we need to check if you still have access to your email address.</p>
-    <p>We’ve sent you a link to sign in to Notify. The link will open in a new browser window, so you can close this one.</p>
+    <p>We’ve sent you a link valid for 1 hour to sign in to Notify. The link will open in a new browser window, so you can close this one.</p>
 
     {{ page_footer(
       secondary_link=url_for('main.email_not_received', next=redirect_url),

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -390,9 +390,9 @@ def test_valid_two_factor_email_link_shows_interstitial(
     client_request.logout()
     page = client_request.get_url(token_url)
 
-    assert normalize_spaces(page.select_one('main .js-hidden').text) == (
-        'Sign in '
-        'Continue to dashboard'
+    assert normalize_spaces(page.select_one('main').text) == (
+        'Click below to complete email re-verification and finish signing in. '
+        'Verify email'
     )
 
     form = page.select_one('form')
@@ -400,9 +400,6 @@ def test_valid_two_factor_email_link_shows_interstitial(
     assert 'action' not in form
     assert form['method'] == 'post'
     assert form['id'] == expected_form_id
-    assert page.select_one('main script').string.strip() == (
-        f'document.getElementById("{expected_form_id}").submit();'
-    )
 
     assert mock_check_code.called is False
 
@@ -443,7 +440,7 @@ def test_two_factor_email_link_has_expired(
             _follow_redirects=True,
         )
 
-    assert page.h1.text.strip() == 'The link has expired'
+    assert page.h1.text.strip() == 'This link has expired'
     assert page.select_one('a:contains("Sign in again")')['href'] == url_for('main.sign_in', next=redirect_url)
 
     assert mock_send_verify_code.called is False
@@ -486,7 +483,7 @@ def test_two_factor_email_link_is_already_used(
         _follow_redirects=True,
     )
 
-    assert page.h1.text.strip() == 'The link has expired'
+    assert page.h1.text.strip() == 'This link has expired'
     assert page.select_one('a:contains("Sign in again")')['href'] == url_for('main.sign_in', next=redirect_url)
 
     assert mock_send_verify_code.called is False
@@ -506,7 +503,7 @@ def test_two_factor_email_link_when_user_is_locked_out(
         _follow_redirects=True,
     )
 
-    assert page.h1.text.strip() == 'The link has expired'
+    assert page.h1.text.strip() == 'This link has expired'
     assert mock_send_verify_code.called is False
 
 


### PR DESCRIPTION
Changes:

- Form is now visible in interstitial.html.
- Text added telling user to press button to complete email verification.
- Test have been fixed in `test_two_factor.py::test_valid_two_factor_email_link_shows_interstitial` based on logic in `get_url()` and `conftest.py`.
- Added text in `re-validate-email-sent.html` telling using the link in the email is valid for 1 hour.