### PR TITLE
Update table listing of sent messages with UTC

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -169,7 +169,7 @@
         {{ notification.status|format_notification_status_as_time(
           notification.created_at|format_datetime_short,
           (notification.updated_at or notification.created_at)|format_datetime_short
-        ) }}
+        ) }} UTC
       </span>
       {% if displayed_on_single_line %}</span>{% endif %}
     {% endcall %}


### PR DESCRIPTION
Follow-up work to #525 

This changeset adds a UTC label to the timestamp of the messages displayed in the sent messages dashboard.

## Security Considerations

- None