### PR TITLE
Hide individual template display if it is in a folder#828

### DIFF
--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -38,18 +38,12 @@
     {% for item in template_list %}
 
     {% set item_link_content %}
-    {% for ancestor in item.ancestors %}
-    <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}"
-      class="usa-link template-list-folder">
-      {{- format_item_name(ancestor.name) -}}
-    </a> <span class="message-name-separator"></span>
-    {% endfor %}
     {% if item.is_folder %}
     <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}"
       class="usa-link template-list-folder">
       <span class="live-search-relevant">{{- format_item_name(item.name) -}}</span>
     </a>
-    {% else %}
+    {% elif not item.ancestors %}
     <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}"
       class="usa-link template-list-template">
       <span class="live-search-relevant">
@@ -70,9 +64,11 @@
     {% endset %}
 
     {% set item_meta %}
+    {% if not item.ancestors %}
     <span id="{{ item.id }}-item-hint" class="usa-hint usa-checkbox__label-description template-list-item-hint">
       {{ item.hint }}
     </span>
+    {% endif %}
     {% endset %}
 
     {# create the item config now to include the label content -#}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -59,13 +59,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             [
                 "folder_one folder_one 2 folders",
                 ("folder_one folder_one_one " "folder_one_one"),
-                (
-                    "folder_one folder_one_one folder_one_one_one "
-                    "folder_one_one_one"
-                ),
-                (
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested"
-                ),
+                ("folder_one folder_one_one folder_one_one_one " "folder_one_one_one"),
+                ("folder_one folder_one_one folder_one_one_one sms_template_nested"),
                 ("folder_one folder_one_two " "folder_one_two"),
                 "folder_two folder_two Empty",
                 ("sms_template_one " "sms_template_one " "Text message template"),
@@ -103,13 +98,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             [
                 "folder_one folder_one 2 folders",
                 ("folder_one folder_one_one " "folder_one_one"),
-                (
-                    "folder_one folder_one_one folder_one_one_one "
-                    "folder_one_one_one"
-                ),
-                (
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested"
-                ),
+                ("folder_one folder_one_one folder_one_one_one " "folder_one_one_one"),
+                ("folder_one folder_one_one folder_one_one_one sms_template_nested"),
                 ("folder_one folder_one_two " "folder_one_two"),
                 "folder_two folder_two Empty",
                 "sms_template_one sms_template_one Text message template",
@@ -147,13 +137,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             [
                 "folder_one folder_one 1 folder",
                 ("folder_one folder_one_one " "folder_one_one"),
-                (
-                    "folder_one folder_one_one folder_one_one_one "
-                    "folder_one_one_one"
-                ),
-                (
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested"
-                ),
+                ("folder_one folder_one_one folder_one_one_one " "folder_one_one_one"),
+                ("folder_one folder_one_one folder_one_one_one sms_template_nested"),
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
             ],
@@ -179,13 +164,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ["Email", "Text message"],
             [
                 "folder_one_one folder_one_one 1 folder",
-                (
-                    "folder_one_one folder_one_one_one "
-                    "folder_one_one_one"
-                ),
-                (
-                    "folder_one_one folder_one_one_one sms_template_nested"
-                ),
+                ("folder_one_one folder_one_one_one " "folder_one_one_one"),
+                ("folder_one_one folder_one_one_one sms_template_nested"),
                 "folder_one_two folder_one_two Empty",
             ],
             [
@@ -207,21 +187,13 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ["All", "Email"],
             [
                 "folder_one_one folder_one_one 1 folder",
-                (
-                    "folder_one_one folder_one_one_one "
-                    "folder_one_one_one"
-                ),
-                (
-                    "folder_one_one folder_one_one_one sms_template_nested"
-                ),
+                ("folder_one_one folder_one_one_one " "folder_one_one_one"),
+                ("folder_one_one folder_one_one_one sms_template_nested"),
             ],
             [
                 "folder_one_one folder_one_one 1 folder",
             ],
-            [
-                "folder_one_one",
-                "folder_one_one_one"
-            ],
+            ["folder_one_one", "folder_one_one_one"],
             None,
         ),
         (
@@ -246,16 +218,12 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ["Email", "Text message"],
             [
                 "folder_one_one_one folder_one_one_one 1 template",
-                (
-                    "folder_one_one_one sms_template_nested"
-                ),
+                ("folder_one_one_one sms_template_nested"),
             ],
             [
                 "folder_one_one_one folder_one_one_one 1 template",
             ],
-            [
-                "folder_one_one_one"
-            ],
+            ["folder_one_one_one"],
             None,
         ),
         (
@@ -349,7 +317,6 @@ def test_should_show_templates_folder_page(
     expected_searchable_text,
     expected_empty_message,
 ):
-    print("Expected search results:", expected_searchable_text)
     mock_get_template_folders.return_value = [
         _folder("folder_two", FOLDER_TWO_ID),
         _folder("folder_one", PARENT_FOLDER_ID),
@@ -500,9 +467,7 @@ def test_template_id_is_searchable_for_services_with_api_keys(
             # Text which should be hidden from all users
             r".template-list-item .display-none"
         )
-    ] == [
-        template_1["id"]
-    ]
+    ] == [template_1["id"]]
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 
@@ -1684,12 +1649,9 @@ def test_show_custom_error_message(
             [
                 ["folder_A", "folder_A", "1 template, 2 folders"],
                 ["folder_A folder_C", "folder_C"],
-                [
-                    "folder_A folder_C sms_template_C",
-                ],
+                ["folder_A folder_C sms_template_C"],
                 ["folder_A folder_D", "folder_D"],
-                [
-                    "folder_A sms_template_A"                ],
+                ["folder_A sms_template_A"],
                 [
                     "folder_E folder_F folder_G",
                     "folder_E",
@@ -1697,9 +1659,7 @@ def test_show_custom_error_message(
                     "folder_G",
                     "1 template",
                 ],
-                [
-                    "folder_E folder_F folder_G email_template_G"
-                ],
+                ["folder_E folder_F folder_G email_template_G"],
                 ["email_template_root", "email_template_root", "Email template"],
             ],
             None,
@@ -1739,12 +1699,8 @@ def test_show_custom_error_message(
             [
                 ["folder_A", "folder_A", "1 template, 1 folder"],
                 ["folder_A folder_C", "folder_C"],
-                [
-                    "folder_A folder_C sms_template_C"
-                ],
-                [
-                    "folder_A sms_template_A"
-                ],
+                ["folder_A folder_C sms_template_C"],
+                ["folder_A sms_template_A"],
             ],
             None,
         ),

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -58,18 +58,15 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ["Email", "Text message"],
             [
                 "folder_one folder_one 2 folders",
-                ("folder_one folder_one_one " "folder_one folder_one_one " "1 folder"),
+                ("folder_one folder_one_one " "folder_one_one"),
                 (
                     "folder_one folder_one_one folder_one_one_one "
-                    "folder_one folder_one_one folder_one_one_one "
-                    "1 template"
+                    "folder_one_one_one"
                 ),
                 (
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "Text message template"
+                    "folder_one folder_one_one folder_one_one_one sms_template_nested"
                 ),
-                ("folder_one folder_one_two " "folder_one folder_one_two " "Empty"),
+                ("folder_one folder_one_two " "folder_one_two"),
                 "folder_two folder_two Empty",
                 ("sms_template_one " "sms_template_one " "Text message template"),
                 ("sms_template_two " "sms_template_two " "Text message template"),
@@ -88,7 +85,6 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "folder_one",
                 "folder_one_one",
                 "folder_one_one_one",
-                "sms_template_nested",
                 "folder_one_two",
                 "folder_two",
                 "sms_template_one",
@@ -106,18 +102,15 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ["Email", "Text message"],
             [
                 "folder_one folder_one 2 folders",
-                ("folder_one folder_one_one " "folder_one folder_one_one " "1 folder"),
+                ("folder_one folder_one_one " "folder_one_one"),
                 (
                     "folder_one folder_one_one folder_one_one_one "
-                    "folder_one folder_one_one folder_one_one_one "
-                    "1 template"
+                    "folder_one_one_one"
                 ),
                 (
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "Text message template"
+                    "folder_one folder_one_one folder_one_one_one sms_template_nested"
                 ),
-                ("folder_one folder_one_two " "folder_one folder_one_two " "Empty"),
+                ("folder_one folder_one_two " "folder_one_two"),
                 "folder_two folder_two Empty",
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
@@ -136,7 +129,6 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "folder_one",
                 "folder_one_one",
                 "folder_one_one_one",
-                "sms_template_nested",
                 "folder_one_two",
                 "folder_two",
                 "sms_template_one",
@@ -154,16 +146,13 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ["All", "Email"],
             [
                 "folder_one folder_one 1 folder",
-                ("folder_one folder_one_one " "folder_one folder_one_one " "1 folder"),
+                ("folder_one folder_one_one " "folder_one_one"),
                 (
                     "folder_one folder_one_one folder_one_one_one "
-                    "folder_one folder_one_one folder_one_one_one "
-                    "1 template"
+                    "folder_one_one_one"
                 ),
                 (
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "Text message template"
+                    "folder_one folder_one_one folder_one_one_one sms_template_nested"
                 ),
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
@@ -177,7 +166,6 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "folder_one",
                 "folder_one_one",
                 "folder_one_one_one",
-                "sms_template_nested",
                 "sms_template_one",
                 "sms_template_two",
             ],
@@ -193,13 +181,10 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "folder_one_one folder_one_one 1 folder",
                 (
                     "folder_one_one folder_one_one_one "
-                    "folder_one_one folder_one_one_one "
-                    "1 template"
+                    "folder_one_one_one"
                 ),
                 (
-                    "folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one_one folder_one_one_one sms_template_nested "
-                    "Text message template"
+                    "folder_one_one folder_one_one_one sms_template_nested"
                 ),
                 "folder_one_two folder_one_two Empty",
             ],
@@ -210,7 +195,6 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             [
                 "folder_one_one",
                 "folder_one_one_one",
-                "sms_template_nested",
                 "folder_one_two",
             ],
             None,
@@ -225,13 +209,10 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "folder_one_one folder_one_one 1 folder",
                 (
                     "folder_one_one folder_one_one_one "
-                    "folder_one_one folder_one_one_one "
-                    "1 template"
+                    "folder_one_one_one"
                 ),
                 (
-                    "folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one_one folder_one_one_one sms_template_nested "
-                    "Text message template"
+                    "folder_one_one folder_one_one_one sms_template_nested"
                 ),
             ],
             [
@@ -239,8 +220,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             ],
             [
                 "folder_one_one",
-                "folder_one_one_one",
-                "sms_template_nested",
+                "folder_one_one_one"
             ],
             None,
         ),
@@ -267,17 +247,14 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             [
                 "folder_one_one_one folder_one_one_one 1 template",
                 (
-                    "folder_one_one_one sms_template_nested "
-                    "folder_one_one_one sms_template_nested "
-                    "Text message template"
+                    "folder_one_one_one sms_template_nested"
                 ),
             ],
             [
                 "folder_one_one_one folder_one_one_one 1 template",
             ],
             [
-                "folder_one_one_one",
-                "sms_template_nested",
+                "folder_one_one_one"
             ],
             None,
         ),
@@ -372,6 +349,7 @@ def test_should_show_templates_folder_page(
     expected_searchable_text,
     expected_empty_message,
 ):
+    print("Expected search results:", expected_searchable_text)
     mock_get_template_folders.return_value = [
         _folder("folder_two", FOLDER_TWO_ID),
         _folder("folder_one", PARENT_FOLDER_ID),
@@ -502,7 +480,6 @@ def test_template_id_is_searchable_for_services_with_api_keys(
         )
     ] == [
         "folder one",
-        f'{template_2["id"]} template two',
         f'{template_1["id"]} template one',
     ]
 
@@ -524,8 +501,7 @@ def test_template_id_is_searchable_for_services_with_api_keys(
             r".template-list-item .display-none"
         )
     ] == [
-        template_2["id"],
-        template_1["id"],
+        template_1["id"]
     ]
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
@@ -1707,21 +1683,13 @@ def test_show_custom_error_message(
             ],
             [
                 ["folder_A", "folder_A", "1 template, 2 folders"],
-                ["folder_A folder_C", "folder_A", "folder_C", "1 template"],
+                ["folder_A folder_C", "folder_C"],
                 [
                     "folder_A folder_C sms_template_C",
-                    "folder_A",
-                    "folder_C",
-                    "sms_template_C",
-                    "Text message template",
                 ],
-                ["folder_A folder_D", "folder_A", "folder_D", "Empty"],
+                ["folder_A folder_D", "folder_D"],
                 [
-                    "folder_A sms_template_A",
-                    "folder_A",
-                    "sms_template_A",
-                    "Text message template",
-                ],
+                    "folder_A sms_template_A"                ],
                 [
                     "folder_E folder_F folder_G",
                     "folder_E",
@@ -1730,12 +1698,7 @@ def test_show_custom_error_message(
                     "1 template",
                 ],
                 [
-                    "folder_E folder_F folder_G email_template_G",
-                    "folder_E",
-                    "folder_F",
-                    "folder_G",
-                    "email_template_G",
-                    "Email template",
+                    "folder_E folder_F folder_G email_template_G"
                 ],
                 ["email_template_root", "email_template_root", "Email template"],
             ],
@@ -1763,11 +1726,6 @@ def test_show_custom_error_message(
                 ],
                 [
                     "folder_E folder_F folder_G email_template_G",
-                    "folder_E",
-                    "folder_F",
-                    "folder_G",
-                    "email_template_G",
-                    "Email template",
                 ],
                 ["email_template_root", "email_template_root", "Email template"],
             ],
@@ -1780,19 +1738,12 @@ def test_show_custom_error_message(
             ],
             [
                 ["folder_A", "folder_A", "1 template, 1 folder"],
-                ["folder_A folder_C", "folder_A", "folder_C", "1 template"],
+                ["folder_A folder_C", "folder_C"],
                 [
-                    "folder_A folder_C sms_template_C",
-                    "folder_A",
-                    "folder_C",
-                    "sms_template_C",
-                    "Text message template",
+                    "folder_A folder_C sms_template_C"
                 ],
                 [
-                    "folder_A sms_template_A",
-                    "folder_A",
-                    "sms_template_A",
-                    "Text message template",
+                    "folder_A sms_template_A"
                 ],
             ],
             None,


### PR DESCRIPTION
**Issue**: The folder full of templates are showing individual templates on the template view instead of being hidden. 
Ticket: https://github.com/orgs/GSA/projects/20/views/1?pane=issue&itemId=40068708

Before:
<img width="566" alt="image" src="https://github.com/GSA/notifications-admin/assets/53159604/62cc1ba4-7aa3-4691-b8d1-3ec46eedd5b5">

After: 
![image](https://github.com/GSA/notifications-admin/assets/53159604/058d813d-279f-4f82-8d16-7ecc3b0b0e0f)

