### PR TITLE
Update tagline on beta.notify.gov #998

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -17,7 +17,7 @@ Notify.gov
     <div class="grid-row grid-gap display-flex flex-align-center">
       <div class="desktop:grid-col-7 tablet:grid-col-12">
         <h1 class="font-serif-2xl usa-hero__heading">Reach people where they are with government-powered text messages</h1>
-        <p class="font-sans-lg">Notify.gov is a text message service that helps federal, state, local, tribal and territorial goverments more effectively communicate with the people who use their services.</p>
+        <p class="font-sans-lg">Notify.gov is a text message service that helps federal, state, local, tribal and territorial governments more effectively communicate with the people who use their services.</p>
         <div class="usa-button-group margin-bottom-5">
           <a class="usa-button usa-button--big margin-right-2" href="{{ url_for('main.sign_in' )}}">Sign in</a>
           if you are an existing pilot partner

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -17,7 +17,7 @@ Notify.gov
     <div class="grid-row grid-gap display-flex flex-align-center">
       <div class="desktop:grid-col-7 tablet:grid-col-12">
         <h1 class="font-serif-2xl usa-hero__heading">Reach people where they are with government-powered text messages</h1>
-        <p class="font-sans-lg">Notify.gov is a text message service that helps federal, state, local, tribal and territorial governments more effectively communicate with the people who use their services.</p>
+        <p class="font-sans-lg">Notify.gov is a text message service that helps federal, state, local, tribal and territorial governments more effectively communicate with the people they serve.</p>
         <div class="usa-button-group margin-bottom-5">
           <a class="usa-button usa-button--big margin-right-2" href="{{ url_for('main.sign_in' )}}">Sign in</a>
           if you are an existing pilot partner

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -16,9 +16,8 @@ Notify.gov
   <div class="grid-container padding-y-4">
     <div class="grid-row grid-gap display-flex flex-align-center">
       <div class="desktop:grid-col-7 tablet:grid-col-12">
-        <h1 class="font-serif-2xl usa-hero__heading">Send text messages to your participants</h1>
-        <p class="font-sans-lg">Notify.gov is a text messaging service that helps federal, state, local, tribal, and territorial governments more
-        effectively communicate with their program participants.</p>
+        <h1 class="font-serif-2xl usa-hero__heading">Reach people where they are with government-powered text messages</h1>
+        <p class="font-sans-lg">Notify.gov is a text message service that helps federal, state, local, tribal and territorial goverments more effectively communicate with the people who use their services.</p>
         <div class="usa-button-group margin-bottom-5">
           <a class="usa-button usa-button--big margin-right-2" href="{{ url_for('main.sign_in' )}}">Sign in</a>
           if you are an existing pilot partner

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -15,7 +15,7 @@ def test_non_logged_in_user_can_see_homepage(
     client_request.logout()
     page = client_request.get("main.index", _test_page_title=False)
 
-    assert page.h1.text.strip() == ("Send text messages to your participants")
+    assert page.h1.text.strip() == ("Reach people where they are with government-powered text messages")
 
     assert page.select_one("a.usa-button.usa-button--big")["href"] == url_for(
         "main.sign_in",


### PR DESCRIPTION
- [x] Switch text of Notify.gov tagline from Send text messages to your participants to **Reach people where they are with government-powered text messages**

- [x]  Switch text of sub tagline to: **Notify.gov is a text message service that helps federal, state, local, tribal and territorial governments more effectively communicate with the people who use their services.**

![image](https://github.com/GSA/notifications-admin/assets/53159604/2fac2029-9ec7-48cc-871e-5b2c99ecd3c5)