### PR TITLE
notify-admin-916 revert restrictions on create service

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -6,7 +6,7 @@ from app import service_api_client
 from app.formatters import email_safe
 from app.main import main
 from app.main.forms import CreateServiceForm
-from app.utils.user import user_is_gov_user, user_is_platform_admin
+from app.utils.user import user_is_gov_user, user_is_logged_in
 
 
 def _create_service(service_name, organization_type, email_from, form):
@@ -42,7 +42,7 @@ def _create_example_template(service_id):
 
 @main.route("/add-service", methods=["GET", "POST"])
 @user_is_gov_user
-@user_is_platform_admin
+@user_is_logged_in
 def add_service():
     default_organization_type = current_user.default_organization_type
     if default_organization_type is None:

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -4,7 +4,7 @@ import pytest
 from flask import url_for
 
 from app.models.user import User
-from tests.conftest import SERVICE_ONE_ID, create_platform_admin_user, normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 def test_render_sign_in_template_for_new_user(client_request):
@@ -71,19 +71,6 @@ def test_doesnt_redirect_to_sign_in_if_no_session_info(
 
     with client_request.session_transaction() as session:
         session["current_session_id"] = None
-
-    # This returns a 403 now
-    with pytest.raises(AssertionError):
-        client_request.get("main.add_service")
-
-
-def test_doesnt_redirect_to_sign_in_if_no_session_info_platform_admin(
-    client_request,
-    mock_get_organization_by_domain,
-):
-    platform_admin = create_platform_admin_user()
-    client_request.login(platform_admin)
-    platform_admin["current_session_id"] = str(uuid.UUID(int=1))
 
     with client_request.session_transaction() as session:
         session["current_session_id"] = None


### PR DESCRIPTION
A previous ticket (#571) made a requirement to be a platform admin in order to create a service.  This is too restrictive and causing problems for initial sign-in, so revert it.