### PR TITLE
Add PII to redis at csv upload time in a way we can retrieve it easily

### DIFF
--- a/app/s3_client/s3_csv_client.py
+++ b/app/s3_client/s3_csv_client.py
@@ -9,6 +9,7 @@ from app.s3_client import (
     get_s3_object,
     set_s3_metadata,
 )
+from app.utils.redis_util import add_row_data_to_redis
 
 FILE_LOCATION_STRUCTURE = "service-{}-notify/{}.csv"
 
@@ -40,6 +41,7 @@ def s3upload(service_id, filedata):
         access_key=access_key,
         secret_key=secret_key,
     )
+    add_row_data_to_redis(filedata["data"], upload_id)
     return upload_id
 
 

--- a/app/utils/redis_util.py
+++ b/app/utils/redis_util.py
@@ -1,3 +1,4 @@
+import app.s3_client.s3_csv_client as s3_csv_client
 from app.extensions import RedisClient as redis_client
 
 
@@ -51,3 +52,11 @@ def get_csv_row(job_id, row_number):
         row_dict[column] = row_list[index]
         index = index + 1
     return row_dict
+
+
+def refresh_job(service_id, job_id):
+    # In the event we make a call to fetch a phone number or csv row data
+    # and it is not there because the data has been purged from redis,
+    # we can refresh it making this call
+    data = s3_csv_client.s3download(service_id, job_id)
+    add_row_data_to_redis(data, job_id)

--- a/app/utils/redis_util.py
+++ b/app/utils/redis_util.py
@@ -1,0 +1,28 @@
+from app.extensions import RedisClient as redis_client
+
+
+def add_row_data_to_redis(data, job_id):
+    # Take all the data the user upload and assume it is all PII
+    # Store a copy of each row to redis
+    # As a convenience, because the phone number is what we use the most,
+    # store the phone by itself as well so it can be retrieved faster
+    rows = data.split("\r\n")
+    column_headers = rows[0]
+    redis_client.set(f"job_{job_id}_column_headers", column_headers)
+
+    column_list = column_headers.split(",")
+    phone_index = 0
+    for column in column_list:
+        if column == "phone number":
+            break
+        phone_index = phone_index + 1
+
+    rows.pop(0)
+    row_count = 0
+    for row in rows:
+        row_list = row.split(",")
+        redis_client.set(f"job_{job_id}_row_{row_count}", row)
+        redis_client.set(
+            f"job_{job_id}_row_{row_count}_phone_number", row_list[phone_index]
+        )
+        row_count = row_count + 1

--- a/sample.env
+++ b/sample.env
@@ -36,10 +36,4 @@ API_HOST_NAME=http://localhost:6011
 REDIS_URL=redis://localhost:6379/0
 
 # Login.gov
-LOGIN_DOT_GOV_CLIENT_ID="urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:test_notify_gov"
-LOGIN_DOT_GOV_USER_INFO_URL="https://idp.int.identitysandbox.gov/api/openid_connect/userinfo"
-LOGIN_DOT_GOV_ACCESS_TOKEN_URL="https://idp.int.identitysandbox.gov/api/openid_connect/token"
-LOGIN_DOT_GOV_LOGOUT_URL="https://idp.int.identitysandbox.gov/openid_connect/logout?client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:test_notify_gov&post_logout_redirect_uri=http://localhost:6012/sign-out"
-LOGIN_DOT_GOV_BASE_LOGOUT_URL="https://idp.int.identitysandbox.gov/openid_connect/logout?"
-LOGIN_DOT_GOV_SIGNOUT_REDIRECT="http://localhost:6012/sign-out"
-LOGIN_DOT_GOV_INITIAL_SIGNIN_URL="https://idp.int.identitysandbox.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:test_notify_gov&nonce=01234567890123456789012345&prompt=select_account&redirect_uri=http://localhost:6012/sign-in&response_type=code&scope=openid+email&state=abcdefghijklmnopabcdefghijklmnop"
+(Get login.gov variables from  https://docs.google.com/document/d/17Iv3cIsIo4ZU1FqryKpXZdmIDbOj5ZRj0rjgNv4zNBg)

--- a/tests/app/utils/test_redis_util.py
+++ b/tests/app/utils/test_redis_util.py
@@ -1,6 +1,13 @@
+from unittest.mock import call
+
 import pytest
 
-from app.utils.redis_util import add_row_data_to_redis, get_csv_row, get_phone_number
+from app.utils.redis_util import (
+    add_row_data_to_redis,
+    get_csv_row,
+    get_phone_number,
+    refresh_job,
+)
 
 
 @pytest.mark.parametrize(
@@ -100,3 +107,52 @@ def test_get_csv_row(
 
     mock_redis_get.assert_called_with(f"job_{job_id}_row_0")
     assert csv_row == expected_val
+
+
+@pytest.mark.parametrize(
+    (
+        "data",
+        "job_id",
+        "expected_key",
+        "expected_val",
+        "expected_columns",
+        "expected_row",
+    ),
+    [
+        (
+            "phone number\r\n15555555555",
+            "aaa",
+            "job_aaa_row_0_phone_number",
+            "15555555555",
+            "phone number",
+            "15555555555",
+        ),
+        (
+            "ssn,phone number\r\n555-55-5555,15556666666",
+            "bbb",
+            "job_bbb_row_0_phone_number",
+            "15556666666",
+            "ssn,phone number",
+            "555-55-5555,15556666666",
+        ),
+    ],
+)
+def test_refresh_job(
+    mocker, data, job_id, expected_key, expected_val, expected_columns, expected_row
+):
+    mock_redis_set = mocker.patch(
+        "app.extensions.RedisClient.set",
+    )
+    mock_download = mocker.patch(
+        "app.s3_client.s3_csv_client.s3download",
+        return_value=data,
+    )
+    refresh_job("service_id", job_id)
+    mock_download.assert_called_once_with("service_id", job_id)
+    assert mock_redis_set.call_count == 3
+    calls = [
+        call(f"job_{job_id}_column_headers", expected_columns),
+        call(f"job_{job_id}_row_0", expected_row),
+        call(f"job_{job_id}_row_0_phone_number", expected_val),
+    ]
+    mock_redis_set.assert_has_calls(calls)

--- a/tests/app/utils/test_redis_util.py
+++ b/tests/app/utils/test_redis_util.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.utils.redis_util import add_row_data_to_redis
+
+
+@pytest.mark.parametrize(
+    ("data", "job_id", "expected_key", "expected_val"),
+    [
+        (
+            "phone number\r\n15555555555",
+            "aaa",
+            "job_aaa_row_0_phone_number",
+            "15555555555",
+        ),
+        (
+            "ssn,phone number\r\n555-55-5555,15556666666",
+            "bbb",
+            "job_bbb_row_0_phone_number",
+            "15556666666",
+        ),
+    ],
+)
+def test_add_data_to_redis(mocker, data, job_id, expected_key, expected_val):
+    mock_redis = mocker.patch("app.extensions.RedisClient.set")
+
+    add_row_data_to_redis(data, job_id)
+
+    mock_redis.assert_called_with(expected_key, expected_val)

--- a/tests/app/utils/test_redis_util.py
+++ b/tests/app/utils/test_redis_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.utils.redis_util import add_row_data_to_redis
+from app.utils.redis_util import add_row_data_to_redis, get_csv_row, get_phone_number
 
 
 @pytest.mark.parametrize(
@@ -21,8 +21,82 @@ from app.utils.redis_util import add_row_data_to_redis
     ],
 )
 def test_add_data_to_redis(mocker, data, job_id, expected_key, expected_val):
-    mock_redis = mocker.patch("app.extensions.RedisClient.set")
+    mock_redis_set = mocker.patch("app.extensions.RedisClient.set")
 
     add_row_data_to_redis(data, job_id)
 
-    mock_redis.assert_called_with(expected_key, expected_val)
+    mock_redis_set.assert_called_with(expected_key, expected_val)
+
+
+@pytest.mark.parametrize(
+    ("data", "job_id", "expected_key", "expected_val"),
+    [
+        (
+            "phone number\r\n15555555555",
+            "aaa",
+            "job_aaa_row_0_phone_number",
+            "15555555555",
+        ),
+        (
+            "ssn,phone number\r\n555-55-5555,15556666666",
+            "bbb",
+            "job_bbb_row_0_phone_number",
+            "15556666666",
+        ),
+    ],
+)
+def test_get_phone_number(mocker, data, job_id, expected_key, expected_val):
+    mock_redis_get = mocker.patch(
+        "app.extensions.RedisClient.get", return_value=expected_val
+    )
+
+    phone_number = get_phone_number(job_id, 0)
+
+    mock_redis_get.assert_called_with(f"job_{job_id}_row_0_phone_number")
+    assert phone_number == expected_val
+
+
+@pytest.mark.parametrize(
+    (
+        "data",
+        "job_id",
+        "expected_key",
+        "expected_val",
+        "expected_columns",
+        "expected_raw_row",
+    ),
+    [
+        (
+            "phone number\r\n15555555555",
+            "aaa",
+            "job_aaa_row_0",
+            {"phone number": "15555555555"},
+            "phone number",
+            "15555555555",
+        ),
+        (
+            "ssn,phone number\r\n555-55-5555,15556666666",
+            "bbb",
+            "job_bbb_row_0r",
+            {"ssn": "555-55-5555", "phone number": "15556666666"},
+            "ssn,phone number",
+            "555-55-5555,15556666666",
+        ),
+    ],
+)
+def test_get_csv_row(
+    mocker, data, job_id, expected_key, expected_val, expected_columns, expected_raw_row
+):
+    mock_redis_get = mocker.patch(
+        "app.extensions.RedisClient.get", side_effect=[expected_raw_row, expected_val]
+    )
+
+    mock_column_headers = mocker.patch(
+        "app.utils.redis_util.get_csv_column_headers", return_value=expected_columns
+    )
+
+    csv_row = get_csv_row(job_id, 0)
+    mock_column_headers.assert_called_with(job_id)
+
+    mock_redis_get.assert_called_with(f"job_{job_id}_row_0")
+    assert csv_row == expected_val


### PR DESCRIPTION
At csv upload time:

1. put the column headers for the job into redis
2. put each row into redis
3. put phone number into redis as a convenience lookup

At report/dashboard generation time:

1. retrieve phone number and/or entire row from redis
2. If the cache has been cleared, refresh it by downloading the s3 file for the job and adding everything to redis again.