### PR TITLE
Changed link to email notify support instead of going to request to go live page

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -206,7 +206,7 @@
       <p>
         {% if current_user.has_permissions('manage_service') %}
           To remove these restrictions, you can send us a
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+          <a class="govuk-link govuk-link--no-visited-state" href="mailto:notify-support@gsa.gov">request to go live</a>.
         {% else %}
           Your service manager can ask to have these restrictions removed.
         {% endif %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -367,7 +367,8 @@ def test_show_restricted_service(
 
     if expected_link:
         assert request_to_live_link.text.strip() == 'request to go live'
-        assert request_to_live_link['href'] == url_for('main.request_to_go_live', service_id=SERVICE_ONE_ID)
+        email_address = 'notify-support@gsa.gov'
+        assert request_to_live_link['href'] == f'mailto:{email_address}'
     else:
         assert not request_to_live_link
 


### PR DESCRIPTION
Will address route later, but wanted to get this completed first as adjusting the route broke a lot of tests