### PR TITLE
Changing "U.S. Notify" to Notify.gov

### DIFF
--- a/docs/notify-pilot-info.md
+++ b/docs/notify-pilot-info.md
@@ -34,7 +34,7 @@ agency money.</td>
 </tbody>
 </table>
 
-### OUR FIRST BET: U.S. Notify
+### OUR FIRST BET: Notify.gov
 
 <table>
 <colgroup>
@@ -49,7 +49,7 @@ style="width:4.63788in;height:3.75964in" /></h3></td>
 <p>No technical knowledge needed to create direct, actionable
 messages.</p>
 <h3 id="send-bulk-messages">Send bulk messages </h3>
-<p>Upload a .csv file with necessary information and Notify sends
+<p>Upload a .csv file with necessary information and Notify.gov sends
 messages customized to each recipient</p>
 <h3 id="see-how-messages-perform">See how messages perform</h3>
 <p>Track how many messages you’ve sent and monitor successful delivery
@@ -58,7 +58,7 @@ rates</p></td>
 </tbody>
 </table>
 
-**U.S. Notify** will be a federally-run shared service allowing staff to
+**Notify.gov** will be a federally-run shared service allowing staff to
 send thousands of customized-to-the-user text messages per year at
 little-to-no-cost. The easy interface requires no technical expertise to
 use and the setup process takes only ten minutes.
@@ -83,22 +83,22 @@ additional features based on partner needs.
 
 To get involved, email us at [notify-support@gsa.gov](mailto:notify-support@gsa.gov) with the following in the subject line!
 
-1.  **Request a Studio introduction and/or a Notify demo:** Request an
+1.  **Request a Studio introduction and/or a Notify.gov demo:** Request an
     introductory call to  
     talk about our product, near term goals, and ways to get involved.
 
-2.  **Provide feedback about Notify:** If you're a potential product
+2.  **Provide feedback about Notify.gov:** If you're a potential product
     user, set up an individual feedback session to help us fortify our
     tool and talk through potential set-up considerations from your
     vantage point.
 
-3.  **Sign up to pilot Notify:** Already think this might be the tool
+3.  **Sign up to pilot Notify.gov:** Already think this might be the tool
     for you? We’re looking for benefit-administering partners to
     co-design a pilot program to test U.S. Notify for specific use cases.
     Early adopters will have wrap-around set-up support from the Studio
     and an opportunity to shape the future of this product.
     
-## US Notify Demo
+## Notify.gov Demo
 
 
 


### PR DESCRIPTION
Updating this one page - more updates to come as we adjust - this one is just timely. 