### PR TITLE
Update cloud.gov org references

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: notify-demo
           push_arguments: >-
             --vars-file deploy-config/demo.yml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: notify-production
           push_arguments: >-
             --vars-file deploy-config/production.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: notify-staging
           push_arguments: >-
             --vars-file deploy-config/staging.yml

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -9,7 +9,7 @@ module "s3" {
   cf_api_url      = local.cf_api_url
   cf_user         = var.cf_user
   cf_password     = var.cf_password
-  cf_org_name     = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name     = "gsa-tts-benefits-studio"
   cf_space_name   = "notify-management"
   s3_service_name = local.s3_service_name
 }

--- a/terraform/create_service_account.sh
+++ b/terraform/create_service_account.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Create a Service User Account for a given space

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-demo"
   env              = "demo"
   app_name         = "notify-admin"

--- a/terraform/destroy_service_account.sh
+++ b/terraform/destroy_service_account.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Destroy a Service User Account in a given space

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-local-dev"
   recursive_delete = true
   key_name         = "${var.username}-admin-dev-key"

--- a/terraform/development/reset.sh
+++ b/terraform/development/reset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 username=`whoami`
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Reset terraform state so run.sh can be run again or for a new username

--- a/terraform/development/run.sh
+++ b/terraform/development/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 username=`whoami`
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Create development infrastructure

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-production"
   env              = "production"
   app_name         = "notify-admin"
@@ -45,7 +45,7 @@ module "api_network_route" {
 # It can be re-enabled after:
 # 1) the app has first been deployed
 # 2) the route has been manually created by an OrgManager:
-#     `cf create-domain gsa-tts-benefits-studio-prototyping beta.notify.gov`
+#     `cf create-domain gsa-tts-benefits-studio beta.notify.gov`
 # 3) the acme-challenge CNAME record must be created
 #       https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service
 ###########################################################################

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-sandbox"
   env              = "sandbox"
   app_name         = "notify-admin"

--- a/terraform/set_space_egress.sh
+++ b/terraform/set_space_egress.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Set egress rules for given space

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-staging"
   env              = "staging"
   app_name         = "notify-admin"


### PR DESCRIPTION
Part of https://github.com/GSA/notifications-api/issues/439

This changeset adjusts our references to the cloud.gov org we are using from gsa-tts-benefits-studio-prototyping to gsa-tts-benefits-studio.

## Security Considerations

- None for this change.