### PR TITLE
Update OWASP ZAP scans

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,14 +112,14 @@ jobs:
         env:
           NOTIFY_ENVIRONMENT: scanning
       - name: Run OWASP Baseline Scan
-        uses: zaproxy/action-baseline@v0.7.0
+        uses: zaproxy/action-baseline@v0.9.0
         with:
-          docker_name: "owasp/zap2docker-stable"
-          target: "http://localhost:6012"
+          docker_name: 'ghcr.io/zaproxy/zaproxy:weekly'
+          target: 'http://localhost:6012'
           fail_action: true
           allow_issue_writing: false
-          rules_file_name: "zap.conf"
-          cmd_options: "-I"
+          rules_file_name: 'zap.conf'
+          cmd_options: '-I'
 
   a11y-scan:
     runs-on: ubuntu-20.04

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -50,9 +50,9 @@ jobs:
         env:
           NOTIFY_ENVIRONMENT: scanning
       - name: Run OWASP Full Scan
-        uses: zaproxy/action-full-scan@v0.4.0
+        uses: zaproxy/action-full-scan@v0.7.0
         with:
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:weekly'
           target: 'http://localhost:6012'
           fail_action: true
           allow_issue_writing: false


### PR DESCRIPTION
The OWASP ZAP scan GitHub Actions have been updated recently and we need to make sure our GitHub Actions account for the recent changes.  This changeset makes sure we are using the latest version of the OWASP ZAP API scan and the correct Docker image.

## Security Considerations

- Helps ensure that we are properly scanning our pull requests and repo.