### PR TITLE
Remove UTC help text from templates#1009

### DIFF
--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -13,12 +13,7 @@
   <p>For <a class="usa-link" href="{{ url_for("main.security") }}">security</a>, this information is only available for seven days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
   <p>This page describes the statuses you’ll see when you’re signed in to Notify.</p>
 
-  <h2 id="text-message-timezones" class="heading-medium">A note about timezones</h2>
-
-  <p>Notify currently uses UTC (Coordinated Universal Time) for managing and displaying all dates and times in the system.  This means that when you're scheduling messages to send later, or are looking at the time a message was sent, it will be in the UTC timezone.</p>
-
-  <p>You can refer to <a href="https://en.wikipedia.org/wiki/Time_in_the_United_States#United_States_and_regional_time_zones">this chart for help</a> with converting UTC times to your local timezone.</p>
-  <!-- <p>If you’re using the Notify API, read our <a class="usa-link" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p> 
+  <!-- <p>If you’re using the Notify API, read our <a class="usa-link" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p>
 
   <h2 id="email-statuses" class="heading-medium">Emails</h2>
   <div class="bottom-gutter-3-2">

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -18,7 +18,7 @@
 {% block maincolumn_content %}
 
   {{ page_header(page_title) }}
-  
+
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
@@ -51,8 +51,8 @@
     <button class="usa-button" type="submit">
       <span class="usa-search__submit-text">Search </span><img src="/assets/img/usa-icons-bg/search--white.svg"
         class="usa-search__submit-icon" alt="Search" />
-    </button> 
-  
+    </button>
+
   {% endcall %}
 
 
@@ -69,11 +69,6 @@
       <a href="{{ download_link }}" download="download" class="usa-link">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
       &emsp;
       Data available for {{ partials.service_data_retention_days }} days
-    </p>
-    <p class="font-body-sm">
-      <a href="https://en.wikipedia.org/wiki/Time_in_the_United_States#United_States_and_regional_time_zones">View timezone chart</a>
-      &emsp;
-      For help with understanding and converting UTC times
     </p>
   {% endif %}
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -18,7 +18,6 @@
 {% block maincolumn_content %}
 
   {{ page_header(page_title) }}
-
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
@@ -52,7 +51,6 @@
       <span class="usa-search__submit-text">Search </span><img src="/assets/img/usa-icons-bg/search--white.svg"
         class="usa-search__submit-icon" alt="Search" />
     </button>
-
   {% endcall %}
 
 


### PR DESCRIPTION
Ticket #: https://github.com/GSA/notifications-admin/issues/1009

This ticket is about removing UTC help text from message-status and notifications.html

![image](https://github.com/GSA/notifications-admin/assets/53159604/bd576b42-0fee-411d-b624-4d59d64ae687)
![image](https://github.com/GSA/notifications-admin/assets/53159604/7821610e-935b-40f2-977e-2f9a43d25fb6)
