### PR TITLE
Removing the link to create an account

### DIFF
--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -28,10 +28,11 @@
       {% endif %}
     {% else %}
       <h1 class="font-body-2xl margin-bottom-3">Sign in</h1>
-      <p>
+      <!-- Removing temporarily for pilot -->
+      <!-- <p>
         If you do not have an account, you can
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.register') }}">create one now</a>.
-      </p>
+      </p> -->
     {% endif %}
 
     {% call form_wrapper(autocomplete=True) %}

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -19,10 +19,11 @@ def test_render_sign_in_template_for_new_user(
     assert normalize_spaces(page.select('label')[1].text) == 'Password'
     assert page.select_one('#password').get('value') is None
     assert page.select_one('#password')['autocomplete'] == 'current-password'
-    assert page.select('main a')[0].text == 'create one now'
-    assert page.select('main a')[0]['href'] == url_for('main.register')
-    assert page.select('main a')[1].text == 'Forgot your password?'
-    assert page.select('main a')[1]['href'] == url_for('main.forgot_password')
+    # Removing for the pilot
+    # assert page.select('main a')[0].text == 'create one now'
+    # assert page.select('main a')[0]['href'] == url_for('main.register')
+    assert page.select('main a')[0].text == 'Forgot your password?'
+    assert page.select('main a')[0]['href'] == url_for('main.forgot_password')
     assert 'Sign in again' not in normalize_spaces(page.text)
 
 


### PR DESCRIPTION
Address #609 

This changeset removes the create account link from the sign-in page.

## Security Considerations

- Prevents users from clicking on a link to perform an action that they no longer have the ability to do.