### PR TITLE
 Re-enable E2E GitHub action and get end-to-end tests working

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,8 +7,6 @@ permissions:
 
 env:
   NOTIFY_ENVIRONMENT: test
-  NEW_RELIC_CONFIG_FILE: newrelic.ini
-  NEW_RELIC_ENVIRONMENT: test
   FLASK_APP: application.py
   WERKZEUG_DEBUG_PIN: off
   REDIS_ENABLED: 0
@@ -119,8 +117,6 @@ jobs:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           ADMIN_CLIENT_USERNAME: notify-admin
           NOTIFY_ENVIRONMENT: e2etest
-          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-          NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
@@ -131,10 +127,6 @@ jobs:
         # Debugging for now to troubleshoot a connectivity issue to the local servers
         # run: curl --request GET --url "http://localhost:6012"
         env:
-          DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
-          ADMIN_CLIENT_USERNAME: notify-admin
           NOTIFY_ENVIRONMENT: e2etest
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
@@ -149,6 +141,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - name: Validate NewRelic config
         env:
+          NEW_RELIC_CONFIG_FILE: newrelic.ini
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           # Need to set a NEW_RELIC_ENVIRONMENT with monitor_mode: true
           NEW_RELIC_ENVIRONMENT: staging

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,9 +114,9 @@ jobs:
       - name: Run Admin server
         run: make run-flask &
       - name: Run E2E tests
-        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers
-        run: curl --request GET --url "http://localhost:6012"
+        # run: curl --request GET --url "http://localhost:6012"
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,69 +47,69 @@ jobs:
       - name: Check coverage threshold
         run: poetry run coverage report --fail-under=90
 
-  # end-to-end-tests:
-  #   permissions:
-  #     checks: write
-  #     pull-requests: write
-  #     contents: write
-  #   runs-on: ubuntu-latest
-  #   services:
-  #     postgres:
-  #       image: postgres
-  #       env:
-  #         POSTGRES_USER: user
-  #         POSTGRES_PASSWORD: password
-  #         POSTGRES_DB: test_notification_api
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #       ports:
-  #         # Maps tcp port 5432 on service container to the host
-  #         - 5432:5432
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: ./.github/actions/setup-project
-  #     - uses: jwalton/gh-find-current-pr@v1
-  #       id: findPr
-  #     - uses: ArtiomTr/jest-coverage-report-action@v2
-  #       with:
-  #         test-script: npm test
-  #         output: report-markdown
-  #         annotations: failed-tests
-  #         prnumber: ${{ steps.findPr.outputs.number }}
-  #     - name: Clone API
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: GSA/notifications-api
-  #         path: './notifications-api'
-  #     - name: Install API dependencies
-  #       with:
-  #         path: './notifications-api'
-  #       run: make bootstrap
-  #       env:
-  #         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-  #         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-  #         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-  #     - name: Run API server
-  #       with:
-  #         path: './notifications-api'
-  #       run: make run-procfile &
-  #       env:
-  #         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-  #         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-  #         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-  #     - name: Run E2E tests
-  #       run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
-  #       env:
-  #         NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
-  #         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-  #         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-  #         NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
-  #         API_HOST_NAME: http://localhost:6011
-  #     - name: Check coverage threshold
-  #       run: poetry run coverage report --fail-under=90
+  end-to-end-tests:
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test_notification_api
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-project
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          test-script: npm test
+          output: report-markdown
+          annotations: failed-tests
+          prnumber: ${{ steps.findPr.outputs.number }}
+      - name: Clone API
+        uses: actions/checkout@v3
+        with:
+          repository: GSA/notifications-api
+          path: './notifications-api'
+      - name: Install API dependencies
+        with:
+          path: './notifications-api'
+        run: make bootstrap
+        env:
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      - name: Run API server
+        with:
+          path: './notifications-api'
+        run: make run-procfile &
+        env:
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      - name: Run E2E tests
+        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        env:
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
+          API_HOST_NAME: http://localhost:6011
+      - name: Check coverage threshold
+        run: poetry run coverage report --fail-under=90
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,6 @@ env:
   NODE_VERSION: 16.15.1
   AWS_US_TOLL_FREE_NUMBER: "+18556438890"
   ADMIN_BASE_URL: http://localhost:6012
-  API_HOST_NAME: https://notify-api-staging.app.cloud.gov
 
 jobs:
   build:
@@ -114,10 +113,11 @@ jobs:
       - name: Run Admin server
         run: make run-flask &
         env:
-          ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
-          ADMIN_CLIENT_USERNAME: notify-admin
+          API_HOST_NAME: https://notify-api-staging.app.cloud.gov
           DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
+          ADMIN_CLIENT_USERNAME: notify-admin
           NOTIFY_ENVIRONMENT: staging
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Run Admin server
         run: make run-flask &
         env:
+          ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
+          ADMIN_CLIENT_USERNAME: ${{ secrets.ADMIN_CLIENT_USERNAME }}
           NOTIFY_ENVIRONMENT: development
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,69 +47,69 @@ jobs:
       - name: Check coverage threshold
         run: poetry run coverage report --fail-under=90
 
-  end-to-end-tests:
-    permissions:
-      checks: write
-      pull-requests: write
-      contents: write
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: test_notification_api
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-project
-      - uses: jwalton/gh-find-current-pr@v1
-        id: findPr
-      - uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          test-script: npm test
-          output: report-markdown
-          annotations: failed-tests
-          prnumber: ${{ steps.findPr.outputs.number }}
-      - name: Clone API
-        uses: actions/checkout@v3
-        with:
-          repository: GSA/notifications-api
-          path: './notifications-api'
-      - name: Install API dependencies
-        with:
-          path: './notifications-api'
-        run: make bootstrap
-        env:
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      - name: Run API server
-        with:
-          path: './notifications-api'
-        run: make run-procfile &
-        env:
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      - name: Run E2E tests
-        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
-        env:
-          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
-          API_HOST_NAME: http://localhost:6011
-      - name: Check coverage threshold
-        run: poetry run coverage report --fail-under=90
+  # end-to-end-tests:
+  #   permissions:
+  #     checks: write
+  #     pull-requests: write
+  #     contents: write
+  #   runs-on: ubuntu-latest
+  #   services:
+  #     postgres:
+  #       image: postgres
+  #       env:
+  #         POSTGRES_USER: user
+  #         POSTGRES_PASSWORD: password
+  #         POSTGRES_DB: test_notification_api
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #       ports:
+  #         # Maps tcp port 5432 on service container to the host
+  #         - 5432:5432
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: ./.github/actions/setup-project
+  #     - uses: jwalton/gh-find-current-pr@v1
+  #       id: findPr
+  #     - uses: ArtiomTr/jest-coverage-report-action@v2
+  #       with:
+  #         test-script: npm test
+  #         output: report-markdown
+  #         annotations: failed-tests
+  #         prnumber: ${{ steps.findPr.outputs.number }}
+  #     - name: Clone API
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: GSA/notifications-api
+  #         path: './notifications-api'
+  #     - name: Install API dependencies
+  #       with:
+  #         path: './notifications-api'
+  #       run: make bootstrap
+  #       env:
+  #         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+  #         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+  #         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+  #     - name: Run API server
+  #       with:
+  #         path: './notifications-api'
+  #       run: make run-procfile &
+  #       env:
+  #         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+  #         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+  #         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+  #     - name: Run E2E tests
+  #       run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+  #       env:
+  #         NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+  #         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+  #         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+  #         NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
+  #         API_HOST_NAME: http://localhost:6011
+  #     - name: Check coverage threshold
+  #       run: poetry run coverage report --fail-under=90
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
-          POSTGRES_DB: test_notification_api
+          POSTGRES_DB: notification_api
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -85,16 +85,16 @@ jobs:
         working-directory: 'notifications-api'
         run: make bootstrap
         env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          DATABASE_URL: postgresql://user:password@localhost:5432/notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run API server
         working-directory: 'notifications-api'
         run: make run-flask &
         env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          DATABASE_URL: postgresql://user:password@localhost:5432/notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run Admin server

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -85,6 +85,7 @@ jobs:
         working-directory: 'notifications-api'
         run: make bootstrap
         env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
@@ -92,6 +93,7 @@ jobs:
         working-directory: 'notifications-api'
         run: make run-flask &
         env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -124,7 +124,9 @@ jobs:
           NOTIFY_E2E_TEST_URI: http://localhost:6012
       - name: Run E2E tests
         # Run the E2E tests against the code found in this PR.
-        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        # --browser webkit doesn't work at this time.
+        run: poetry run pytest -v --browser chromium --browser firefox tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers
         # run: curl --request GET --url "http://localhost:6012"
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,6 +119,7 @@ jobs:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_E2E_TEST_URI: http://localhost:6012
       - name: Run E2E tests
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,7 +97,7 @@ jobs:
           REDIS_URL: redis://localhost:6379
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_ENVIRONMENT: staging
+          NOTIFY_ENVIRONMENT: development
       - name: Run API server
         working-directory: 'notifications-api'
         run: make run-procfile &
@@ -107,7 +107,7 @@ jobs:
           REDIS_URL: redis://localhost:6379
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_ENVIRONMENT: staging
+          NOTIFY_ENVIRONMENT: development
       - name: Run Admin server
         run: make run-flask &
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -125,7 +125,7 @@ jobs:
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           # Run the E2E tests against the code found in this PR.
-          NOTIFY_E2E_TEST_URI: http://localhost:6012/
+          NOTIFY_E2E_TEST_URI: http://localhost:6012
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,6 +100,7 @@ jobs:
           REDIS_URL: redis://localhost:6379
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_ENVIRONMENT: development
       - name: Run API server
         working-directory: 'notifications-api'
         run: make run-procfile &
@@ -109,6 +110,7 @@ jobs:
           REDIS_URL: redis://localhost:6379
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_ENVIRONMENT: development
       - name: Run Admin server
         run: make run-flask &
       - name: Run E2E tests

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -125,7 +125,7 @@ jobs:
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           # Run the E2E tests against the code found in this PR.
-          NOTIFY_E2E_TEST_URI: http://localhost:6012
+          NOTIFY_E2E_TEST_URI: http://localhost:6012/
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,33 +73,27 @@ jobs:
       - uses: ./.github/actions/setup-project
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-      - uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          test-script: npm test
-          output: report-markdown
-          annotations: failed-tests
-          prnumber: ${{ steps.findPr.outputs.number }}
-      - name: Clone API
-        uses: actions/checkout@v3
-        with:
-          repository: GSA/notifications-api
-          path: './notifications-api'
-      - name: Install API dependencies
-        with:
-          path: './notifications-api'
-        run: make bootstrap
-        env:
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      - name: Run API server
-        with:
-          path: './notifications-api'
-        run: make run-procfile &
-        env:
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      # - name: Clone API
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: GSA/notifications-api
+      #     path: './notifications-api'
+      # - name: Install API dependencies
+      #   with:
+      #     path: './notifications-api'
+      #   run: make bootstrap
+      #   env:
+      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      # - name: Run API server
+      #   with:
+      #     path: './notifications-api'
+      #   run: make run-procfile &
+      #   env:
+      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run E2E tests
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         env:
@@ -107,7 +101,7 @@ jobs:
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
-          API_HOST_NAME: http://localhost:6011
+          # API_HOST_NAME: http://localhost:6011
       - name: Check coverage threshold
         run: poetry run coverage report --fail-under=90
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,10 +77,9 @@ jobs:
         uses: actions/checkout@v3
         with:
          repository: GSA/notifications-api
-         path: './notifications-api'
+         path: 'notifications-api'
       - name: Install API dependencies
-        with:
-          path: './notifications-api'
+        working-directory: 'notifications-api'
         run: make bootstrap
         env:
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,10 +97,19 @@ jobs:
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run Admin server
         run: make run-flask &
-      - name: Run E2E tests
+      - name: Run E2E tests 1
         # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
-        run: |
+        run:
           curl --request GET --url "http://localhost:6012"
+        env:
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          # Run the E2E tests against the code found in this PR.
+          NOTIFY_E2E_TEST_URI: http://localhost:6012
+      - name: Run E2E tests 2
+        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        run:
           curl --request GET --url "http://127.0.0.1:6012"
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,6 +114,8 @@ jobs:
       #     NOTIFY_ENVIRONMENT: development
       - name: Run Admin server
         run: make run-flask &
+        env:
+          NOTIFY_ENVIRONMENT: development
       - name: Run E2E tests
         # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,9 @@ env:
   WERKZEUG_DEBUG_PIN: off
   REDIS_ENABLED: 0
   NODE_VERSION: 16.15.1
+  AWS_US_TOLL_FREE_NUMBER: "+18556438890"
+  ADMIN_BASE_URL: http://localhost:6012
+  API_HOST_NAME: http://localhost:6011
 
 jobs:
   build:
@@ -85,14 +88,13 @@ jobs:
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      # - name: Run API server
-      #   with:
-      #     path: './notifications-api'
-      #   run: make run-procfile &
-      #   env:
-      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      - name: Run API server
+        working-directory: 'notifications-api'
+        run: make run-flask &
+        env:
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run E2E tests
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         env:
@@ -100,7 +102,6 @@ jobs:
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
-          # API_HOST_NAME: http://localhost:6011
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,11 +73,11 @@ jobs:
       - uses: ./.github/actions/setup-project
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-      # - name: Clone API
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: GSA/notifications-api
-      #     path: './notifications-api'
+      - name: Clone API
+        uses: actions/checkout@v3
+        with:
+         repository: GSA/notifications-api
+         path: './notifications-api'
       # - name: Install API dependencies
       #   with:
       #     path: './notifications-api'
@@ -102,8 +102,6 @@ jobs:
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
           # API_HOST_NAME: http://localhost:6011
-      - name: Check coverage threshold
-        run: poetry run coverage report --fail-under=90
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,8 @@ env:
   NODE_VERSION: 16.15.1
   AWS_US_TOLL_FREE_NUMBER: "+18556438890"
   ADMIN_BASE_URL: http://localhost:6012
-  API_HOST_NAME: http://localhost:6011
+  #API_HOST_NAME: http://localhost:6011
+  API_HOST_NAME: https://notify-api-staging.app.cloud.gov
 
 jobs:
   build:
@@ -56,67 +57,67 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: test_notification_api
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-      redis:
-        image: redis
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 6379 on service container to the host
-          - 6379:6379
+    # services:
+    #   postgres:
+    #     image: postgres
+    #     env:
+    #       POSTGRES_USER: user
+    #       POSTGRES_PASSWORD: password
+    #       POSTGRES_DB: test_notification_api
+    #     options: >-
+    #       --health-cmd pg_isready
+    #       --health-interval 10s
+    #       --health-timeout 5s
+    #       --health-retries 5
+    #     ports:
+    #       # Maps tcp port 5432 on service container to the host
+    #       - 5432:5432
+    #   redis:
+    #     image: redis
+    #     options: >-
+    #       --health-cmd "redis-cli ping"
+    #       --health-interval 10s
+    #       --health-timeout 5s
+    #       --health-retries 5
+    #     ports:
+    #       # Maps tcp port 6379 on service container to the host
+    #       - 6379:6379
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-      - name: Clone API
-        uses: actions/checkout@v3
-        with:
-         repository: GSA/notifications-api
-         path: 'notifications-api'
-      - name: Install API dependencies
-        working-directory: 'notifications-api'
-        run: make bootstrap
-        env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          REDIS_URL: redis://localhost:6379
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_ENVIRONMENT: development
-      - name: Run API server
-        working-directory: 'notifications-api'
-        run: make run-procfile &
-        env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          REDIS_URL: redis://localhost:6379
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_ENVIRONMENT: development
+      # - name: Clone API
+      #   uses: actions/checkout@v3
+      #   with:
+      #    repository: GSA/notifications-api
+      #    path: 'notifications-api'
+      # - name: Install API dependencies
+      #   working-directory: 'notifications-api'
+      #   run: make bootstrap
+      #   env:
+      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+      #     REDIS_URL: redis://localhost:6379
+      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      #     NOTIFY_ENVIRONMENT: development
+      # - name: Run API server
+      #   working-directory: 'notifications-api'
+      #   run: make run-procfile &
+      #   env:
+      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+      #     REDIS_URL: redis://localhost:6379
+      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      #     NOTIFY_ENVIRONMENT: development
       - name: Run Admin server
         run: make run-flask &
       - name: Run E2E tests
-        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers
-        # run: curl --request GET --url "http://localhost:6012"
+        run: curl --request GET --url "http://localhost:6012"
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,6 +131,11 @@ jobs:
         # Debugging for now to troubleshoot a connectivity issue to the local servers
         # run: curl --request GET --url "http://localhost:6012"
         env:
+          DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
+          ADMIN_CLIENT_USERNAME: notify-admin
+          NOTIFY_ENVIRONMENT: e2etest
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,8 +15,7 @@ env:
   NODE_VERSION: 16.15.1
   AWS_US_TOLL_FREE_NUMBER: "+18556438890"
   ADMIN_BASE_URL: http://localhost:6012
-  #API_HOST_NAME: http://localhost:6011
-  API_HOST_NAME: https://notify-api-staging.app.cloud.gov
+  API_HOST_NAME: http://localhost:6011
 
 jobs:
   build:
@@ -57,61 +56,61 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    # services:
-    #   postgres:
-    #     image: postgres
-    #     env:
-    #       POSTGRES_USER: user
-    #       POSTGRES_PASSWORD: password
-    #       POSTGRES_DB: test_notification_api
-    #     options: >-
-    #       --health-cmd pg_isready
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-    #     ports:
-    #       # Maps tcp port 5432 on service container to the host
-    #       - 5432:5432
-    #   redis:
-    #     image: redis
-    #     options: >-
-    #       --health-cmd "redis-cli ping"
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-    #     ports:
-    #       # Maps tcp port 6379 on service container to the host
-    #       - 6379:6379
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test_notification_api
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 6379 on service container to the host
+          - 6379:6379
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-      # - name: Clone API
-      #   uses: actions/checkout@v3
-      #   with:
-      #    repository: GSA/notifications-api
-      #    path: 'notifications-api'
-      # - name: Install API dependencies
-      #   working-directory: 'notifications-api'
-      #   run: make bootstrap
-      #   env:
-      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-      #     REDIS_URL: redis://localhost:6379
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      #     NOTIFY_ENVIRONMENT: development
-      # - name: Run API server
-      #   working-directory: 'notifications-api'
-      #   run: make run-procfile &
-      #   env:
-      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-      #     REDIS_URL: redis://localhost:6379
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      #     NOTIFY_ENVIRONMENT: development
+      - name: Clone API
+        uses: actions/checkout@v3
+        with:
+         repository: GSA/notifications-api
+         path: 'notifications-api'
+      - name: Install API dependencies
+        working-directory: 'notifications-api'
+        run: make bootstrap
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          REDIS_URL: redis://localhost:6379
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_ENVIRONMENT: development
+      - name: Run API server
+        working-directory: 'notifications-api'
+        run: make run-procfile &
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          REDIS_URL: redis://localhost:6379
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_ENVIRONMENT: development
       - name: Run Admin server
         run: make run-flask &
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,13 +95,16 @@ jobs:
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      - name: Run Admin server
+        run: make run-flask &
       - name: Run E2E tests
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
+          # Run the E2E tests against the code found in this PR.
+          NOTIFY_E2E_TEST_URI: http://localhost:6012
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -115,10 +115,10 @@ jobs:
         run: make run-flask &
         env:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
-          ADMIN_CLIENT_USERNAME: ${{ secrets.ADMIN_CLIENT_USERNAME }}
+          ADMIN_CLIENT_USERNAME: notify-admin
           DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          NOTIFY_ENVIRONMENT: development
+          NOTIFY_ENVIRONMENT: staging
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,14 +78,14 @@ jobs:
         with:
          repository: GSA/notifications-api
          path: './notifications-api'
-      # - name: Install API dependencies
-      #   with:
-      #     path: './notifications-api'
-      #   run: make bootstrap
-      #   env:
-      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      - name: Install API dependencies
+        with:
+          path: './notifications-api'
+        run: make bootstrap
+        env:
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       # - name: Run API server
       #   with:
       #     path: './notifications-api'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,10 @@ jobs:
       - name: Run Admin server
         run: make run-flask &
       - name: Run E2E tests
-        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        run: |
+          curl --request GET --url "http://localhost:6012"
+          curl --request GET --url "http://127.0.0.1:6012"
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,20 +97,10 @@ jobs:
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run Admin server
         run: make run-flask &
-      - name: Run E2E tests 1
+      - name: Run E2E tests
         # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
-        run:
-          curl --request GET --url "http://localhost:6012"
-        env:
-          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          # Run the E2E tests against the code found in this PR.
-          NOTIFY_E2E_TEST_URI: http://localhost:6012
-      - name: Run E2E tests 2
-        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
-        run:
-          curl --request GET --url "http://127.0.0.1:6012"
+        # Debugging for now to troubleshoot a connectivity issue to the local servers
+        run: curl --request GET --url "http://localhost:6012"
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,62 @@ jobs:
         run: npm test
       - name: Run py tests with coverage
         run: poetry run coverage run --omit=*/notifications_utils/* -m pytest --maxfail=10 --ignore=tests/end_to_end tests/
+      - name: Check coverage threshold
+        run: poetry run coverage report --fail-under=90
+
+  end-to-end-tests:
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test_notification_api
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-project
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          test-script: npm test
+          output: report-markdown
+          annotations: failed-tests
+          prnumber: ${{ steps.findPr.outputs.number }}
+      - name: Clone API
+        uses: actions/checkout@v3
+        with:
+          repository: GSA/notifications-api
+          path: './notifications-api'
+      - name: Install API dependencies
+        with:
+          path: './notifications-api'
+        run: make bootstrap
+        env:
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      - name: Run API server
+        with:
+          path: './notifications-api'
+        run: make run-procfile &
+        env:
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run E2E tests
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         env:
@@ -51,22 +107,9 @@ jobs:
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
+          API_HOST_NAME: http://localhost:6011
       - name: Check coverage threshold
         run: poetry run coverage report --fail-under=90
-      - name: Health check
-        run: |
-          response=$(curl -url ${{secrets.NOTIFY_E2E_TEST_URI}}_status)
-          if grep -q "ok" <<< "$response"; then
-            echo "Health check passed"
-          else
-            echo "Health check failed"
-            exit 1
-          fi
-        env:
-          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,6 +119,8 @@ jobs:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           ADMIN_CLIENT_USERNAME: notify-admin
           NOTIFY_ENVIRONMENT: staging
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+          NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ env:
   NODE_VERSION: 16.15.1
   AWS_US_TOLL_FREE_NUMBER: "+18556438890"
   ADMIN_BASE_URL: http://localhost:6012
-  API_HOST_NAME: http://localhost:6011
+  API_HOST_NAME: https://notify-api-staging.app.cloud.gov
 
 jobs:
   build:
@@ -56,61 +56,61 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: test_notification_api
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-      redis:
-        image: redis
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 6379 on service container to the host
-          - 6379:6379
+    # services:
+    #   postgres:
+    #     image: postgres
+    #     env:
+    #       POSTGRES_USER: user
+    #       POSTGRES_PASSWORD: password
+    #       POSTGRES_DB: test_notification_api
+    #     options: >-
+    #       --health-cmd pg_isready
+    #       --health-interval 10s
+    #       --health-timeout 5s
+    #       --health-retries 5
+    #     ports:
+    #       # Maps tcp port 5432 on service container to the host
+    #       - 5432:5432
+    #   redis:
+    #     image: redis
+    #     options: >-
+    #       --health-cmd "redis-cli ping"
+    #       --health-interval 10s
+    #       --health-timeout 5s
+    #       --health-retries 5
+    #     ports:
+    #       # Maps tcp port 6379 on service container to the host
+    #       - 6379:6379
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-      - name: Clone API
-        uses: actions/checkout@v3
-        with:
-         repository: GSA/notifications-api
-         path: 'notifications-api'
-      - name: Install API dependencies
-        working-directory: 'notifications-api'
-        run: make bootstrap
-        env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          REDIS_URL: redis://localhost:6379
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_ENVIRONMENT: development
-      - name: Run API server
-        working-directory: 'notifications-api'
-        run: make run-procfile &
-        env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-          REDIS_URL: redis://localhost:6379
-          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          NOTIFY_ENVIRONMENT: development
+      # - name: Clone API
+      #   uses: actions/checkout@v3
+      #   with:
+      #    repository: GSA/notifications-api
+      #    path: 'notifications-api'
+      # - name: Install API dependencies
+      #   working-directory: 'notifications-api'
+      #   run: make bootstrap
+      #   env:
+      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+      #     REDIS_URL: redis://localhost:6379
+      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      #     NOTIFY_ENVIRONMENT: development
+      # - name: Run API server
+      #   working-directory: 'notifications-api'
+      #   run: make run-procfile &
+      #   env:
+      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+      #     REDIS_URL: redis://localhost:6379
+      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+      #     NOTIFY_ENVIRONMENT: development
       - name: Run Admin server
         run: make run-flask &
         env:
@@ -120,6 +120,7 @@ jobs:
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
           NOTIFY_E2E_TEST_URI: http://localhost:6012
       - name: Run E2E tests
+        # Run the E2E tests against the code found in this PR.
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers
         # run: curl --request GET --url "http://localhost:6012"
@@ -127,7 +128,6 @@ jobs:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-          # Run the E2E tests against the code found in this PR.
           NOTIFY_E2E_TEST_URI: http://localhost:6012
 
   validate-new-relic-config:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,65 +53,66 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    # services:
-    #   postgres:
-    #     image: postgres
-    #     env:
-    #       POSTGRES_USER: user
-    #       POSTGRES_PASSWORD: password
-    #       POSTGRES_DB: test_notification_api
-    #     options: >-
-    #       --health-cmd pg_isready
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-    #     ports:
-    #       # Maps tcp port 5432 on service container to the host
-    #       - 5432:5432
-    #   redis:
-    #     image: redis
-    #     options: >-
-    #       --health-cmd "redis-cli ping"
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-    #     ports:
-    #       # Maps tcp port 6379 on service container to the host
-    #       - 6379:6379
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test_notification_api
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 6379 on service container to the host
+          - 6379:6379
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-      # - name: Clone API
-      #   uses: actions/checkout@v3
-      #   with:
-      #    repository: GSA/notifications-api
-      #    path: 'notifications-api'
-      # - name: Install API dependencies
-      #   working-directory: 'notifications-api'
-      #   run: make bootstrap
-      #   env:
-      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-      #     REDIS_URL: redis://localhost:6379
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      #     NOTIFY_ENVIRONMENT: development
-      # - name: Run API server
-      #   working-directory: 'notifications-api'
-      #   run: make run-procfile &
-      #   env:
-      #     DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
-      #     SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
-      #     REDIS_URL: redis://localhost:6379
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      #     NOTIFY_ENVIRONMENT: development
+      - name: Clone API
+        uses: actions/checkout@v3
+        with:
+         repository: GSA/notifications-api
+         path: 'notifications-api'
+      - name: Install API dependencies
+        working-directory: 'notifications-api'
+        run: make bootstrap
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          REDIS_URL: redis://localhost:6379
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_ENVIRONMENT: staging
+      - name: Run API server
+        working-directory: 'notifications-api'
+        run: make run-procfile &
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          REDIS_URL: redis://localhost:6379
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_ENVIRONMENT: staging
       - name: Run Admin server
         run: make run-flask &
         env:
-          API_HOST_NAME: https://notify-api-staging.app.cloud.gov
+          # API_HOST_NAME: https://notify-api-staging.app.cloud.gov
+          API_HOST_NAME: http://localhost:6011
           DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,6 +116,9 @@ jobs:
         run: make run-flask &
         env:
           NOTIFY_ENVIRONMENT: development
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run E2E tests
         run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -117,9 +117,9 @@ jobs:
         env:
           NOTIFY_ENVIRONMENT: development
       - name: Run E2E tests
-        # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # Debugging for now to troubleshoot a connectivity issue to the local servers
-        run: curl --request GET --url "http://localhost:6012"
+        # run: curl --request GET --url "http://localhost:6012"
         env:
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,7 +118,7 @@ jobs:
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           ADMIN_CLIENT_USERNAME: notify-admin
-          NOTIFY_ENVIRONMENT: staging
+          NOTIFY_ENVIRONMENT: e2etest
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
-          POSTGRES_DB: notification_api
+          POSTGRES_DB: test_notification_api
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -85,16 +85,16 @@ jobs:
         working-directory: 'notifications-api'
         run: make bootstrap
         env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/notification_api
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run API server
         working-directory: 'notifications-api'
         run: make run-flask &
         env:
-          DATABASE_URL: postgresql://user:password@localhost:5432/notification_api
-          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/notification_api
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
+          SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run Admin server

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,29 +44,29 @@ jobs:
         run: npm test
       - name: Run py tests with coverage
         run: poetry run coverage run --omit=*/notifications_utils/* -m pytest --maxfail=10 --ignore=tests/end_to_end tests/
-      # - name: Run E2E tests
-      #   run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
-      #   env:
-      #     NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      #     NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
+      - name: Run E2E tests
+        run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+        env:
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
       - name: Check coverage threshold
         run: poetry run coverage report --fail-under=90
-      # - name: Health check
-      #   run: |
-      #     response=$(curl -url ${{secrets.NOTIFY_E2E_TEST_URI}}_status)
-      #     if grep -q "ok" <<< "$response"; then
-      #       echo "Health check passed"
-      #     else
-      #       echo "Health check failed"
-      #       exit 1
-      #     fi
-      #   env:
-      #     NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
-      #     NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
-      #     NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-      #     NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
+      - name: Health check
+        run: |
+          response=$(curl -url ${{secrets.NOTIFY_E2E_TEST_URI}}_status)
+          if grep -q "ok" <<< "$response"; then
+            echo "Health check passed"
+          else
+            echo "Health check failed"
+            exit 1
+          fi
+        env:
+          NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
+          NOTIFY_E2E_TEST_URI: ${{ secrets.NOTIFY_E2E_TEST_URI }}
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,6 +116,8 @@ jobs:
         env:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           ADMIN_CLIENT_USERNAME: ${{ secrets.ADMIN_CLIENT_USERNAME }}
+          DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
           NOTIFY_ENVIRONMENT: development
           NOTIFY_E2E_AUTH_STATE_PATH: ${{ secrets.NOTIFY_E2E_AUTH_STATE_PATH }}
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,7 +126,7 @@ jobs:
         # Run the E2E tests against the code found in this PR.
         # run: poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
         # --browser webkit doesn't work at this time.
-        run: poetry run pytest -v --browser chromium --browser firefox tests/end_to_end
+        run: make e2e-test
         # Debugging for now to troubleshoot a connectivity issue to the local servers
         # run: curl --request GET --url "http://localhost:6012"
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,6 +71,16 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 6379 on service container to the host
+          - 6379:6379
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
@@ -87,14 +97,16 @@ jobs:
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          REDIS_URL: redis://localhost:6379
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run API server
         working-directory: 'notifications-api'
-        run: make run-flask &
+        run: make run-procfile &
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/test_notification_api
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          REDIS_URL: redis://localhost:6379
           NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
           NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run Admin server

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ dead-code:
 
 .PHONY: e2e-test
 e2e-test: export NEW_RELIC_ENVIRONMENT=test
-e2e-test: ## Run end-to-end integration tests
-	poetry run pytest -v --browser chromium --browser firefox --browser webkit tests/end_to_end
+e2e-test: ## Run end-to-end integration tests; note that --browser webkit isn't currently working
+	poetry run pytest -v --browser chromium --browser firefox tests/end_to_end
 
 .PHONY: js-lint
 js-lint: ## Run javascript linting scanners

--- a/app/config.py
+++ b/app/config.py
@@ -169,6 +169,14 @@ class E2ETest(Staging):
     TESTING = True
     WTF_CSRF_ENABLED = False
 
+    # buckets - mirror staging
+    CSV_UPLOAD_BUCKET = cloud_config.s3_credentials(
+        "notify-api-csv-upload-bucket-staging"
+    )
+    LOGO_UPLOAD_BUCKET = cloud_config.s3_credentials(
+        "notify-admin-logo-upload-bucket-staging"
+    )
+
 
 class Demo(Staging):
     HEADER_COLOUR = "#6F72AF"  # $mauve

--- a/app/config.py
+++ b/app/config.py
@@ -159,6 +159,7 @@ class E2ETest(Staging):
     """
 
     # Borrowed from development environment
+    DEBUG = True
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None
     HTTP_PROTOCOL = "http"

--- a/app/config.py
+++ b/app/config.py
@@ -81,8 +81,7 @@ class Config(object):
         "IBAN": "GB33BUKB20201555555555",
         "swift": "ABCDEF12",
         "notify_billing_email_addresses": [
-            "generic@digital.cabinet-office.gov.uk",
-            "first.last@digital.cabinet-office.gov.uk",
+            "tts-benefits-studio@gsa.gov",
         ],
     }
 
@@ -152,6 +151,25 @@ class Staging(Production):
     HEADER_COLOUR = "#00ff00"  # $green
 
 
+class E2ETest(Staging):
+    """
+    An environment config that is intended to operate as if it were in the
+    staging environment but with the configuration of the development and test
+    environments so the E2E tests work.
+    """
+
+    # Borrowed from development environment
+    SESSION_COOKIE_SECURE = False
+    SESSION_PROTECTION = None
+    HTTP_PROTOCOL = "http"
+    ASSET_DOMAIN = ""
+    ASSET_PATH = "/static/"
+
+    # Borrowed from test environment
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+
+
 class Demo(Staging):
     HEADER_COLOUR = "#6F72AF"  # $mauve
 
@@ -173,6 +191,7 @@ class Scanning(Production):
 configs = {
     "development": Development,
     "test": Test,
+    "e2etest": E2ETest,
     "scanning": Scanning,
     "staging": Staging,
     "demo": Demo,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import os
-import re
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from unittest.mock import Mock, PropertyMock
@@ -35,8 +34,6 @@ from . import (
 )
 
 load_dotenv()
-
-E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
 
 
 class ElementNotFound(Exception):
@@ -3519,88 +3516,6 @@ def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
         "app.org_invite_api_client.get_invited_user",
         side_effect=_get,
     )
-
-
-def login_for_end_to_end_testing(browser):
-    # Open a new page and go to the staging site.
-    context = browser.new_context()
-    page = context.new_page()
-    page.goto(f"{E2E_TEST_URI}/")
-
-    sign_in_button = page.get_by_role("link", name="Sign in")
-
-    # Test trying to sign in.
-    sign_in_button.click()
-
-    # Wait for the next page to fully load.
-    page.wait_for_load_state("domcontentloaded")
-
-    # Check for the sign in form elements.
-    # NOTE:  Playwright cannot find input elements by role and recommends using
-    #        get_by_label() instead; however, hidden form elements do not have
-    #        labels associated with them, hence the XPath!
-    # See https://playwright.dev/python/docs/api/class-page#page-get-by-label
-    # and https://playwright.dev/python/docs/locators#locate-by-css-or-xpath
-    # for more information.
-    email_address_input = page.get_by_label("Email address")
-    password_input = page.get_by_label("Password")
-    continue_button = page.get_by_role("button", name=re.compile("Continue"))
-
-    # Sign in to the site.
-    email_address_input.fill(os.getenv("NOTIFY_E2E_TEST_EMAIL"))
-    password_input.fill(os.getenv("NOTIFY_E2E_TEST_PASSWORD"))
-    continue_button.click()
-
-    # Wait for the next page to fully load.
-    page.wait_for_load_state("domcontentloaded")
-
-    # Check for the sign in form elements.
-    # NOTE:  Playwright cannot find input elements by role and recommends using
-    #        get_by_label() instead; however, hidden form elements do not have
-    #        labels associated with them, hence the XPath!
-    # See https://playwright.dev/python/docs/api/class-page#page-get-by-label
-    # and https://playwright.dev/python/docs/locators#locate-by-css-or-xpath
-    # for more information.
-    # mfa_input = page.get_by_label('Text message code')
-    # continue_button = page.get_by_role('button', name=re.compile('Continue'))
-
-    # # Enter MFA code and continue.
-    # TODO: Revisit this at a later point in time.
-    # totp = pyotp.TOTP(
-    #     os.getenv('MFA_TOTP_SECRET'),
-    #     digits=int(os.getenv('MFA_TOTP_LENGTH'))
-    # )
-
-    # mfa_input.fill(totp.now())
-    # continue_button.click()
-
-    # page.wait_for_load_state('domcontentloaded')
-
-    # Save storage state into the file.
-    auth_state_path = os.path.join(
-        os.getenv("NOTIFY_E2E_AUTH_STATE_PATH"), "state.json"
-    )
-    context.storage_state(path=auth_state_path)
-
-
-@pytest.fixture(scope="session")
-def end_to_end_context(browser):
-    context = browser.new_context()
-    return context
-
-
-@pytest.fixture(scope="session")
-def end_to_end_authenticated_context(browser):
-    # Create and load a previously authenticated context for Playwright E2E
-    # tests.
-    # login_for_end_to_end_testing(browser)
-
-    auth_state_path = os.path.join(
-        os.getenv("NOTIFY_E2E_AUTH_STATE_PATH"), "state.json"
-    )
-    context = browser.new_context(storage_state=auth_state_path)
-
-    return context
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3593,7 +3593,7 @@ def end_to_end_context(browser):
 def end_to_end_authenticated_context(browser):
     # Create and load a previously authenticated context for Playwright E2E
     # tests.
-    login_for_end_to_end_testing(browser)
+    # login_for_end_to_end_testing(browser)
 
     auth_state_path = os.path.join(
         os.getenv("NOTIFY_E2E_AUTH_STATE_PATH"), "state.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3576,12 +3576,11 @@ def login_for_end_to_end_testing(browser):
 
     # page.wait_for_load_state('domcontentloaded')
 
-    # # Save storage state into the file.
-    # auth_state_path = os.path.join(
-    #     os.getenv('NOTIFY_E2E_AUTH_STATE_PATH'),
-    #     'state.json'
-    # )
-    # context.storage_state(path=auth_state_path)
+    # Save storage state into the file.
+    auth_state_path = os.path.join(
+        os.getenv("NOTIFY_E2E_AUTH_STATE_PATH"), "state.json"
+    )
+    context.storage_state(path=auth_state_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,8 @@ from . import (
 
 load_dotenv()
 
+E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
+
 
 class ElementNotFound(Exception):
     pass
@@ -529,7 +531,7 @@ def mock_update_service(mocker):
                     "sms_sender",
                     "permissions",
                 ]
-            }
+            },
         )
         return {"data": service}
 
@@ -2353,7 +2355,7 @@ def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too com
             _test_page_title=True,
             _test_for_elements_without_class=True,
             _optional_args="",
-            **endpoint_kwargs
+            **endpoint_kwargs,
         ):
             return ClientRequest.get_url(
                 url_for(endpoint, **(endpoint_kwargs or {})) + _optional_args,
@@ -2372,7 +2374,7 @@ def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too com
             _expected_redirect=None,
             _test_page_title=True,
             _test_for_elements_without_class=True,
-            **endpoint_kwargs
+            **endpoint_kwargs,
         ):
             resp = logged_in_client.get(
                 url,
@@ -2414,7 +2416,7 @@ def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too com
             _follow_redirects=False,
             _expected_redirect=None,
             _content_type=None,
-            **endpoint_kwargs
+            **endpoint_kwargs,
         ):
             return ClientRequest.post_url(
                 url_for(endpoint, **(endpoint_kwargs or {})),
@@ -2473,7 +2475,7 @@ def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too com
             _expected_status=302,
             _optional_args="",
             _content_type=None,
-            **endpoint_kwargs
+            **endpoint_kwargs,
         ):
             return ClientRequest.post_response_from_url(
                 url_for(endpoint, **(endpoint_kwargs or {})) + _optional_args,
@@ -3523,7 +3525,7 @@ def login_for_end_to_end_testing(browser):
     # Open a new page and go to the staging site.
     context = browser.new_context()
     page = context.new_page()
-    page.goto(os.getenv("NOTIFY_E2E_TEST_URI"))
+    page.goto(f"{E2E_TEST_URI}/")
 
     sign_in_button = page.get_by_role("link", name="Sign in")
 

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -89,7 +89,7 @@ def end_to_end_authenticated_context(browser):
 
 
 @pytest.fixture(scope="session")
-def bypass_sign_in(end_to_end_context):
+def authenticated_page(end_to_end_context):
     # Open a new page and go to the staging site.
     page = end_to_end_context.new_page()
 

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -1,0 +1,105 @@
+import os
+import re
+
+import pytest
+
+E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
+
+
+def login_for_end_to_end_testing(browser):
+    # Open a new page and go to the staging site.
+    context = browser.new_context()
+    page = context.new_page()
+    page.goto(f"{E2E_TEST_URI}/")
+
+    sign_in_button = page.get_by_role("link", name="Sign in")
+
+    # Test trying to sign in.
+    sign_in_button.click()
+
+    # Wait for the next page to fully load.
+    page.wait_for_load_state("domcontentloaded")
+
+    # Check for the sign in form elements.
+    # NOTE:  Playwright cannot find input elements by role and recommends using
+    #        get_by_label() instead; however, hidden form elements do not have
+    #        labels associated with them, hence the XPath!
+    # See https://playwright.dev/python/docs/api/class-page#page-get-by-label
+    # and https://playwright.dev/python/docs/locators#locate-by-css-or-xpath
+    # for more information.
+    email_address_input = page.get_by_label("Email address")
+    password_input = page.get_by_label("Password")
+    continue_button = page.get_by_role("button", name=re.compile("Continue"))
+
+    # Sign in to the site.
+    email_address_input.fill(os.getenv("NOTIFY_E2E_TEST_EMAIL"))
+    password_input.fill(os.getenv("NOTIFY_E2E_TEST_PASSWORD"))
+    continue_button.click()
+
+    # Wait for the next page to fully load.
+    page.wait_for_load_state("domcontentloaded")
+
+    # Check for the sign in form elements.
+    # NOTE:  Playwright cannot find input elements by role and recommends using
+    #        get_by_label() instead; however, hidden form elements do not have
+    #        labels associated with them, hence the XPath!
+    # See https://playwright.dev/python/docs/api/class-page#page-get-by-label
+    # and https://playwright.dev/python/docs/locators#locate-by-css-or-xpath
+    # for more information.
+    # mfa_input = page.get_by_label('Text message code')
+    # continue_button = page.get_by_role('button', name=re.compile('Continue'))
+
+    # # Enter MFA code and continue.
+    # TODO: Revisit this at a later point in time.
+    # totp = pyotp.TOTP(
+    #     os.getenv('MFA_TOTP_SECRET'),
+    #     digits=int(os.getenv('MFA_TOTP_LENGTH'))
+    # )
+
+    # mfa_input.fill(totp.now())
+    # continue_button.click()
+
+    # page.wait_for_load_state('domcontentloaded')
+
+    # Save storage state into the file.
+    auth_state_path = os.path.join(
+        os.getenv("NOTIFY_E2E_AUTH_STATE_PATH"), "state.json"
+    )
+    context.storage_state(path=auth_state_path)
+
+
+@pytest.fixture(scope="session")
+def end_to_end_context(browser):
+    context = browser.new_context()
+    return context
+
+
+@pytest.fixture(scope="session")
+def end_to_end_authenticated_context(browser):
+    # Create and load a previously authenticated context for Playwright E2E
+    # tests.
+    # login_for_end_to_end_testing(browser)
+
+    auth_state_path = os.path.join(
+        os.getenv("NOTIFY_E2E_AUTH_STATE_PATH"), "state.json"
+    )
+    context = browser.new_context(storage_state=auth_state_path)
+
+    return context
+
+
+@pytest.fixture(scope="session")
+def bypass_sign_in(end_to_end_context):
+    # Open a new page and go to the staging site.
+    page = end_to_end_context.new_page()
+
+    page.goto(f"{E2E_TEST_URI}/")
+
+    sign_in_button = page.get_by_role("link", name="Sign in")
+
+    # Sign in to the site - E2E test accounts are set to flow through.
+    sign_in_button.click()
+
+    # Wait for the next page to fully load.
+    page.wait_for_load_state("domcontentloaded")
+    return page

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -28,11 +28,6 @@ def test_add_new_service_workflow(end_to_end_context):
     page = _bypass_sign_in(end_to_end_context)
     page.goto(f"{E2E_TEST_URI}/")
 
-    # sign_in_button = page.get_by_role("link", name="Sign in")
-    #
-    # Test trying to sign in. Because we are loading the email and password
-    # sign_in_button.click()
-    #
     # Wait for the next page to fully load.
     page.wait_for_load_state("domcontentloaded")
 

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -24,7 +24,6 @@ def _bypass_sign_in(end_to_end_context):
 
 
 def test_add_new_service_workflow(end_to_end_context):
-    # page = end_to_end_context.new_page()
     page = _bypass_sign_in(end_to_end_context)
     page.goto(f"{E2E_TEST_URI}/")
 

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -4,12 +4,14 @@ import re
 
 from playwright.sync_api import expect
 
+E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
+
 
 def _bypass_sign_in(end_to_end_context):
     # Open a new page and go to the staging site.
     page = end_to_end_context.new_page()
 
-    page.goto(os.getenv("NOTIFY_E2E_TEST_URI"))
+    page.goto(f"{E2E_TEST_URI}/")
 
     sign_in_button = page.get_by_role("link", name="Sign in")
 
@@ -24,7 +26,7 @@ def _bypass_sign_in(end_to_end_context):
 def test_add_new_service_workflow(end_to_end_context):
     # page = end_to_end_context.new_page()
     page = _bypass_sign_in(end_to_end_context)
-    page.goto(os.getenv("NOTIFY_E2E_TEST_URI"))
+    page.goto(f"{E2E_TEST_URI}/")
 
     # sign_in_button = page.get_by_role("link", name="Sign in")
     #
@@ -41,9 +43,7 @@ def test_add_new_service_workflow(end_to_end_context):
         browser_type=end_to_end_context.browser.browser_type.name,
     )
 
-    accounts_uri = "{}accounts".format(os.getenv("NOTIFY_E2E_TEST_URI"))
-
-    page.goto(accounts_uri)
+    page.goto(f"{E2E_TEST_URI}/accounts")
 
     # Check to make sure that we've arrived at the next page.
     page.wait_for_load_state("domcontentloaded")
@@ -82,24 +82,13 @@ def test_add_new_service_workflow(end_to_end_context):
 
     # Retrieve some prominent elements on the page for testing.
     service_name_input = page.locator('xpath=//input[@name="name"]')
-    federal_radio_button = page.locator('xpath=//input[@value="federal"]')
-    state_radio_button = page.locator('xpath=//input[@value="state"]')
-    other_radio_button = page.locator('xpath=//input[@value="other"]')
     add_service_button = page.get_by_role("button", name=re.compile("Add service"))
 
     expect(service_name_input).to_be_visible()
-    expect(federal_radio_button).to_be_visible()
-    expect(state_radio_button).to_be_visible()
-    expect(other_radio_button).to_be_visible()
     expect(add_service_button).to_be_visible()
 
     # Fill in the form.
     service_name_input.fill(new_service_name)
-    expect(federal_radio_button).to_be_enabled()
-    # Trying to click directly on the radio button resulted in a "not in viewport error" and this is the
-    # suggested workaround.  Googling, the reason seems to be that there might be some (invisible?) css positioned
-    # above the radio button itself.
-    page.click("text='Federal government'")
 
     # Click on add service.
     add_service_button.click()
@@ -108,7 +97,7 @@ def test_add_new_service_workflow(end_to_end_context):
     page.wait_for_load_state("domcontentloaded")
 
     # Check for the service name title and heading.
-    service_heading = page.get_by_text(new_service_name)
+    service_heading = page.get_by_text(new_service_name, exact=True)
     expect(service_heading).to_be_visible()
     expect(page).to_have_title(re.compile(new_service_name))
 

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -7,8 +7,8 @@ from playwright.sync_api import expect
 E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
 
 
-def test_add_new_service_workflow(bypass_sign_in, end_to_end_context):
-    page = bypass_sign_in(end_to_end_context)
+def test_add_new_service_workflow(authenticated_page, end_to_end_context):
+    page = authenticated_page
     page.goto(f"{E2E_TEST_URI}/")
 
     # Wait for the next page to fully load.

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -7,24 +7,8 @@ from playwright.sync_api import expect
 E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
 
 
-def _bypass_sign_in(end_to_end_context):
-    # Open a new page and go to the staging site.
-    page = end_to_end_context.new_page()
-
-    page.goto(f"{E2E_TEST_URI}/")
-
-    sign_in_button = page.get_by_role("link", name="Sign in")
-
-    # Sign in to the site - E2E test accounts are set to flow through.
-    sign_in_button.click()
-
-    # Wait for the next page to fully load.
-    page.wait_for_load_state("domcontentloaded")
-    return page
-
-
-def test_add_new_service_workflow(end_to_end_context):
-    page = _bypass_sign_in(end_to_end_context)
+def test_add_new_service_workflow(bypass_sign_in, end_to_end_context):
+    page = bypass_sign_in(end_to_end_context)
     page.goto(f"{E2E_TEST_URI}/")
 
     # Wait for the next page to fully load.

--- a/tests/end_to_end/test_accounts_page.py
+++ b/tests/end_to_end/test_accounts_page.py
@@ -15,7 +15,7 @@ def _bypass_sign_in(end_to_end_context):
 
     sign_in_button = page.get_by_role("link", name="Sign in")
 
-    # Test trying to sign in. Because we are loading the email and password
+    # Sign in to the site - E2E test accounts are set to flow through.
     sign_in_button.click()
 
     # Wait for the next page to fully load.

--- a/tests/end_to_end/test_landing_and_sign_in_pages.py
+++ b/tests/end_to_end/test_landing_and_sign_in_pages.py
@@ -3,11 +3,13 @@ import re
 
 from playwright.sync_api import expect
 
+E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
+
 
 def test_landing_page(end_to_end_context):
     # Open a new page and go to the staging site.
     page = end_to_end_context.browser.new_page()
-    page.goto(os.getenv("NOTIFY_E2E_TEST_URI"))
+    page.goto(f"{E2E_TEST_URI}/")
 
     # Check to make sure that we've arrived at the next page.
     page.wait_for_load_state("domcontentloaded")
@@ -17,7 +19,8 @@ def test_landing_page(end_to_end_context):
 
     # Retrieve some prominent elements on the page for testing.
     main_header = page.get_by_role(
-        "heading", name="Send text messages to your participants"
+        "heading",
+        name="Reach people where they are with government-powered text messages",
     )
     sign_in_button = page.get_by_role("link", name="Sign in")
     benefits_studio_email = page.get_by_role("link", name="tts-benefits-studio@gsa.gov")
@@ -51,7 +54,7 @@ def test_landing_page(end_to_end_context):
 # def test_sign_in_and_mfa_pages(end_to_end_context):
 #     # Open a new page and go to the staging site.
 #     page = end_to_end_context.new_page()
-#     page.goto(os.getenv("NOTIFY_E2E_TEST_URI"))
+#     page.goto(f"{E2E_TEST_URI}/")
 #     print(f"test_sign_in_and_mfa_pages initial {page}")
 #
 #     sign_in_button = page.get_by_role("link", name="Sign in")


### PR DESCRIPTION
## Description

This changeset re-enables the GitHub action job for end-to-end tests that we had to previously disable.  There are several notable pieces to this:

- As a part of the new end-to-end test action, a local copy of the API is spun up within the container running the action
- A new configuration environment was created for end-to-end tests that mirrors a combination of the staging, development, and test environments; this ensures the latest code is being run with the PR changes and that the end-to-end tests can work
- The `tests/end_to_end` folder has been cleaned up to be a proper Python module and has its own `conftest.py` file for `pytest` to keep everything consolidated

## Security Considerations

- We have to be mindful that no sensitive configuration information is shared
- The tests run assuming that an E2E test user has been created that has the permissions to get into the site; this is already configured and managed through a combination of GitHub secrets and environment variables