### PR TITLE
Rework downloadable reports and fix process_type 

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -451,7 +451,6 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 form.template_content.data,
                 service_id,
                 form.subject.data if hasattr(form, 'subject') else None,
-                form.process_type.data,
                 template_folder_id
             )
         except HTTPError as e:
@@ -525,8 +524,7 @@ def edit_service_template(service_id, template_id):
                 template['template_type'],
                 form.template_content.data,
                 service_id,
-                subject,
-                form.process_type.data,
+                subject
             )
         except HTTPError as e:
             if e.status_code == 400:

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -190,7 +190,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @cache.delete('service-{service_id}-templates')
     @cache.delete_by_pattern('service-{service_id}-template-*')
     def update_service_template(
-        self, id_, name, type_, content, service_id, subject=None, process_type=None
+        self, id_, name, type_, content, service_id, subject=None
     ):
         """
         Update a service template.
@@ -206,10 +206,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             data.update({
                 'subject': subject
             })
-        if process_type:
-            data.update({
-                'process_type': process_type
-            })
+        data.update({
+            'process_type': 'normal'
+        })
         data = _attach_current_user(data)
         endpoint = "/service/{0}/template/{1}".format(service_id, id_)
         return self.post(endpoint, data)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -163,7 +163,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.delete(endpoint, data)
 
     @cache.delete('service-{service_id}-templates')
-    def create_service_template(self, name, type_, content, service_id, subject=None, process_type='normal',
+    def create_service_template(self, name, type_, content, service_id, subject=None,
                                 parent_folder_id=None):
         """
         Create a service template.
@@ -173,7 +173,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "template_type": type_,
             "content": content,
             "service": service_id,
-            "process_type": process_type,
+            "process_type": 'normal',
         }
         if subject:
             data.update({

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -62,7 +62,7 @@ def generate_notifications_csv(**kwargs):
         original_column_headers = original_upload.column_headers
         fieldnames = ['Row number'] + original_column_headers + ['Template', 'Type', 'Job', 'Status', 'Time']
     else:
-        fieldnames = ['Recipient', 'Reference', 'Template', 'Type', 'Sent by', 'Sent by email', 'Job', 'Status', 'Time']
+        fieldnames = ['Recipient', 'Template', 'Type', 'Sent by', 'Job', 'Status', 'Time']
 
     yield ','.join(fieldnames) + '\n'
 
@@ -85,11 +85,9 @@ def generate_notifications_csv(**kwargs):
             else:
                 values = [
                     notification['recipient'],
-                    notification['client_reference'],
                     notification['template_name'],
                     notification['template_type'],
                     notification['created_by_name'] or '',
-                    notification['created_by_email_address'] or '',
                     notification['job_name'] or '',
                     notification['status'],
                     notification['created_at']

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -522,7 +522,6 @@ def test_can_create_email_template_with_parent_folder(
         'template_content': "here's a burrito 🌯",
         'template_type': 'email',
         'service': SERVICE_ONE_ID,
-        'process_type': 'normal',
         'parent_folder_id': PARENT_FOLDER_ID
     }
     client_request.post('.add_service_template',
@@ -540,7 +539,6 @@ def test_can_create_email_template_with_parent_folder(
         data['template_content'],
         SERVICE_ONE_ID,
         data['subject'],
-        data['process_type'],
         data['parent_folder_id'])
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1110,7 +1110,6 @@ def test_should_redirect_when_saving_a_template(
             'template_content': content,
             'template_type': 'sms',
             'service': SERVICE_ONE_ID,
-            'process_type': 'normal',
         },
         _expected_status=302,
         _expected_redirect=url_for(
@@ -1120,7 +1119,7 @@ def test_should_redirect_when_saving_a_template(
         ),
     )
     mock_update_service_template.assert_called_with(
-        fake_uuid, name, 'sms', content, SERVICE_ONE_ID, None, 'normal',
+        fake_uuid, name, 'sms', content, SERVICE_ONE_ID, None
     )
 
 
@@ -1140,7 +1139,6 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
             'template_content': "new template <em>content</em> with & entity",
             'template_type': 'sms',
             'service': SERVICE_ONE_ID,
-            'process_type': 'priority',
         },
         _expected_status=302,
         _expected_redirect=url_for(
@@ -1155,8 +1153,7 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
         'sms',
         "new template <em>content</em> with & entity",
         SERVICE_ONE_ID,
-        None,
-        'priority'
+        None
     )
 
 
@@ -1420,7 +1417,6 @@ def test_should_redirect_when_saving_a_template_email(
             'template_type': 'email',
             'service': SERVICE_ONE_ID,
             'subject': subject,
-            'process_type': 'normal'
         },
         _expected_status=302,
         _expected_redirect=url_for(
@@ -1430,7 +1426,7 @@ def test_should_redirect_when_saving_a_template_email(
         ),
     )
     mock_update_service_template.assert_called_with(
-        fake_uuid, name, 'email', content, SERVICE_ONE_ID, subject, 'normal',
+        fake_uuid, name, 'email', content, SERVICE_ONE_ID, subject
     )
 
 
@@ -1803,7 +1799,6 @@ def test_should_create_sms_template_without_downgrading_unicode_characters(
             'template_content': msg,
             'template_type': template_type,
             'service': SERVICE_ONE_ID,
-            'process_type': 'normal'
         },
         expected_status=302,
     )
@@ -1814,8 +1809,7 @@ def test_should_create_sms_template_without_downgrading_unicode_characters(
         msg,  # content
         ANY,  # service_id
         ANY,  # subject
-        ANY,  # process_type
-        ANY,  # parent_folder_id
+        ANY  # parent_folder_id
     )
 
 

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -77,14 +77,14 @@ def _get_notifications_csv_mock(
 @pytest.mark.parametrize('created_by_name, expected_content', [
     (
         None, [
-            'Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time\n',
-            'foo@bar.com,ref 1234,foo,sms,,sender@email.gsa.gov,,Delivered,1943-04-19 12:00:00\r\n',
+            'Recipient,Template,Type,Sent by,Job,Status,Time\n',
+            'foo@bar.com,foo,sms,,,Delivered,1943-04-19 12:00:00\r\n',
         ]
     ),
     (
         'Anne Example', [
-            'Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time\n',
-            'foo@bar.com,ref 1234,foo,sms,Anne Example,sender@email.gsa.gov,,Delivered,1943-04-19 12:00:00\r\n',
+            'Recipient,Template,Type,Sent by,Job,Status,Time\n',
+            'foo@bar.com,foo,sms,Anne Example,,Delivered,1943-04-19 12:00:00\r\n',
         ]
     ),
 ])


### PR DESCRIPTION
1.   See notifications-api #316.  This PR removes the columns 'reference' and 'sent_by_email' from downloadable csv reports.  The other points in that story are connected with the the lack of delivery receipts on staging, and are addressed in notifications-api #317.

2.  When we removed priority-queue from the UI for an option when a new template is created, for some reason the default process_type 'normal' was not being used when we wanted to save the new template.  Hardcode the value to 'normal'.