### PR TITLE
Continue e2e tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,15 +45,15 @@ jobs:
       - name: Run E2E tests
         run: pipenv run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         env:
-          MFA_TOTP_INTERVAL: ${{ MFA_TOTP_INTERVAL }}
-          MFA_TOTP_LENGTH: ${{ MFA_TOTP_LENGTH }}
-          MFA_TOTP_SECRET: ${{ MFA_TOTP_SECRET }}
-          NOTIFY_E2E_AUTH_STATE_PATH: ${{ NOTIFY_E2E_AUTH_STATE_PATH }}
-          NOTIFY_E2E_TEST_EMAIL: ${{ NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD: ${{ NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD }}
-          NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_E2E_TEST_URI: ${{ NOTIFY_E2E_TEST_URI }}
+          MFA_TOTP_INTERVAL: ${{ secrets.MFA_TOTP_INTERVAL }}
+          MFA_TOTP_LENGTH: ${{ secrets.MFA_TOTP_LENGTH }}
+          MFA_TOTP_SECRET: ${{ secrets.MFA_TOTP_SECRET }}
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD }}
+          NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
       - name: Check coverage threshold
         run: pipenv run coverage report --fail-under=90
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,9 +45,15 @@ jobs:
       - name: Run E2E tests
         run: pipenv run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         env:
-          NOTIFY_STAGING_HTTP_AUTH_PASSWORD: ${{ secrets.NOTIFY_STAGING_HTTP_AUTH_PASSWORD }}
-          NOTIFY_STAGING_HTTP_AUTH_USER: ${{ secrets.NOTIFY_STAGING_HTTP_AUTH_USER }}
-          NOTIFY_STAGING_URI: ${{ secrets.NOTIFY_STAGING_URI }}
+          MFA_TOTP_INTERVAL: ${{ MFA_TOTP_INTERVAL }}
+          MFA_TOTP_LENGTH: ${{ MFA_TOTP_LENGTH }}
+          MFA_TOTP_SECRET: ${{ MFA_TOTP_SECRET }}
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD: ${{ NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD }}
+          NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_E2E_TEST_URI: ${{ NOTIFY_E2E_TEST_URI }}
       - name: Check coverage threshold
         run: pipenv run coverage report --fail-under=90
 

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ app/templates/vendor
 secrets.auto.tfvars
 terraform.tfstate
 terraform.tfstate.backup
+
+# Playwright
+playwright/

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ py-test: ## Run python unit tests
 .PHONY: e2e-test
 e2e-test: export NEW_RELIC_ENVIRONMENT=test
 e2e-test: ## Run end-to-end integration tests
-	pipenv run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+	rm -rf playwright
+	mkdir -p playwright/.auth
+	pipenv run pytest -vv --browser chromium --browser firefox --browser webkit tests/end_to_end
 
 .PHONY: js-lint
 js-lint: ## Run javascript linting scanners

--- a/Pipfile
+++ b/Pipfile
@@ -36,8 +36,8 @@ newrelic = "*"
 flask-talisman = "*"
 notifications-utils = {editable = true, ref = "main", git = "https://github.com/GSA/notifications-utils.git"}
 coverage = "*"
-pytest-playwright = "*"
 radon = "==6.0.1"
+pyotp = "~=2.8.0"
 
 [dev-packages]
 isort = "==5.12.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ba88d2c8e70243162c4fd03b8ddf1ec9c5542d0d2ccee7b4e8f4fd543912179"
+            "sha256": "f917cb96474cec9127313580dcebcbf25c87219551800fa2091210c7ba390a09"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -50,19 +50,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4a435fdbd77628e3d32cfbc8b6225e779d8f789027fadb6a51fe1b456e15ef54",
-                "sha256:57d618f03bd269ebef6287dd4ed86ddaa1d53a4021008ad3267c6097be17e172"
+                "sha256:2b509a959966a572f15db5768a18066ce1f53022ac53fca9421c620219fa3998",
+                "sha256:e095ede98d3680e65966ab71f273b7d86938f5d853773ef96f4cb646277c2a4b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.28"
+            "version": "==1.28.30"
         },
         "botocore": {
             "hashes": [
-                "sha256:1fcfbd23c7f1f66f16c5c1a1e8565ee8ff68429cc0ee9d2acfb1b55739584cbd",
-                "sha256:d6310826e37ba0209e904d691638b8e848342ec17f5187568ca02ad092c55c45"
+                "sha256:269f20dcadd8dfd0c26d0e6fbceb84814ff6638ff3aafcc5324b9fb9949a7051",
+                "sha256:3cf6a9d7621b897c9ff23cd02113826141b3dd3d7e90273b661efc4dc05f84e2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.28"
+            "version": "==1.31.30"
         },
         "cachetools": {
             "hashes": [
@@ -77,7 +77,7 @@
                 "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
                 "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2023.7.22"
         },
         "cffi": {
@@ -235,23 +235,23 @@
                 "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac",
                 "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.2.0"
         },
         "click": {
             "hashes": [
-                "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd",
-                "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.6"
+            "version": "==8.1.7"
         },
         "colorama": {
             "hashes": [
                 "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
                 "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_version > '3.4'",
             "version": "==0.4.6"
         },
         "coverage": {
@@ -360,7 +360,7 @@
                 "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c",
                 "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.1.0"
         },
         "eventlet": {
@@ -548,14 +548,6 @@
             ],
             "markers": "python_version < '3.10'",
             "version": "==6.8.0"
-        },
-        "iniconfig": {
-            "hashes": [
-                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
-                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -758,24 +750,24 @@
         },
         "newrelic": {
             "hashes": [
-                "sha256:2567ba9e29fd7b9f4c23cf16a5a149097eb0e5da587734c5a40732d75aaec189",
-                "sha256:365d3b1a10d1021217beeb28a93c1356a9feb94bd24f02972691dc71227e40dc",
-                "sha256:4ed36fb91f152128825459eae9a52da364352ea95bcd78b405b0a5b8057b2ed7",
-                "sha256:55a64d2abadf69bbc7bb01178332c4f25247689a97b01a62125d162ea7ec8974",
-                "sha256:722072d57e2d416de68b650235878583a2a8809ea39c7dd5c8c11a19089b7665",
-                "sha256:8a2271b76ea684a63936302579d6085d46a2b54042cb91dc9b0d71a0cd4dd38b",
-                "sha256:9601d886669fe1e0c23bbf91fb68ab23086011816ba96c6dd714c60dc0a74088",
-                "sha256:b6cddd869ac8f7f32f6de8212ae878a21c9e63f2183601d239a76d38c5d5a366",
-                "sha256:cf3b67327e64d2b50aec855821199b2bc46bc0c2d142df269d420748dd49b31b",
-                "sha256:d9af0130e1f1ca032c606d15a6d5558d27273a063b7c53702218b3beccd50b23",
-                "sha256:dbda843100c99ac3291701c0a70fedb705c0b0707800c60b93657d3985aae357",
-                "sha256:ecd0666557419dbe11b04e3b38480b3113b3c4670d42619420d60352a1956dd8",
-                "sha256:f2fd24b32dbf510e4e3fe40b71ad395dd73a4bb9f5eaf59eb5ff22ed76ba2d41",
-                "sha256:f9c9f7842234a51e4a2fdafe42c42ebe0b6b1966279f2f91ec8a9c16480c2236",
-                "sha256:fc975c29548e25805ead794d9de7ab3cb8ba4a6a106098646e1ab03112d1432e"
+                "sha256:39a699f88042255634c88beff92c2fc10d9d522b6c989f52a6ae098823b51a02",
+                "sha256:56161cbaa97f93a807db4bd61436ff7757c8a896758d325b708567cca48bfd13",
+                "sha256:62c558a5dbfa8728cbb0addd199038c0e75feb79282a9e07c272a2acaf250094",
+                "sha256:6bd507fa91175cc558c810cefe2b7ee20d1143f88a7153e255d49d7ce12cd287",
+                "sha256:74a7b07153aaac65cefe21183ebbedc5dee7d0cd681ec27c5258499b7a4319b1",
+                "sha256:7555f4bd91bea441cd2a5dc94848034e4ab2ab068d30905288a789d3214b1a03",
+                "sha256:885c852dc88d9612fe3de1940246e9200a510a289b0cf56459494782096cdba4",
+                "sha256:930457ffd0cd5696f75cd0d761e550cecbba2eadc37c0db617c25b7c4a5d19e1",
+                "sha256:962ac353b66f2827b337af941b86dff2d61d1c7638e5cab950e995e53e52665c",
+                "sha256:9eb93901fd9caebc7f965812a7dea349d43b44d45d693ffb6ee6c4c40b5de78d",
+                "sha256:ae9b96bad4f6b92a45fe28d7303b747d36aa2f9ad545fd3fc51f7eac2a45f011",
+                "sha256:c4d87e6d517f7bc8bf5f982b6260ce1efc642b4fe5b83f23d11a69a9351d83c3",
+                "sha256:d0c15312c6cd73559f5b01fe018feaf018a4566210338fdc5616dfb4f1ce24f0",
+                "sha256:e7789b0340d04bbd31c76d42f2d5d064b47f90c09c74978e6175d77bcdd9e226",
+                "sha256:f9361fc81911e42c272eab640569cbce1849873f5c5c9d74c9a58a3b8bd23d2f"
             ],
             "index": "pypi",
-            "version": "==8.10.0"
+            "version": "==8.10.1"
         },
         "notifications-python-client": {
             "hashes": [
@@ -834,41 +826,12 @@
             ],
             "version": "==2.0.3"
         },
-        "packaging": {
-            "hashes": [
-                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
-                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==23.1"
-        },
         "phonenumbers": {
             "hashes": [
                 "sha256:3d802739a22592e4127139349937753dee9b6a20bdd5d56847cd885bdc766b1f",
                 "sha256:b360c756252805d44b447b5bca6d250cf6bd6c69b6f0f4258f3bfe5ab81bef69"
             ],
             "version": "==8.13.18"
-        },
-        "playwright": {
-            "hashes": [
-                "sha256:41f0280472af94c426e941f6a969ff6a7ea156dc15fd01d09ac4b8f092e2346e",
-                "sha256:428fdf9bfff586b73f96df53692d50d422afb93ca4650624f61e8181f548fed2",
-                "sha256:678b9926be2df06321d11a525d4bf08d9f4a5b151354a3b82fe2ac14476322d5",
-                "sha256:68d56efe5ce916bab349177e90726837a6f0cae77ebd6a5200f5333b787b25fb",
-                "sha256:8b5d96aae54289129ab19d3d0e2e431171ae3e5d88d49a10900dcbe569a27d43",
-                "sha256:b476f63251876f1625f490af8d58ec0db90b555c623b7f54105f91d33878c06d",
-                "sha256:b574889ef97b7f44a633aa10d72b8966a850a4354d915fd0bc7e8658e825dd63"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.37.0"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
-                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2.0"
         },
         "prometheus-client": {
             "hashes": [
@@ -884,13 +847,6 @@
                 "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
             ],
             "version": "==2.21"
-        },
-        "pyee": {
-            "hashes": [
-                "sha256:2770c4928abc721f46b705e6a72b0c59480c4a69c9a83ca0b00bb994f1ea4b32",
-                "sha256:9f066570130c554e9cc12de5a9d86f57c7ee47fece163bbdaa3e9c933cfbdfa5"
-            ],
-            "version": "==9.0.4"
         },
         "pyexcel": {
             "hashes": [
@@ -947,6 +903,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.8.0"
         },
+        "pyotp": {
+            "hashes": [
+                "sha256:889d037fdde6accad28531fc62a790f089e5dfd5b638773e9ee004cce074a2e5",
+                "sha256:c2f5e17d9da92d8ec1f7de6331ab08116b9115adbabcba6e208d46fc49a98c5a"
+            ],
+            "index": "pypi",
+            "version": "==2.8.0"
+        },
         "pyproj": {
             "hashes": [
                 "sha256:00fab048596c17572fa8980014ef117dbb2a445e6f7ba3b9ddfcc683efc598e7",
@@ -978,36 +942,12 @@
             "index": "pypi",
             "version": "==3.6.0"
         },
-        "pytest": {
-            "hashes": [
-                "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
-                "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==7.4.0"
-        },
-        "pytest-base-url": {
-            "hashes": [
-                "sha256:e1e88a4fd221941572ccdcf3bf6c051392d2f8b6cef3e0bc7da95abec4b5346e",
-                "sha256:ed36fd632c32af9f1c08f2c2835dcf42ca8fcd097d6ed44a09f253d365ad8297"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==2.0.0"
-        },
-        "pytest-playwright": {
-            "hashes": [
-                "sha256:68dd0069e2dbf8e6024c6237d51d0277626687d94ba0dd387cea2a94ae4005b9",
-                "sha256:9e9622e5507f8d27a3c7fd07aadcf43122f0086b69d1b3e6728995c8dbc0e44f"
-            ],
-            "index": "pypi",
-            "version": "==0.4.2"
-        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "python-dotenv": {
@@ -1023,16 +963,8 @@
                 "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c",
                 "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.0.7"
-        },
-        "python-slugify": {
-            "hashes": [
-                "sha256:70ca6ea68fe63ecc8fa4fcf00ae651fc8a5d02d93dcd12ae6d4fc7ca46c4d395",
-                "sha256:ce0d46ddb668b3be82f4ed5e503dbc33dd815d83e2eb6824211310d3fb172a27"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.0.1"
         },
         "pytz": {
             "hashes": [
@@ -1085,7 +1017,7 @@
                 "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "radon": {
@@ -1130,11 +1062,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:d59c97e7b774979a5ccb96388efc9eb65518004537e85d52e81eaee89ab6dd91",
-                "sha256:e13e1b0bc760e9b0127eda042845999b2f913e12437046e663b833aa96d89715"
+                "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d",
+                "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==68.1.0"
+            "version": "==68.1.2"
         },
         "shapely": {
             "hashes": [
@@ -1185,7 +1117,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "smartypants": {
@@ -1194,35 +1126,12 @@
             ],
             "version": "==2.0.1"
         },
-        "text-unidecode": {
-            "hashes": [
-                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
-                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
-            ],
-            "version": "==1.3"
-        },
         "texttable": {
             "hashes": [
                 "sha256:290348fb67f7746931bcdfd55ac7584ecd4e5b0846ab164333f0794b121760f2",
                 "sha256:b7b68139aa8a6339d2c320ca8b1dc42d13a7831a346b446cb9eb385f0c76310c"
             ],
             "version": "==1.6.7"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==2.0.1"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
-                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.7.1"
         },
         "urllib3": {
             "hashes": [
@@ -1306,19 +1215,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4a435fdbd77628e3d32cfbc8b6225e779d8f789027fadb6a51fe1b456e15ef54",
-                "sha256:57d618f03bd269ebef6287dd4ed86ddaa1d53a4021008ad3267c6097be17e172"
+                "sha256:2b509a959966a572f15db5768a18066ce1f53022ac53fca9421c620219fa3998",
+                "sha256:e095ede98d3680e65966ab71f273b7d86938f5d853773ef96f4cb646277c2a4b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.28"
+            "version": "==1.28.30"
         },
         "botocore": {
             "hashes": [
-                "sha256:1fcfbd23c7f1f66f16c5c1a1e8565ee8ff68429cc0ee9d2acfb1b55739584cbd",
-                "sha256:d6310826e37ba0209e904d691638b8e848342ec17f5187568ca02ad092c55c45"
+                "sha256:269f20dcadd8dfd0c26d0e6fbceb84814ff6638ff3aafcc5324b9fb9949a7051",
+                "sha256:3cf6a9d7621b897c9ff23cd02113826141b3dd3d7e90273b661efc4dc05f84e2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.28"
+            "version": "==1.31.30"
         },
         "cachecontrol": {
             "extras": [
@@ -1336,7 +1245,7 @@
                 "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
                 "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2023.7.22"
         },
         "cffi": {
@@ -1486,7 +1395,7 @@
                 "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac",
                 "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.2.0"
         },
         "cryptography": {
@@ -1799,7 +1708,7 @@
                 "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
                 "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
         },
         "mdurl": {
@@ -2022,7 +1931,7 @@
                 "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
                 "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
             ],
-            "markers": "python_version >= '3.7'",
+            "index": "pypi",
             "version": "==7.4.0"
         },
         "pytest-base-url": {
@@ -2070,7 +1979,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "python-slugify": {
@@ -2124,7 +2033,7 @@
                 "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "requests": {
@@ -2156,7 +2065,7 @@
                 "sha256:146a90b3b6b47cac4a73c12866a499e9817426423f57c5a66949c086191a8808",
                 "sha256:fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==13.5.2"
         },
         "s3transfer": {
@@ -2172,7 +2081,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "smmap": {
@@ -2180,7 +2089,7 @@
                 "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94",
                 "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==5.0.0"
         },
         "sortedcontainers": {
@@ -2218,7 +2127,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tomli": {

--- a/docs/end_to_end_tests.md
+++ b/docs/end_to_end_tests.md
@@ -149,9 +149,9 @@ deployment per environment.  These are added in as environment
 secrets.
 
 These variables also need to be set as repository secrets in the
-Admin site for the E2E tests to run successfully in the CI/CD
-pipeline.  They must be added as repository secrets for both
-GitHub Actions and Dependabot.
+Admin site and API for both the regular tests and E2E tests to
+run successfully in the CI/CD pipeline.  They must be added as
+repository secrets for both GitHub Actions and Dependabot.
 
 
 ### E2E Environment Variable Management

--- a/docs/end_to_end_tests.md
+++ b/docs/end_to_end_tests.md
@@ -87,6 +87,7 @@ NOTIFY_E2E_TEST_HTTP_AUTH_USER         # This is optional
 NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD     # This is optional
 NOTIFY_E2E_TEST_EMAIL
 NOTIFY_E2E_TEST_PASSWORD
+NOTIFY_E2E_AUTH_STATE_PATH
 ```
 
 This file is **not** checked into source control and is configured to be
@@ -163,6 +164,7 @@ NOTIFY_E2E_TEST_HTTP_AUTH_USER         # This is optional
 NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD     # This is optional
 NOTIFY_E2E_TEST_EMAIL
 NOTIFY_E2E_TEST_PASSWORD
+NOTIFY_E2E_AUTH_STATE_PATH
 ```
 
 These are only set for the Admin site in GitHub, but must be set

--- a/docs/end_to_end_tests.md
+++ b/docs/end_to_end_tests.md
@@ -33,7 +33,8 @@ doing this:
 
 1. Run `brew --prefix` to see Homebrew's root directory
 
-1. Create or modify the local `.env` file in the project and add this line:
+1. Create or modify the local `.env` file in the project and add this
+   line:
 
    `NODE_EXTRA_CA_CERTS=/CHANGE-TO-HOMEBREW-INSTALL-PATH/etc/ca-certificates/cert.pem`
 
@@ -56,26 +57,36 @@ your environment is set up and configured as outlined in the README.
 At your shell in the project root folder, run the following commands:
 
 ```sh
-pipenv install pytest-playwright
+pipenv install pytest-playwright --dev
 pipenv run playwright install --with-deps
 ```
 
 This will install Playwright and its `pytest` plugin, then the
 additional dependencies that Playwright requires.
 
-See more details on the [Playwright for Python Installation page](https://playwright.dev/python/docs/intro).
+See more details on the
+[Playwright for Python Installation page](https://playwright.dev/python/docs/intro).
 
 
 ## Local Configuration
 
-In order to run the E2E tests successfully on your local machine, you'll also
-need to make sure you have a `.env` file in the root project folder, and that it
-has at least these environment variables set in it:
+In order to run the E2E tests successfully on your local machine, you'll
+also need to make sure you have a `.env` file in the root project folder
+and that it has at least these environment variables set in it:
 
 ```
-NOTIFY_STAGING_URI
-NOTIFY_STAGING_HTTP_AUTH_USER
-NOTIFY_STAGING_HTTP_AUTH_PASSWORD
+# MFA Configuration - must be set to the same values for both the API
+# and the Admin site.
+MFA_TOTP_SECRET
+MFA_TOTP_LENGTH
+MFA_TOTP_INTERVAL
+
+# E2E Test Configuration - only set for the Admin site.
+NOTIFY_E2E_TEST_URI
+NOTIFY_E2E_TEST_HTTP_AUTH_USER         # This is optional
+NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD     # This is optional
+NOTIFY_E2E_TEST_EMAIL
+NOTIFY_E2E_TEST_PASSWORD
 ```
 
 This file is **not** checked into source control and is configured to be
@@ -99,7 +110,8 @@ tests run in multiple headless browsers.
 ## How to Create and Maintain E2E Tests
 
 All of the E2E tests are found in the `tests/end_to_end` folder and are
-written as `pytest` scripts using [Playwright's Python Framework](https://playwright.dev/python/docs/writing-tests).
+written as `pytest` scripts using
+[Playwright's Python Framework](https://playwright.dev/python/docs/writing-tests).
 
 
 ## Maintaining E2E Tests with GitHub
@@ -117,4 +129,42 @@ This is done for a couple of reasons:
 - Allows us to configure E2E tests separately
 
 The environment variables are managed as a part of the GitHub
-repository settings.
+environment and repository settings.
+
+
+### MFA Environment Variable Management
+
+These are the MFA environment variables that must be set:
+
+```
+MFA_TOTP_SECRET
+MFA_TOTP_LENGTH
+MFA_TOTP_INTERVAL
+```
+
+The MFA-related environment variables need to be set for each
+environment in the API as they are pulled in as a part of
+deployment per environment.  These are added in as environment
+secrets.
+
+These variables also need to be set as repository secrets in the
+Admin site for the E2E tests to run successfully in the CI/CD
+pipeline.  They must be added as repository secrets for both
+GitHub Actions and Dependabot.
+
+
+### E2E Environment Variable Management
+
+These are the E2E test environment variables that must be set:
+
+```
+NOTIFY_E2E_TEST_URI
+NOTIFY_E2E_TEST_HTTP_AUTH_USER         # This is optional
+NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD     # This is optional
+NOTIFY_E2E_TEST_EMAIL
+NOTIFY_E2E_TEST_PASSWORD
+```
+
+These are only set for the Admin site in GitHub, but must be set
+for both GitHub Actions and Dependabot for the same reason as
+the MFA environment variables.

--- a/sample.env
+++ b/sample.env
@@ -28,6 +28,7 @@ NOTIFY_E2E_TEST_URI=http://localhost:6012/
 #NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD="this is optional - don't write secrets to the sample file"
 NOTIFY_E2E_TEST_EMAIL=fake.user@example.com
 NOTIFY_E2E_TEST_PASSWORD="don't write secrets to the sample file"
+NOTIFY_E2E_AUTH_STATE_PATH=playwright/.auth/
 
 #############################################################
 

--- a/sample.env
+++ b/sample.env
@@ -14,6 +14,23 @@ NODE_VERSION=16.15.1
 
 #############################################################
 
+# MFA Configuration
+MFA_TOTP_SECRET="don't write secrets to the sample file"
+MFA_TOTP_LENGTH=6
+MFA_TOTP_INTERVAL=30
+
+#############################################################
+
+# E2E Testing
+
+NOTIFY_E2E_TEST_URI=http://localhost:6012/
+#NOTIFY_E2E_TEST_HTTP_AUTH_USER="this is optional"
+#NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD="this is optional - don't write secrets to the sample file"
+NOTIFY_E2E_TEST_EMAIL=fake.user@example.com
+NOTIFY_E2E_TEST_PASSWORD="don't write secrets to the sample file"
+
+#############################################################
+
 # Local Docker setup
 # API_HOST_NAME=http://dev:6011
 # REDIS_URL=redis://adminredis:6379/0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3361,7 +3361,7 @@ def login_for_end_to_end_testing(browser):
     sign_in_button.click()
 
     # Wait for the next page to fully load.
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Check for the sign in form elements.
     # NOTE:  Playwright cannot find input elements by role and recommends using
@@ -3380,7 +3380,7 @@ def login_for_end_to_end_testing(browser):
     continue_button.click()
 
     # Wait for the next page to fully load.
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Check for the sign in form elements.
     # NOTE:  Playwright cannot find input elements by role and recommends using
@@ -3401,10 +3401,14 @@ def login_for_end_to_end_testing(browser):
     mfa_input.fill(totp.now())
     continue_button.click()
 
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Save storage state into the file.
-    context.storage_state(path='state.json')
+    auth_state_path = os.path.join(
+        os.getenv('NOTIFY_E2E_AUTH_STATE_PATH'),
+        'state.json'
+    )
+    context.storage_state(path=auth_state_path)
 
 
 @pytest.fixture(scope='session')
@@ -3427,6 +3431,11 @@ def end_to_end_authenticated_context(browser):
     # Create and load a previously authenticated context for Playwright E2E
     # tests.
     login_for_end_to_end_testing(browser)
-    context = browser.new_context(storage_state='state.json')
+
+    auth_state_path = os.path.join(
+        os.getenv('NOTIFY_E2E_AUTH_STATE_PATH'),
+        'state.json'
+    )
+    context = browser.new_context(storage_state=auth_state_path)
 
     yield context

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 
@@ -11,6 +12,9 @@ def test_accounts_page(end_to_end_authenticated_context):
     accounts_uri = '{}accounts'.format(os.getenv('NOTIFY_E2E_TEST_URI'))
 
     page.goto(accounts_uri)
+
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('domcontentloaded')
 
     # Check to make sure that we've arrived at the next page.
     # Check the page title exists and matches what we expect.
@@ -27,3 +31,89 @@ def test_accounts_page(end_to_end_authenticated_context):
     )
 
     expect(add_service_button).to_be_visible()
+
+
+def test_add_new_service_workflow(end_to_end_authenticated_context):
+    # Prepare for adding a new service later in the test.
+    current_date_time = datetime.datetime.now()
+    new_service_name = 'E2E Federal Test Service {now} - {browser_type}'.format(
+        now=current_date_time.strftime('%m/%d/%Y %H:%M:%S'),
+        browser_type=end_to_end_authenticated_context.browser.browser_type.name
+    )
+
+    # Open a new page and go to the staging site.
+    page = end_to_end_authenticated_context.new_page()
+
+    accounts_uri = '{}accounts'.format(os.getenv('NOTIFY_E2E_TEST_URI'))
+
+    page.goto(accounts_uri)
+
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('domcontentloaded')
+
+    # Check to make sure that we've arrived at the next page.
+    # Check the page title exists and matches what we expect.
+    expect(page).to_have_title(re.compile('Choose service'))
+
+    # Check for the sign in heading.
+    sign_in_heading = page.get_by_role('heading', name='Choose service')
+    expect(sign_in_heading).to_be_visible()
+
+    # Retrieve some prominent elements on the page for testing.
+    add_service_button = page.get_by_role(
+        'button',
+        name=re.compile('Add a new service')
+    )
+
+    expect(add_service_button).to_be_visible()
+
+    existing_service_link = page.get_by_role(
+        'link',
+        name=new_service_name
+    )
+
+    # Check to see if the service was already created - if so, we should fail.
+    # TODO:  Figure out how to make this truly isolated, and/or work in a
+    #        delete service workflow.
+    expect(existing_service_link).to_have_count(0)
+
+    # Click on add a new service.
+    add_service_button.click()
+
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('domcontentloaded')
+
+    # Check for the sign in heading.
+    about_heading = page.get_by_role('heading', name='About your service')
+    expect(about_heading).to_be_visible()
+
+    # Retrieve some prominent elements on the page for testing.
+    service_name_input = page.locator('xpath=//input[@name="name"]')
+    federal_radio_button = page.locator('xpath=//input[@value="federal"]')
+    state_radio_button = page.locator('xpath=//input[@value="state"]')
+    other_radio_button = page.locator('xpath=//input[@value="other"]')
+    add_service_button = page.get_by_role(
+        'button',
+        name=re.compile('Add service')
+    )
+
+    expect(service_name_input).to_be_visible()
+    expect(federal_radio_button).to_be_visible()
+    expect(state_radio_button).to_be_visible()
+    expect(other_radio_button).to_be_visible()
+    expect(add_service_button).to_be_visible()
+
+    # Fill in the form.
+    service_name_input.fill(new_service_name)
+    federal_radio_button.click()
+
+    # Click on add service.
+    add_service_button.click()
+
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('domcontentloaded')
+
+    # Check for the service name title and heading.
+    service_heading = page.get_by_text(new_service_name)
+    expect(service_heading).to_be_visible()
+    expect(page).to_have_title(re.compile(new_service_name))

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -1,0 +1,29 @@
+import os
+import re
+
+from playwright.sync_api import expect
+
+
+def test_accounts_page(end_to_end_authenticated_context):
+    # Open a new page and go to the staging site.
+    page = end_to_end_authenticated_context.new_page()
+
+    accounts_uri = '{}accounts'.format(os.getenv('NOTIFY_E2E_TEST_URI'))
+
+    page.goto(accounts_uri)
+
+    # Check to make sure that we've arrived at the next page.
+    # Check the page title exists and matches what we expect.
+    expect(page).to_have_title(re.compile('Choose service'))
+
+    # Check for the sign in heading.
+    sign_in_heading = page.get_by_role('heading', name='Choose service')
+    expect(sign_in_heading).to_be_visible()
+
+    # Retrieve some prominent elements on the page for testing.
+    add_service_button = page.get_by_role(
+        'button',
+        name=re.compile('Add a new service')
+    )
+
+    expect(add_service_button).to_be_visible()

--- a/tests/end_to_end/test_landing_and_sign_in_pages.py
+++ b/tests/end_to_end/test_landing_and_sign_in_pages.py
@@ -2,7 +2,6 @@ import os
 import re
 
 import pyotp
-
 from playwright.sync_api import expect
 
 

--- a/tests/end_to_end/test_landing_and_sign_in_pages.py
+++ b/tests/end_to_end/test_landing_and_sign_in_pages.py
@@ -180,6 +180,10 @@ def test_sign_in_and_mfa_pages(end_to_end_context):
     # Check to make sure that we've arrived at the next page.
     page.wait_for_load_state('domcontentloaded')
 
+    # Check that no MFA code error happened.
+    code_not_found_error = page.get_by_text('Code not found')
+    expect(code_not_found_error).to_have_count(0)
+
     # Check the page title exists and matches what we expect.
     # This could be either the Dashboard of a service if there is only
     # one, or choosing a service if there are multiple.

--- a/tests/end_to_end/test_landing_and_sign_in_pages.py
+++ b/tests/end_to_end/test_landing_and_sign_in_pages.py
@@ -12,7 +12,7 @@ def test_landing_page(end_to_end_context):
     page.goto(os.getenv('NOTIFY_E2E_TEST_URI'))
 
     # Check to make sure that we've arrived at the next page.
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Check the page title exists and matches what we expect.
     expect(page).to_have_title(re.compile('Notify.gov'))
@@ -66,7 +66,7 @@ def test_sign_in_and_mfa_pages(end_to_end_context):
     sign_in_button.click()
 
     # Check to make sure that we've arrived at the next page.
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Check the page title exists and matches what we expect.
     expect(page).to_have_title(re.compile('Sign in'))
@@ -121,7 +121,7 @@ def test_sign_in_and_mfa_pages(end_to_end_context):
     continue_button.click()
 
     # Wait for the next page to fully load.
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Check the page title exists and matches what we expect.
     expect(page).to_have_title(re.compile('Check your phone'))
@@ -179,10 +179,9 @@ def test_sign_in_and_mfa_pages(end_to_end_context):
     continue_button.click()
 
     # Check to make sure that we've arrived at the next page.
-    page.wait_for_load_state('networkidle')
+    page.wait_for_load_state('domcontentloaded')
 
     # Check the page title exists and matches what we expect.
-    expect(page).to_have_title(re.compile('Dashboard'))
-
-    # Save storage state into the file.
-    end_to_end_context.storage_state(path='state.json')
+    # This could be either the Dashboard of a service if there is only
+    # one, or choosing a service if there are multiple.
+    expect(page).to_have_title(re.compile('Dashboard|Choose service'))

--- a/tests/end_to_end/test_landing_and_sign_in_pages.py
+++ b/tests/end_to_end/test_landing_and_sign_in_pages.py
@@ -1,13 +1,18 @@
 import os
 import re
 
+import pyotp
+
 from playwright.sync_api import expect
 
 
-def test_landing_page(end_to_end_auth_context):
+def test_landing_page(end_to_end_context):
     # Open a new page and go to the staging site.
-    page = end_to_end_auth_context.new_page()
-    page.goto(os.environ.get('NOTIFY_STAGING_URI'))
+    page = end_to_end_context.new_page()
+    page.goto(os.getenv('NOTIFY_E2E_TEST_URI'))
+
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('networkidle')
 
     # Check the page title exists and matches what we expect.
     expect(page).to_have_title(re.compile('Notify.gov'))
@@ -50,22 +55,21 @@ def test_landing_page(end_to_end_auth_context):
         ).to_be_visible()
 
 
-def test_sign_in_page(end_to_end_auth_context):
+def test_sign_in_and_mfa_pages(end_to_end_context):
     # Open a new page and go to the staging site.
-    page = end_to_end_auth_context.new_page()
-    page.goto(os.environ.get('NOTIFY_STAGING_URI'))
+    page = end_to_end_context.new_page()
+    page.goto(os.getenv('NOTIFY_E2E_TEST_URI'))
 
     sign_in_button = page.get_by_role('link', name='Sign in')
 
     # Test trying to sign in.
     sign_in_button.click()
 
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('networkidle')
+
     # Check the page title exists and matches what we expect.
-    # NOTE:  The dash is a special character!  It had to be copied from
-    #        the template itself.
-    # TODO:  Improve this check, or change it so no special character is
-    #        needed.  Better yet, fix the template(s) character too.
-    expect(page).to_have_title(re.compile('Sign in – Notify.gov'))
+    expect(page).to_have_title(re.compile('Sign in'))
 
     # Check for the sign in heading.
     sign_in_heading = page.get_by_role('heading', name='Sign in')
@@ -81,7 +85,10 @@ def test_sign_in_page(end_to_end_auth_context):
     email_address_input = page.get_by_label('Email address')
     password_input = page.get_by_label('Password')
     csrf_token = page.locator('xpath=//input[@name="csrf_token"]')
-    continue_button = page.get_by_role('button', name=re.compile('Continue'))
+    continue_button = page.get_by_role(
+        'button',
+        name=re.compile('Continue')
+    )
     forgot_password_link = page.get_by_role(
         'link',
         name='Forgot your password?'
@@ -106,4 +113,76 @@ def test_sign_in_page(end_to_end_auth_context):
         '/forgot-password'
     )
 
-    # TODO:  Figure out how to actually sign in...
+    # Sign in to the site.
+    email_address_input.fill(
+        os.getenv('NOTIFY_E2E_TEST_EMAIL')
+    )
+    password_input.fill(os.getenv('NOTIFY_E2E_TEST_PASSWORD'))
+    continue_button.click()
+
+    # Wait for the next page to fully load.
+    page.wait_for_load_state('networkidle')
+
+    # Check the page title exists and matches what we expect.
+    expect(page).to_have_title(re.compile('Check your phone'))
+
+    # Check for the sign in heading.
+    sign_in_heading = page.get_by_role(
+        'heading',
+        name='Check your phone'
+    )
+    expect(sign_in_heading).to_be_visible()
+
+    # Check for the sign in form elements.
+    # NOTE:  Playwright cannot find input elements by role and recommends using
+    #        get_by_label() instead; however, hidden form elements do not have
+    #        labels associated with them, hence the XPath!
+    # See https://playwright.dev/python/docs/api/class-page#page-get-by-label
+    # and https://playwright.dev/python/docs/locators#locate-by-css-or-xpath
+    # for more information.
+    mfa_input = page.get_by_label('Text message code')
+    csrf_token = page.locator('xpath=//input[@name="csrf_token"]')
+    continue_button = page.get_by_role(
+        'button',
+        name=re.compile('Continue')
+    )
+    not_received_message_link = page.get_by_role(
+        'link',
+        name='Not received a text message?'
+    )
+
+    # Make sure form elements are visible and not visible as expected.
+    expect(mfa_input).to_be_visible()
+    expect(continue_button).to_be_visible()
+    expect(not_received_message_link).to_be_visible()
+
+    expect(csrf_token).to_be_hidden()
+
+    # Make sure form elements are configured correctly with the right
+    # attributes.
+    expect(mfa_input).to_have_attribute('type', 'tel')
+    expect(mfa_input).to_have_attribute('pattern', '[0-9]*')
+    expect(csrf_token).to_have_attribute('type', 'hidden')
+    expect(continue_button).to_have_attribute('type', 'submit')
+    expect(not_received_message_link).to_have_attribute(
+        'href',
+        '/text-not-received'
+    )
+
+    # Enter MFA code and continue.
+    totp = pyotp.TOTP(
+        os.getenv('MFA_TOTP_SECRET'),
+        digits=int(os.getenv('MFA_TOTP_LENGTH'))
+    )
+
+    mfa_input.fill(totp.now())
+    continue_button.click()
+
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state('networkidle')
+
+    # Check the page title exists and matches what we expect.
+    expect(page).to_have_title(re.compile('Dashboard'))
+
+    # Save storage state into the file.
+    end_to_end_context.storage_state(path='state.json')


### PR DESCRIPTION
Part of #676 

This changeset adds authentication support to our E2E tests so that we can fully test the Notify app.  There is updated documentation to explain how this is accomplished and managed, and the GitHub management side of this has already been taken care of.

## Security Considerations

- There is a considerable amount of environment variable management added; it's all documented in the PR.
- This relies on https://github.com/GSA/notifications-api/pull/431 for the update with how MFA codes are generated in the API when signing in; this is necessary in order to pragmatically simulate a user being able to login with MFA and authenticate.