### PR TITLE
fix scheduled jobs time

### DIFF
--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -109,7 +109,7 @@ class JobApiClient(NotifyAdminAPIClient):
         # make a datetime object in the user's preferred timezone
 
         if scheduled_for:
-            scheduled_for = self.convert_user_time_to_utc(scheduled_for)
+            scheduled_for = JobApiClient.convert_user_time_to_utc(scheduled_for)
             data.update({"scheduled_for": scheduled_for})
 
         data = _attach_current_user(data)

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -117,6 +117,14 @@ def hide_from_search_engines(f):
     return decorated_function
 
 
+# Function used for debugging.
+# Do print(hilite(message)) while debugging, then remove your print statements
+def hilite(message):
+    ansi_green = "\033[32m"
+    ansi_reset = "\033[0m"
+    return f"{ansi_green}{message}{ansi_reset}"
+
+
 # Function to merge two dict or lists with a JSON-like structure into one.
 # JSON-like means they can contain all types JSON can: all the main primitives
 # plus nested lists or dictionaries.

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -22,9 +22,3 @@ def is_less_than_days_ago(date_from_db, number_of_days):
 
 def parse_naive_dt(dt):
     return parser.parse(dt, ignoretz=True)
-
-
-def hilite(message):
-    ansi_green = "\033[32m"
-    ansi_reset = "\033[0m"
-    return f"{ansi_green}{message}{ansi_reset}"

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -22,3 +22,9 @@ def is_less_than_days_ago(date_from_db, number_of_days):
 
 def parse_naive_dt(dt):
     return parser.parse(dt, ignoretz=True)
+
+
+def hilite(message):
+    ansi_green = "\033[32m"
+    ansi_reset = "\033[0m"
+    return f"{ansi_green}{message}{ansi_reset}"

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -32,16 +32,24 @@ def test_client_creates_job_data_correctly(mocker, fake_uuid):
     )
 
 
+def test_convert_user_time_to_utc():
+    original_time = "2023-12-01T12:00:00"
+    utc_time = JobApiClient.convert_user_time_to_utc(original_time)
+    assert utc_time == "2023-12-01T17:00:00"
+
+
 def test_client_schedules_job(mocker, fake_uuid):
     mocker.patch("app.notify_client.current_user", id="1")
 
     mock_post = mocker.patch("app.notify_client.job_api_client.JobApiClient.post")
 
-    when = "2016-08-25T13:04:21.767198"
+    # The default timezone is US/Easter which is off by 4 hours in the summer from UTC
+    when_in_utc = "2016-08-25T17:04:21"
+    when = "2016-08-25T13:04:21"
 
     JobApiClient().create_job(fake_uuid, 1, scheduled_for=when)
 
-    assert mock_post.call_args[1]["data"]["scheduled_for"] == when
+    assert mock_post.call_args[1]["data"]["scheduled_for"] == when_in_utc
 
 
 def test_client_gets_job_by_service_and_job(mocker):


### PR DESCRIPTION
The backend is 100% in UTC.

When the user wants to schedule a job, we need to intercept the time they select and convert it to UTC.