### PR TITLE
notify-admin-487 platform admin view errors

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -689,7 +689,6 @@ def format_stats_by_service(services):
             "name": service["name"],
             "stats": service["statistics"],
             "restricted": service["restricted"],
-            "research_mode": service["research_mode"],
             "created_at": service["created_at"],
             "active": service["active"],
         }


### PR DESCRIPTION
remove reference to 'research_mode' inadvertently left in last sweep.