### PR TITLE
Adjust positional arguments flagged by flake8-bugbear

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -956,9 +956,9 @@ class OnOffField(GovukRadiosField):
         ]
         super().__init__(
             label,
+            *args,
             choices=choices,
             thing=f"{choices[0][1].lower()} or {choices[1][1].lower()}",
-            *args,
             **kwargs,
         )
 

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -3,7 +3,7 @@ from app.notify_client import NotifyAdminAPIClient, cache
 
 class StatusApiClient(NotifyAdminAPIClient):
     def get_status(self, *params):
-        return self.get(url="/_status", *params)
+        return self.get(*params, url="/_status")
 
     @cache.set("live-service-and-organization-counts", ttl_in_seconds=3600)
     def get_count_of_live_services_and_organizations(self):


### PR DESCRIPTION
The new release of flake8-bugbear is starting to flag positional argument unpacking that comes after keyword arguments in function calls as a style warning that fails.  This is a good thing to catch because it can lead to unexpected side effects with function arguments and/or errors thrown by Python.

See the following links for more details:

- https://stackoverflow.com/questions/58961715/python-value-unpacking-order-in-method-parameters
- https://github.com/python/cpython/issues/82741

This changeset fixes a couple of instances where the positional argument unpacking was happening after keyword arguments were being provided.  I've tested these changes both before and after updating the `flake8-bugbear` dependency locally, and the site loads fine and the tests all pass.

## Security Considerations

- Helps prevent bugs from being exploited in our code.