### PR TITLE
maybe fix 404 on signout

### DIFF
--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -34,6 +34,7 @@ def sign_out():
     if current_user.is_authenticated:
         # TODO This doesn't work yet, due to problems above.
         current_user.sign_out()
-
-        return redirect(os.getenv("LOGIN_DOT_GOV_LOGOUT_URL"))
+        login_dot_gov_logout_url = os.getenv("LOGIN_DOT_GOV_LOGOUT_URL")
+        if login_dot_gov_logout_url:
+            return redirect(login_dot_gov_logout_url)
     return redirect(url_for("main.index"))


### PR DESCRIPTION
Although I can't reproduce the problem, I think the issue is:

1. The code in sign_out.py assumes that an environment variable for login.gov logout url is defined and redirects to it
2. If a developer (or staging) has not defined the login.gov variables then they are redirecting to None

Fixed by adding a test to make sure it's defined.

It is curious that I can't repro the issue, even if I comment out the env variable and restart.