### PR TITLE
Fix test_register.py flake8-bugbear warning

### DIFF
--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -322,7 +322,7 @@ def test_register_from_invite(
         "+12024900460",
         "somreallyhardthingtoguess",
         "sms_auth",
-    ),
+    )
     mock_get_invited_user_by_id.assert_called_once_with(sample_invite["id"])
 
 


### PR DESCRIPTION
This changeset fixes a small syntax issue with one of the tests that is being picked up by the new version of flake8-bugbear.  It turns out there was an extraneous comma left in the test.

## Security Considerations

- None with this change.