### PR TITLE
Added UTC to formatter return strings and appropriate tests

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -34,14 +34,14 @@ def convert_to_boolean(value):
 
 
 def format_datetime(date):
-    return '{} at {}'.format(
+    return '{} at {} UTC'.format(
         format_date(date),
         format_time_24h(date)
     )
 
 
 def format_datetime_24h(date):
-    return '{} at {}'.format(
+    return '{} at {} UTC'.format(
         format_date(date),
         format_time_24h(date),
     )
@@ -52,28 +52,28 @@ def format_time(date):
 
 
 def format_datetime_normal(date):
-    return '{} at {}'.format(
+    return '{} at {} UTC'.format(
         format_date_normal(date),
         format_time_24h(date)
     )
 
 
 def format_datetime_short(date):
-    return '{} at {}'.format(
+    return '{} at {} UTC'.format(
         format_date_short(date),
         format_time_24h(date)
     )
 
 
 def format_datetime_relative(date):
-    return '{} at {}'.format(
+    return '{} at {} UTC'.format(
         get_human_day(date),
         format_time_24h(date)
     )
 
 
 def format_datetime_numeric(date):
-    return '{} {}'.format(
+    return '{} {} UTC'.format(
         format_date_numeric(date),
         format_time_24h(date),
     )
@@ -134,7 +134,7 @@ def format_date_human(date):
 
 
 def format_datetime_human(date, date_prefix=''):
-    return '{} at {}'.format(
+    return '{} at {} UTC'.format(
         get_human_day(date, date_prefix='on'),
         format_time_24h(date),
     )

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -35,7 +35,7 @@
       {% elif created_by %}
         by {{ created_by.name }}
       {% endif %}
-      {{ created_at|format_datetime_human }} UTC
+      {{ created_at|format_datetime_human }}
     </p>
 
     <div class="">

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -57,38 +57,38 @@ def test_format_number_in_pounds_as_currency(input_number, formatted_number):
 
 @pytest.mark.parametrize('time, human_readable_datetime', [
     # incoming in UTC, outgoing in "human formatted" UTC
-    ('2018-03-14 09:00', '14 March at 09:00'),
-    ('2018-03-14 19:00', '14 March at 19:00'),
+    ('2018-03-14 09:00', '14 March at 09:00 UTC'),
+    ('2018-03-14 19:00', '14 March at 19:00 UTC'),
 
-    ('2018-03-15 09:00', '15 March at 09:00'),
-    ('2018-03-15 19:00', '15 March at 19:00'),
+    ('2018-03-15 09:00', '15 March at 09:00 UTC'),
+    ('2018-03-15 19:00', '15 March at 19:00 UTC'),
 
-    ('2018-03-19 09:00', '19 March at 09:00'),
-    ('2018-03-19 19:00', '19 March at 19:00'),
-    ('2018-03-19 23:59', '19 March at 23:59'),
+    ('2018-03-19 09:00', '19 March at 09:00 UTC'),
+    ('2018-03-19 19:00', '19 March at 19:00 UTC'),
+    ('2018-03-19 23:59', '19 March at 23:59 UTC'),
 
-    ('2018-03-20 00:00', '19 March at 00:00'),  # we specifically refer to 00:00 as belonging to the day before.
-    ('2018-03-20 04:01', 'yesterday at 04:01'),
-    ('2018-03-20 09:00', 'yesterday at 09:00'),
-    ('2018-03-20 19:00', 'yesterday at 19:00'),
-    ('2018-03-20 23:59', 'yesterday at 23:59'),
+    ('2018-03-20 00:00', '19 March at 00:00 UTC'),  # we specifically refer to 00:00 as belonging to the day before.
+    ('2018-03-20 04:01', 'yesterday at 04:01 UTC'),
+    ('2018-03-20 09:00', 'yesterday at 09:00 UTC'),
+    ('2018-03-20 19:00', 'yesterday at 19:00 UTC'),
+    ('2018-03-20 23:59', 'yesterday at 23:59 UTC'),
 
-    ('2018-03-21 00:00', 'yesterday at 00:00'),  # we specifically refer to 00:00 as belonging to the day before.
-    ('2018-03-21 04:01', 'today at 04:01'),
-    ('2018-03-21 09:00', 'today at 09:00'),
-    ('2018-03-21 12:00', 'today at 12:00'),
-    ('2018-03-21 19:00', 'today at 19:00'),
-    ('2018-03-21 23:59', 'today at 23:59'),
+    ('2018-03-21 00:00', 'yesterday at 00:00 UTC'),  # we specifically refer to 00:00 as belonging to the day before.
+    ('2018-03-21 04:01', 'today at 04:01 UTC'),
+    ('2018-03-21 09:00', 'today at 09:00 UTC'),
+    ('2018-03-21 12:00', 'today at 12:00 UTC'),
+    ('2018-03-21 19:00', 'today at 19:00 UTC'),
+    ('2018-03-21 23:59', 'today at 23:59 UTC'),
 
-    ('2018-03-22 00:00', 'today at 00:00'),
-    ('2018-03-22 04:01', 'tomorrow at 04:01'),
-    ('2018-03-22 09:00', 'tomorrow at 09:00'),
-    ('2018-03-22 19:00', 'tomorrow at 19:00'),
-    ('2018-03-22 23:59', 'tomorrow at 23:59'),
+    ('2018-03-22 00:00', 'today at 00:00 UTC'),
+    ('2018-03-22 04:01', 'tomorrow at 04:01 UTC'),
+    ('2018-03-22 09:00', 'tomorrow at 09:00 UTC'),
+    ('2018-03-22 19:00', 'tomorrow at 19:00 UTC'),
+    ('2018-03-22 23:59', 'tomorrow at 23:59 UTC'),
 
-    ('2018-03-23 04:01', '23 March at 04:01'),
-    ('2018-03-23 09:00', '23 March at 09:00'),
-    ('2018-03-23 19:00', '23 March at 19:00'),
+    ('2018-03-23 04:01', '23 March at 04:01 UTC'),
+    ('2018-03-23 09:00', '23 March at 09:00 UTC'),
+    ('2018-03-23 19:00', '23 March at 19:00 UTC'),
 
 ])
 def test_format_datetime_relative(time, human_readable_datetime):

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -153,7 +153,7 @@ def test_can_show_notifications(
     assert normalize_spaces(
         first_row.select_one('.table-field-right-aligned .align-with-message-body').text
     ) == (
-        'Delivered 1 January at 06:01'
+        'Delivered 1 January at 06:01 UTC'
     )
 
     assert page_title in page.h1.text.strip()
@@ -626,16 +626,16 @@ def test_redacts_templates_that_should_be_redacted(
 @freeze_time("2017-09-27 12:30:00.000000")
 @pytest.mark.parametrize(
     "message_type, status, expected_hint_status, single_line", [
-        ('email', 'created', 'Sending since 27 September at 12:30', True),
-        ('email', 'sending', 'Sending since 27 September at 12:30', True),
-        ('email', 'temporary-failure', 'Inbox not accepting messages right now 27 September at 12:31', False),
-        ('email', 'permanent-failure', 'Email address does not exist 27 September at 12:31', False),
-        ('email', 'delivered', 'Delivered 27 September at 12:31', True),
-        ('sms', 'created', 'Sending since 27 September at 12:30', True),
-        ('sms', 'sending', 'Sending since 27 September at 12:30', True),
-        ('sms', 'temporary-failure', 'Phone not accepting messages right now 27 September at 12:31', False),
-        ('sms', 'permanent-failure', 'Not delivered 27 September at 12:31', False),
-        ('sms', 'delivered', 'Delivered 27 September at 12:31', True),
+        ('email', 'created', 'Sending since 27 September at 12:30 UTC', True),
+        ('email', 'sending', 'Sending since 27 September at 12:30 UTC', True),
+        ('email', 'temporary-failure', 'Inbox not accepting messages right now 27 September at 12:31 UTC', False),
+        ('email', 'permanent-failure', 'Email address does not exist 27 September at 12:31 UTC', False),
+        ('email', 'delivered', 'Delivered 27 September at 12:31 UTC', True),
+        ('sms', 'created', 'Sending since 27 September at 12:30 UTC', True),
+        ('sms', 'sending', 'Sending since 27 September at 12:30 UTC', True),
+        ('sms', 'temporary-failure', 'Phone not accepting messages right now 27 September at 12:31 UTC', False),
+        ('sms', 'permanent-failure', 'Not delivered 27 September at 12:31 UTC', False),
+        ('sms', 'delivered', 'Delivered 27 September at 12:31 UTC', True),
     ]
 )
 def test_sending_status_hint_displays_correctly_on_notifications_page(

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -114,55 +114,55 @@ def test_view_conversation(
     for index, expected in enumerate([
         (
             'message-8',
-            'yesterday at 14:59',
+            'yesterday at 14:59 UTC',
         ),
         (
             'message-7',
-            'yesterday at 14:59',
+            'yesterday at 14:59 UTC',
         ),
         (
             'message-6',
-            'yesterday at 16:59',
+            'yesterday at 16:59 UTC',
         ),
         (
             'message-5',
-            'yesterday at 18:59',
+            'yesterday at 18:59 UTC',
         ),
         (
             'message-4',
-            'yesterday at 20:59',
+            'yesterday at 20:59 UTC',
         ),
         (
             'message-3',
-            'yesterday at 22:59',
+            'yesterday at 22:59 UTC',
         ),
         (
             'message-2',
-            'yesterday at 22:59',
+            'yesterday at 22:59 UTC',
         ),
         (
             'message-1',
-            'yesterday at 23:00',
+            'yesterday at 23:00 UTC',
         ),
         (
             expected_outbound_content,
-            'yesterday at 00:00',
+            'yesterday at 00:00 UTC',
         ),
         (
             expected_outbound_content,
-            'yesterday at 00:00',
+            'yesterday at 00:00 UTC',
         ),
         (
             expected_outbound_content,
-            'yesterday at 00:00',
+            'yesterday at 00:00 UTC',
         ),
         (
             expected_outbound_content,
-            'yesterday at 00:00',
+            'yesterday at 00:00 UTC',
         ),
         (
             expected_outbound_content,
-            'yesterday at 00:00',
+            'yesterday at 00:00 UTC',
         ),
     ]):
         assert (

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -389,14 +389,14 @@ def test_download_inbox(
     )
     assert response.get_data(as_text=True) == (
         'Phone number,Message,Received\r\n'
-        '(202) 867-5300,message-1,2016-07-01 11:00\r\n'
-        '(202) 867-5300,message-2,2016-07-01 10:59\r\n'
-        '(202) 867-5300,message-3,2016-07-01 10:59\r\n'
-        '(202) 867-5302,message-4,2016-07-01 08:59\r\n'
-        '+33 1 12 34 56 78,message-5,2016-07-01 06:59\r\n'
-        '(202) 555-0104,message-6,2016-07-01 04:59\r\n'
-        '(202) 555-0104,message-7,2016-07-01 02:59\r\n'
-        '+682 12345,message-8,2016-07-01 02:59\r\n'
+        '(202) 867-5300,message-1,2016-07-01 11:00 UTC\r\n'
+        '(202) 867-5300,message-2,2016-07-01 10:59 UTC\r\n'
+        '(202) 867-5300,message-3,2016-07-01 10:59 UTC\r\n'
+        '(202) 867-5302,message-4,2016-07-01 08:59 UTC\r\n'
+        '+33 1 12 34 56 78,message-5,2016-07-01 06:59 UTC\r\n'
+        '(202) 555-0104,message-6,2016-07-01 04:59 UTC\r\n'
+        '(202) 555-0104,message-7,2016-07-01 02:59 UTC\r\n'
+        '+682 12345,message-8,2016-07-01 02:59 UTC\r\n'
     )
 
 
@@ -648,7 +648,7 @@ def test_should_show_upcoming_jobs_on_dashboard(
         page.select_one('a.banner-dashboard').text
     ) == (
         '2 files waiting to send '
-        'sending starts today at 11:09'
+        'sending starts today at 11:09 UTC'
     )
 
     assert page.select_one('a.banner-dashboard')['href'] == url_for(

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -83,7 +83,7 @@ def test_should_show_page_for_one_job(
 
     assert page.h1.text.strip() == 'thisisatest.csv'
     assert ' '.join(page.find('tbody').find('tr').text.split()) == (
-        '2021234567 template content Delivered 1 January at 11:10'
+        '2021234567 template content Delivered 1 January at 11:10 UTC'
     )
     assert page.find('div', {'data-key': 'notifications'})['data-resource'] == url_for(
         'main.view_job_updates',
@@ -104,7 +104,7 @@ def test_should_show_page_for_one_job(
     assert normalize_spaces(page.select_one('tbody tr').text) == normalize_spaces(
         '2021234567 '
         'template content '
-        'Delivered 1 January at 11:10'
+        'Delivered 1 January at 11:10 UTC'
     )
     assert page.select_one('tbody tr a')['href'] == url_for(
         'main.view_notification',
@@ -329,7 +329,7 @@ def test_should_show_scheduled_job(
     )
 
     assert normalize_spaces(page.select('main p')[1].text) == (
-        'Sending Two week reminder tomorrow at 05:00'
+        'Sending Two week reminder tomorrow at 05:00 UTC'
     )
     assert page.select('main p a')[0]['href'] == url_for(
         'main.view_template_version',

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -188,7 +188,7 @@ def test_view_providers_shows_all_providers(
     assert table_data[1].text.strip() == "20"
     assert table_data[2].text.strip() == "42"
     assert table_data[3].text.strip() == "True"
-    assert table_data[4].text.strip() == "16 January at 15:20"
+    assert table_data[4].text.strip() == "16 January at 15:20 UTC"
     assert table_data[5].text.strip() == "Test User"
 
     domestic_sms_second_row = domestic_sms_table.tbody.find_all('tr')[1]

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -472,7 +472,7 @@ def test_caseworker_sees_template_page_if_template_is_deleted(
 
     content = str(page)
     assert url_for("main.send_one_off", service_id=SERVICE_ONE_ID, template_id=fake_uuid) not in content
-    assert page.select('p.hint')[0].text.strip() == 'This template was deleted today at 15:00.'
+    assert page.select('p.hint')[0].text.strip() == 'This template was deleted today at 15:00 UTC.'
 
     mock_get_deleted_template.assert_called_with(SERVICE_ONE_ID, template_id, None)
 
@@ -1571,7 +1571,7 @@ def test_should_show_page_for_a_deleted_template(
     content = str(page)
     assert url_for("main.edit_service_template", service_id=SERVICE_ONE_ID, template_id=fake_uuid) not in content
     assert url_for("main.send_one_off", service_id=SERVICE_ONE_ID, template_id=fake_uuid) not in content
-    assert page.select('p.hint')[0].text.strip() == 'This template was deleted today at 15:00.'
+    assert page.select('p.hint')[0].text.strip() == 'This template was deleted today at 15:00 UTC.'
     assert 'Delete this template' not in page.select_one('main').text
 
     mock_get_deleted_template.assert_called_with(SERVICE_ONE_ID, template_id, None)

--- a/tests/app/main/views/uploads/test_upload_hub.py
+++ b/tests/app/main/views/uploads/test_upload_hub.py
@@ -48,7 +48,7 @@ def test_get_upload_hub_page(
 
     assert normalize_spaces(uploads[0].text.strip()) == (
         'some.csv '
-        'Sent 1 January 2016 at 11:09 '
+        'Sent 1 January 2016 at 11:09 UTC '
         '0 pending 8 delivered 2 failed'
     )
     assert uploads[0].select_one('a.file-list-filename-large')['href'] == (
@@ -79,12 +79,12 @@ def test_uploads_page_shows_scheduled_jobs(
         ),
         (
             'even_later.csv '
-            'Sending 1 January 2016 at 23:09 '
+            'Sending 1 January 2016 at 23:09 UTC '
             '1 text message waiting to send'
         ),
         (
             'send_me_later.csv '
-            'Sending 1 January 2016 at 11:09 '
+            'Sending 1 January 2016 at 11:09 UTC '
             '1 text message waiting to send'
         ),
     ]


### PR DESCRIPTION
Added:
- UTC has been added to return strings in time formatters.
- Tests have been fixed where assertion was missing the UTC label at the end.

Removed:
- Hardcoded UTC label in `notifications.html`.

I didn't see anywhere else in the code where UTC should be removed that it wasn't needed. Any `p` tags or `div` tags with UTC in them that inform the user are still there.