### PR TITLE
The error message for unsupported characters is very hard to find#967

### DIFF
--- a/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
+++ b/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
@@ -475,3 +475,7 @@ details form {
   padding-left: 5px;
   letter-spacing: 0.04em;
 }
+
+.edit-textbox-error-mt {
+   margin-top: 1.5rem;
+}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -19,16 +19,21 @@
     class="form-group{% if field.errors %} form-group-error{% endif %} {{ extra_form_group_classes }}"
     data-module="{% if autofocus %}autofocus{% elif colour_preview %}colour-preview{% endif %}"
   >
+    {% if field.errors %}
+      <div class="usa-alert usa-alert--error edit-textbox-error-mt" role="alert">
+        <div class="usa-alert__body">
+          <h4 class="usa-alert__heading">Error message</h4>
+          <p class="usa-alert__text" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
+            {% if not safe_error_message %}{{ field.errors[0] }}{% else %}{{ field.errors[0]|safe }}{% endif %}
+          </p>
+        </div>
+      </div>
+    {% endif %}
     <label class="usa-label" for="{{ field.name }}">
       {% if label %}
         {{ label }}
       {% else %}
         {{ field.label.text }}
-      {% endif %}
-      {% if field.errors %}
-        <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
-          {% if not safe_error_message %}{{ field.errors[0] }}{% else %}{{ field.errors[0]|safe }}{% endif %}
-        </span>
       {% endif %}
     </label>
     {% if hint %}


### PR DESCRIPTION
**Issue ticket**: https://github.com/GSA/notifications-admin/issues/967
**Goal**: To add a noticeable alert message for users to see when an unwanted character is being used. 
**Before**: 
![image](https://github.com/GSA/notifications-admin/assets/53159604/1e7dd2a8-cf74-4422-850d-ab186ce9b4dd)
**After**: 
![image](https://github.com/GSA/notifications-admin/assets/53159604/e338c621-a53e-47b1-9f9d-b1667b2b3ca8)
