### PR TITLE
Restore skipped test in test_send.py

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -164,17 +164,17 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.28.75"
+version = "1.28.79"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.28.75-py3-none-any.whl", hash = "sha256:b959decd588982bc919bfcbebc7916926b05003a0093e7f2845362da4f5dd9fc"},
-    {file = "boto3-1.28.75.tar.gz", hash = "sha256:63d772a784e8e35ee51974eb1c20dff5faa51b007d22c5647783f18966bf4042"},
+    {file = "boto3-1.28.79-py3-none-any.whl", hash = "sha256:02ce7dcad2d3b054cd99e7ca6df7a708e016a31b1c98b46d8df3b3891070c121"},
+    {file = "boto3-1.28.79.tar.gz", hash = "sha256:b8acb57a124434284d6ab69c61d32d70e84e13e2c27c33b4ad3c32f15ad407d3"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.75,<1.32.0"
+botocore = ">=1.31.79,<1.32.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.7.0,<0.8.0"
 
@@ -183,13 +183,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.75"
+version = "1.31.79"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.31.75-py3-none-any.whl", hash = "sha256:fa078c4aa9a5777b3ede756540e62fec551e13d39cf7abf9a37bb81981496d68"},
-    {file = "botocore-1.31.75.tar.gz", hash = "sha256:d704ea9867b2227de0350bc2a5ca2543349e164ecb5d15edbfacbb05f2056482"},
+    {file = "botocore-1.31.79-py3-none-any.whl", hash = "sha256:6f1fc49e9e12f9772b4fef577837670bc84d772a7c946b4d08fe2890e34a4305"},
+    {file = "botocore-1.31.79.tar.gz", hash = "sha256:07ecb93833475dde68e5c0e02a7ccf8ca22caf68cdc892651c300529894133e1"},
 ]
 
 [package.dependencies]
@@ -1388,16 +1388,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1807,13 +1797,13 @@ files = [
 
 [[package]]
 name = "pip"
-version = "23.3"
+version = "23.3.1"
 description = "The PyPA recommended tool for installing Python packages."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pip-23.3-py3-none-any.whl", hash = "sha256:bc38bb52bc286514f8f7cb3a1ba5ed100b76aaef29b521d48574329331c5ae7b"},
-    {file = "pip-23.3.tar.gz", hash = "sha256:bb7d4f69f488432e4e96394612f43ab43dd478d073ef7422604a570f7157561e"},
+    {file = "pip-23.3.1-py3-none-any.whl", hash = "sha256:55eb67bb6171d37447e82213be585b75fe2b12b359e993773aca4de9247a052b"},
+    {file = "pip-23.3.1.tar.gz", hash = "sha256:1fcaa041308d01f14575f6d0d2ea4b75a3e2871fe4f9c694976f908768e14174"},
 ]
 
 [[package]]

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2292,7 +2292,6 @@ def test_warns_if_file_sent_already(
     mock_get_jobs.assert_called_once_with(SERVICE_ONE_ID, limit_days=0)
 
 
-@pytest.mark.skip(reason="Test fails for unknown reason at this time.")
 @pytest.mark.parametrize(
     "uploaded_file_name",
     [
@@ -2302,36 +2301,33 @@ def test_warns_if_file_sent_already(
 )
 def test_warns_if_file_sent_already_errors(
     client_request,
-    mock_get_users_by_service,
-    mock_get_live_service,
-    mock_get_service_template,
-    mock_has_permissions,
-    mock_get_service_statistics,
-    mock_get_job_doesnt_exist,
     mock_get_jobs,
-    fake_uuid,
     mocker,
+    fake_uuid,
     uploaded_file_name,
 ):
     mocker.patch(
         "app.main.views.send.s3download", return_value=("phone number,\n2028675209")
-    )
+        )
     mocker.patch(
         "app.main.views.send.get_csv_metadata",
         return_value={"original_file_name": uploaded_file_name},
     )
 
     with pytest.raises(
-        expected_exception=Exception, match="Unable to locate credentials"
+        expected_exception=Exception
     ):
         stmt_for_test_warns_if_file_sent_already_errors(
             client_request, uploaded_file_name, fake_uuid, mock_get_jobs
         )
 
-
 def stmt_for_test_warns_if_file_sent_already_errors(
-    client_request, uploaded_file_name, fake_uuid, mock_get_jobs
+    client_request,
+    uploaded_file_name,
+    fake_uuid,
+    mock_get_jobs
 ):
+
     page = client_request.get(
         "main.check_messages",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2312,13 +2312,13 @@ def test_warns_if_file_sent_already_errors(
     mocker,
     uploaded_file_name,
 ):
-    mocker.patch(
-        "app.main.views.send.s3download", return_value=("phone number,\n2028675209")
-    )
-    mocker.patch(
-        "app.main.views.send.get_csv_metadata",
-        return_value={"original_file_name": uploaded_file_name},
-    )
+    # mocker.patch(
+    #     "app.main.views.send.s3download", return_value=("phone number,\n2028675209")
+    # )
+    # mocker.patch(
+    #     "app.main.views.send.get_csv_metadata",
+    #     return_value={"original_file_name": uploaded_file_name},
+    # )
 
     # The exception that actually gets reported is from
     # botocore.errorfactory.NoSuchKey, but that cannot be referenced directly.
@@ -2331,13 +2331,21 @@ def test_warns_if_file_sent_already_errors(
         expected_exception=Exception, match="The specified key does not exist"
     ):
         stmt_for_test_warns_if_file_sent_already_errors(
-            client_request, uploaded_file_name, fake_uuid, mock_get_jobs
+            client_request, uploaded_file_name, fake_uuid, mock_get_jobs, mocker
         )
 
 
 def stmt_for_test_warns_if_file_sent_already_errors(
-    client_request, uploaded_file_name, fake_uuid, mock_get_jobs
+    client_request, uploaded_file_name, fake_uuid, mock_get_jobs, mocker
 ):
+    mocker.patch(
+        "app.main.views.send.s3download", return_value=("phone number,\n2028675209")
+    )
+    mocker.patch(
+        "app.main.views.send.get_csv_metadata",
+        return_value={"original_file_name": uploaded_file_name},
+    )
+
     page = client_request.get(
         "main.check_messages",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2312,32 +2312,6 @@ def test_warns_if_file_sent_already_errors(
     mocker,
     uploaded_file_name,
 ):
-    # mocker.patch(
-    #     "app.main.views.send.s3download", return_value=("phone number,\n2028675209")
-    # )
-    # mocker.patch(
-    #     "app.main.views.send.get_csv_metadata",
-    #     return_value={"original_file_name": uploaded_file_name},
-    # )
-
-    # The exception that actually gets reported is from
-    # botocore.errorfactory.NoSuchKey, but that cannot be referenced directly.
-    # You have to capture the botocore.exceptions.ClientError object.
-    # However, it is a bit more nuanced than that, and that alone won't match
-    # properly here with the pytest.raises wrapper.
-    # See https://stackoverflow.com/questions/42975609/how-to-capture-botocores-nosuchkey-exception
-    # for more information.
-    with pytest.raises(
-        expected_exception=Exception, match="The specified key does not exist"
-    ):
-        stmt_for_test_warns_if_file_sent_already_errors(
-            client_request, uploaded_file_name, fake_uuid, mock_get_jobs, mocker
-        )
-
-
-def stmt_for_test_warns_if_file_sent_already_errors(
-    client_request, uploaded_file_name, fake_uuid, mock_get_jobs, mocker
-):
     mocker.patch(
         "app.main.views.send.s3download", return_value=("phone number,\n2028675209")
     )
@@ -2346,6 +2320,28 @@ def stmt_for_test_warns_if_file_sent_already_errors(
         return_value={"original_file_name": uploaded_file_name},
     )
 
+    # The exception that actually gets reported is from
+    # botocore.errorfactory.NoSuchKey, but that cannot be referenced directly.
+    # You have to capture the botocore.exceptions.ClientError object.
+    # However, it is a bit more nuanced than that, and that alone won't match
+    # properly here with the pytest.raises wrapper.
+    # See https://stackoverflow.com/questions/42975609/how-to-capture-botocores-nosuchkey-exception
+    # for more information.
+
+    # There can sometimes be another exception thrown if the environment isn't
+    # configured fully, hence the multiple messages in the match argumment.
+    with pytest.raises(
+        expected_exception=Exception,
+        match=r"The specified key does not exist|Unable to locate credentials",
+    ):
+        stmt_for_test_warns_if_file_sent_already_errors(
+            client_request, uploaded_file_name, fake_uuid, mock_get_jobs
+        )
+
+
+def stmt_for_test_warns_if_file_sent_already_errors(
+    client_request, uploaded_file_name, fake_uuid, mock_get_jobs
+):
     page = client_request.get(
         "main.check_messages",
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
This changeset restores the skipped test in `test_send.py`.  It appears that the exception being thrown changed, so the match was no longer working.  The `boto3` and `botocore` dependencies are updated as a part of this to make sure they are running the latest.

This pull request addresses https://github.com/GSA/notifications-admin/issues/908

## Security Considerations

- Keeps our test suite running properly.