### PR TITLE
Remove final metrics reference

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -5,7 +5,6 @@ import traceback
 
 import eventlet
 import gunicorn
-from gds_metrics.gunicorn import child_exit  # noqa
 
 workers = 5
 worker_class = "eventlet"


### PR DESCRIPTION
This changeset removes a leftover reference to the gds_metrics library, which was taken out previously.

## Security Considerations

- None with this change.