### PR TITLE
878 - Moved the invite team member button to a more obvious place on the page

### DIFF
--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -9,9 +9,19 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="font-body-lg">
-    Team members
-  </h1>
+  <div class="display-flex flex-justify flex-align-center">
+    <h1 class="font-body-xl margin-0">
+      Team members
+    </h1>
+    {% if current_user.has_permissions('manage_service') %}
+      {{ usaButton({
+      "element": "a",
+      "text": "Invite a team member",
+      "href": url_for('.invite_user', service_id=current_service.id),
+      "classes": "usa-button--outline"
+      }) }}
+    {% endif %}
+  </div>
 
   {% if show_search_box %}
     <div data-module="autofocus">
@@ -83,16 +93,5 @@
       </div>
     {% endfor %}
   </div>
-
-  {% if current_user.has_permissions('manage_service') %}
-    <div class="js-stick-at-bottom-when-scrolling">
-      {{ usaButton({
-        "element": "a",
-        "text": "Invite a team member",
-        "href": url_for('.invite_user', service_id=current_service.id),
-        "classes": "usa-button"
-      }) }}
-    </div>
-  {% endif %}
 
 {% endblock %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -775,15 +775,11 @@ def test_should_show_page_for_inviting_user(
 
 
 def test_should_not_show_page_for_inviting_user_without_permissions(
-    client_request,
-    mock_get_template_folders,
-    active_user_empty_permissions
+    client_request, mock_get_template_folders, active_user_empty_permissions
 ):
     client_request.login(active_user_empty_permissions)
     page = client_request.get(
-        "main.invite_user",
-        service_id=SERVICE_ONE_ID,
-        _expected_status=403
+        "main.invite_user", service_id=SERVICE_ONE_ID, _expected_status=403
     )
 
     assert "not allowed to see this page" in page.h1.string.strip()
@@ -815,7 +811,7 @@ def test_should_show_page_for_inviting_user_with_email_prefilled(
         user_id=fake_uuid,
         # We have the user’s name in the H1 but don’t want it duplicated
         # in the page title
-        _test_page_title=False
+        _test_page_title=False,
     )
     assert normalize_spaces(page.select_one("title").text).startswith(
         "Invite a team member"
@@ -830,7 +826,7 @@ def test_should_show_page_if_prefilled_user_is_already_a_team_member(
     mock_get_template_folders,
     fake_uuid,
     active_user_with_permissions,
-    active_caseworking_user
+    active_caseworking_user,
 ):
     client_request.login(active_user_with_permissions)
     mocker.patch(


### PR DESCRIPTION
- Moved it to the top so there's no issue with scrolling
- Removed the sticky scroll-to-bottom js wrapper
- Applied outline style so it doesn't compete with "Send Message" button