### PR TITLE
Switch to port healthcheck

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,8 +6,7 @@ applications:
     instances: ((instances))
     memory: ((memory))
     command: newrelic-admin run-program gunicorn -c /home/vcap/app/gunicorn_config.py application
-    health-check-type: http
-    health-check-http-endpoint: '/_status?simple=true'
+    health-check-type: port
     health-check-invocation-timeout: 10
     routes:
       - route: ((public_admin_route))


### PR DESCRIPTION
Testing whether our redirect is the issue for deploying the production instance.