### PR TITLE
notify-admin-562 fix back link in copy template workflow

### DIFF
--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.choose_template', service_id=current_service.id)
+    "href": url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id) if template_folder_id else url_for('main.choose_template', service_id=current_service.id)
   }) }}
 {% endblock %}
 

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    "href": url_for('main.choose_template', service_id=current_service.id)
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
The bug was that we were passing a 'template_folder_id' of None, which resulted in a URL ending in templates/all/folders, which could not be found.

The fix was to not pass the template_folder_id if it's None, which results in a URL ending in templates/all which shows all the templates for a service.