### PR TITLE
Notify admin 931 add a preferred timezone widget

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1279,6 +1279,23 @@ class ChangeNameForm(StripWhitespaceForm):
     new_name = GovukTextInputField("Your name")
 
 
+class ChangePreferredTimezoneForm(StripWhitespaceForm):
+    def __init__(self, *args, **kwargs):
+        super(ChangePreferredTimezoneForm, self).__init__(*args, **kwargs)
+        self.new_preferred_timezone.choices = [
+            ("US/Eastern", "US/Eastern"),
+            ("US/Central", "US/Central"),
+            ("US/Mountain", "US/Mountain"),
+            ("US/Pacific", "US/Pacific"),
+            ("US/Hawaii", "US/Hawaii"),
+        ]
+
+    new_preferred_timezone = GovukRadiosField(
+        "What timezone would you like to use?",
+        default="US/Eastern",
+    )
+
+
 class ChangeEmailForm(StripWhitespaceForm):
     def __init__(self, validate_email_func, *args, **kwargs):
         self.validate_email_func = validate_email_func

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -24,6 +24,7 @@ from app.main.forms import (
     ChangeMobileNumberForm,
     ChangeNameForm,
     ChangePasswordForm,
+    ChangePreferredTimezoneForm,
     ConfirmPasswordForm,
     ServiceOnOffSettingForm,
     TwoFactorForm,
@@ -58,6 +59,22 @@ def user_profile_name():
 
     return render_template(
         "views/user-profile/change.html", thing="name", form_field=form.new_name
+    )
+
+
+@main.route("/user-profile/preferred_timezone", methods=["GET", "POST"])
+@user_is_logged_in
+def user_profile_preferred_timezone():
+    form = ChangePreferredTimezoneForm(new_name=current_user.preferred_timezone)
+
+    if form.validate_on_submit():
+        current_user.update(preferred_timezone=form.new_preferred_timezone.data)
+        current_user.preferred_timezone = form.new_preferred_timezone.data
+        return redirect(url_for(".user_profile"))
+    return render_template(
+        "views/user-profile/change.html",
+        thing="preferred timezone",
+        form_field=form.new_preferred_timezone,
     )
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -54,7 +54,6 @@ class User(JSONModel, UserMixin):
         super().__init__(_dict)
         self.permissions = _dict.get("permissions", {})
         self._platform_admin = _dict["platform_admin"]
-        self.preferred_timezone = "US/Eastern"
 
     @classmethod
     def from_id(cls, user_id):
@@ -366,6 +365,7 @@ class User(JSONModel, UserMixin):
             "permissions": [x for x in self._permissions],
             "organizations": self.organization_ids,
             "current_session_id": self.current_session_id,
+            "preferred_timezone": self.preferred_timezone,
         }
         if hasattr(self, "_password"):
             dct["password"] = self._password

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -157,6 +157,7 @@ class HeaderNavigation(Navigation):
             "user_profile_mobile_number_delete",
             "user_profile_name",
             "user_profile_password",
+            "user_profile_preferred_timezone",
             "user_profile_disable_platform_admin_view",
         },
         "platform-admin": {

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -12,6 +12,7 @@ ALLOWED_ATTRIBUTES = {
     "updated_by",
     "current_session_id",
     "email_access_validated_at",
+    "preferred_timezone",
 }
 
 

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -64,6 +64,17 @@
         }}
       {% endcall %}
 
+      {% call row() %}
+        {{ text_field('Preferred Timezone') }}
+        {{ optional_text_field(current_user.preferred_timezone) }}
+        {{ edit_field(
+            'Change',
+            url_for('.user_profile_preferred_timezone'),
+            suffix='preferred timezone'
+          )
+        }}
+      {% endcall %}
+
       {% if current_user.platform_admin or session.get('disable_platform_admin_view') %}
         {% call row(id='disable-platform-admin') %}
           {{ text_field('Use platform admin view') }}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -63,7 +63,7 @@
           )
         }}
       {% endcall %}
-
+      IS IT HERE???? {{ current_user.preferred_timezone }}
       {% call row() %}
         {{ text_field('Preferred Timezone') }}
         {{ optional_text_field(current_user.preferred_timezone) }}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -63,7 +63,6 @@
           )
         }}
       {% endcall %}
-      IS IT HERE???? {{ current_user.preferred_timezone }}
       {% call row() %}
         {{ text_field('Preferred Timezone') }}
         {{ optional_text_field(current_user.preferred_timezone) }}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -253,6 +253,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "user_profile_mobile_number_delete",
             "user_profile_name",
             "user_profile_password",
+            "user_profile_preferred_timezone",
             "using_notify",
             "verify",
             "verify_email",


### PR DESCRIPTION
Add a selector widget so the user can change their preferred timezone.  Offer choices in the main US timezones that should handle daylight/standard automatically.