### PR TITLE
notify-admin-652 create new service does not work in demo

### DIFF
--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -18,8 +18,8 @@
 
       {{ form.name(param_extensions={"hint": {"text": "You can change this later"}}) }}
 
-      <!--on demo, default_organization_type is defined as something so we never get these radio buttons,
-          but then it becomes impossible to add a service-->
+      <!--See add_service.py  the default_organization_type is not currently useful for Notify.gov
+          and here it is causing an issue where services can't be created -->
       <!--{% if not default_organization_type %}-->
         {{ form.organization_type }}
       <!--{% endif %}-->

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -18,9 +18,11 @@
 
       {{ form.name(param_extensions={"hint": {"text": "You can change this later"}}) }}
 
-      {% if not default_organization_type %}
+      <!--on demo, default_organization_type is defined as something so we never get these radio buttons,
+          but then it becomes impossible to add a service-->
+      <!--{% if not default_organization_type %}-->
         {{ form.organization_type }}
-      {% endif %}
+      <!--{% endif %}-->
 
       {{ page_footer('Add service') }}
 


### PR DESCRIPTION
If you look at line 50 in add_service.py, it says that default_organization_type is not helpful for Notify.gov so it is explicitly being set to None in the form.

However, on demo somehow the default_organization_type variable is set (it seems to come from the current_user), and this is causing the radio buttons not to display, which means when the form is submitted, the validation fails -- silently.

So I comment out the if clause so the radio buttons always display.