### PR TITLE
Dynamic retention count

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -290,8 +290,12 @@ def init_app(application):
 
             if service_id:
                 global_limit = current_app.config["GLOBAL_SERVICE_MESSAGE_LIMIT"]
-                global_messages_count = service_api_client.get_global_notification_count(service_id)
-                remaining_global_messages = global_limit - global_messages_count.get("count")
+                global_messages_count = (
+                    service_api_client.get_global_notification_count(service_id)
+                )
+                remaining_global_messages = global_limit - global_messages_count.get(
+                    "count"
+                )
         return {"daily_global_messages_remaining": remaining_global_messages}
 
     @application.before_request

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -286,7 +286,10 @@ def init_app(application):
     def _attach_current_global_daily_messages():
         remaining_global_messages = 0
         if current_app:
-            service_id = session.get("service_id")
+            if request.view_args:
+                service_id = request.view_args.get("service_id", session.get("service_id"))
+            else:
+                service_id = session.get("service_id")
 
             if service_id:
                 global_limit = current_app.config["GLOBAL_SERVICE_MESSAGE_LIMIT"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -287,8 +287,9 @@ def init_app(application):
         remaining_global_messages = 0
 
         if current_app:
+            service_id = session.get("service_id")
             global_limit = current_app.config["GLOBAL_SERVICE_MESSAGE_LIMIT"]
-            global_messages_count = service_api_client.get_global_notification_count()
+            global_messages_count = service_api_client.get_global_notification_count(service_id)
             remaining_global_messages = global_limit - global_messages_count
         return {"daily_global_messages_remaining": remaining_global_messages}
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -287,7 +287,9 @@ def init_app(application):
         remaining_global_messages = 0
         if current_app:
             if request.view_args:
-                service_id = request.view_args.get("service_id", session.get("service_id"))
+                service_id = request.view_args.get(
+                    "service_id", session.get("service_id")
+                )
             else:
                 service_id = session.get("service_id")
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -285,12 +285,13 @@ def init_app(application):
     @application.context_processor
     def _attach_current_global_daily_messages():
         remaining_global_messages = 0
-
         if current_app:
             service_id = session.get("service_id")
-            global_limit = current_app.config["GLOBAL_SERVICE_MESSAGE_LIMIT"]
-            global_messages_count = service_api_client.get_global_notification_count(service_id)
-            remaining_global_messages = global_limit - global_messages_count
+
+            if service_id:
+                global_limit = current_app.config["GLOBAL_SERVICE_MESSAGE_LIMIT"]
+                global_messages_count = service_api_client.get_global_notification_count(service_id)
+                remaining_global_messages = global_limit - global_messages_count.get("count")
         return {"daily_global_messages_remaining": remaining_global_messages}
 
     @application.before_request

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -498,7 +498,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return int(count)
 
     def get_global_notification_count(self, service_id):
-       return self.get("/service/{}/notification-count".format(service_id))
+        return self.get("/service/{}/notification-count".format(service_id))
 
 
 service_api_client = ServiceAPIClient()

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from notifications_utils.clients.redis import daily_total_cache_key
-
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -497,11 +497,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
         return int(count)
 
-    def get_global_notification_count(self):
-        # if cache is not set, or not enabled, return 0
-        count = redis_client.get(daily_total_cache_key()) or 0
-
-        return int(count)
+    def get_global_notification_count(self, service_id):
+       return self.get("/service/{}/notification-count".format(service_id))
 
 
 service_api_client = ServiceAPIClient()

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -321,6 +321,14 @@ def test_route_permissions(
     route,
 ):
     with notify_admin.test_request_context():
+
+        def _get(mocker):
+            return {"count": 0}
+
+        mocker.patch(
+            "app.service_api_client.get_global_notification_count", side_effect=_get
+        )
+
         validate_route_permission(
             mocker,
             notify_admin,
@@ -346,6 +354,14 @@ def test_route_invalid_permissions(
     route,
 ):
     with notify_admin.test_request_context():
+
+        def _get(mocker):
+            return {"count": 0}
+
+        mocker.patch(
+            "app.service_api_client.get_global_notification_count", side_effect=_get
+        )
+
         validate_route_permission(
             mocker,
             notify_admin,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1174,6 +1174,14 @@ def test_route_for_service_permissions(
     mock_get_inbound_sms_summary,
 ):
     with notify_admin.test_request_context():
+
+        def _get(mocker):
+            return {"count": 0}
+
+        mocker.patch(
+            "app.service_api_client.get_global_notification_count", side_effect=_get
+        )
+
         validate_route_permission(
             mocker,
             notify_admin,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2424,7 +2424,7 @@ def _os_environ():
 
 
 @pytest.fixture()  # noqa (C901 too complex)
-def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too complex)
+def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too complex)
     def _get(mocker):
         return {"count": 0}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2423,8 +2423,15 @@ def _os_environ():
         os.environ[k] = v
 
 
-@pytest.fixture()
-def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too complex)
+@pytest.fixture()  # noqa (C901 too complex)
+def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too complex)
+    def _get(mocker):
+        return {"count": 0}
+
+    mocker.patch(
+        "app.service_api_client.get_global_notification_count", side_effect=_get
+    )
+
     class ClientRequest:
         @staticmethod
         @contextmanager


### PR DESCRIPTION
Updated context processor to display notification count to front end.

Added a mock call to the api inside of the `client_request` fixture in `tests/conftest.py`. 