### PR TITLE
822 - restrict international message services

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -95,17 +95,19 @@
           }}
         {% endcall %}
         
-        {% call settings_row(if_has_permission='sms') %}
-          {{ text_field('Send international text messages') }}
-          {{ boolean_field('international_sms' in current_service.permissions) }}
-          {{ edit_field(
-            'Change',
-            url_for('.service_set_international_sms', service_id=current_service.id),
-            permissions=['manage_service'],
-            suffix='your settings for sending international text messages',
-          )
-          }}
-        {% endcall %}
+        {% if current_user.platform_admin %}
+          {% call settings_row(if_has_permission='sms') %}
+            {{ text_field('Send international text messages') }}
+            {{ boolean_field('international_sms' in current_service.permissions) }}
+            {{ edit_field(
+              'Change',
+              url_for('.service_set_international_sms', service_id=current_service.id),
+              permissions=['manage_service'],
+              suffix='your settings for sending international text messages',
+            )
+            }}
+          {% endcall %}
+        {% endif %}
         
         <!-- {% call settings_row(if_has_permission='sms') %}
                   {{ text_field('Receive text messages') }}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -60,7 +60,6 @@ def mock_get_service_settings_page_common(
                 "Send text messages On Change your settings for sending text messages",
                 "Start text messages with service name On Change your settings "
                 "for starting text messages with service name",
-                "Send international text messages Off Change your settings for sending international text messages",
             ],
         ),
         (
@@ -235,7 +234,6 @@ def test_send_files_by_email_row_on_settings_page(
                 "Send text messages On Change your settings for sending text messages",
                 "Start text messages with service name On Change your settings "
                 "for starting text messages with service name",
-                "Send international text messages On Change your settings for sending international text messages",
             ],
         ),
         (
@@ -246,7 +244,6 @@ def test_send_files_by_email_row_on_settings_page(
                 "Send text messages On Change your settings for sending text messages",
                 "Start text messages with service name On Change your settings "
                 "for starting text messages with service name",
-                "Send international text messages Off Change your settings for sending international text messages",
             ],
         ),
     ],


### PR DESCRIPTION
Created conditional to only show international number option when a platform admin