### PR TITLE
Update sprint goals for Sprint N

### DIFF
--- a/docs/sprint-goals.md
+++ b/docs/sprint-goals.md
@@ -1,6 +1,16 @@
 # Notify Sprint Goals Log
 
-## Sprint: M (6/22/23)
+## Sprint: N (7/5/23)
+
+|             | Goals                                                                                                                              | Impact                                                                                                                                     |
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| Engineering | [Simulate a bulk messaging test](https://github.com/GSA/notifications-api/issues/87) (which requires the Cyanide or otherwise research we spoke about); Test opt-out list retrieval info after internal team tests kick off; Begin implementation of [E2E tests](https://github.com/GSA/notifications-admin/issues/591); Implement beta.notify.gov [landing page](https://github.com/GSA/notifications-admin/issues/590); Finalize the agreement info and message limit handling ADRs for data model updates     |   Prepare site for public launch after LATO, make the data model align with our vision and progress towards higher daily messag send capability, enable automated replies for first partner, work towards a more reliable application                                |
+| UX          | Start [user testing interviews](https://github.com/GSA/notifications-admin/issues/592) and feedback; Kick off internal message recipient [opt-out test](https://github.com/GSA/notifications-admin/issues/395); Continue to iron out details with the [send message flow wireframes](https://github.com/GSA/notifications-admin/issues/573)          | Gain feedback on usability and functionality, streamline confusing flows and processes         |
+| Content    | Continue contributing to the strategy of the newly forming Content sub-team as we can (our focus is more on user testing this sprint) | Clearer understanding of roles and responsibilities on content strategy |
+| Security    | Respond to any assessment questions and/or needs                                                  | Keep the LATO award timeline as short as possible
+
+
+## Sprint: Merlin (6/22/23)
 
 |             | Goals                                                                                                                              | Impact                                                                                                                                     |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
This changeset updates our sprint goals to gear up for our next sprint, Sprint N (full name TBD), starting on 7/5/23.

Thanks to @tdlowden for the notes beforehand!

## Security Considerations

- None; only public information shared in this.