### PR TITLE
Fix sms allowance switching to live

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -124,6 +124,14 @@ def service_switch_live(service_id):
 
     if form.validate_on_submit():
         current_service.update_status(live=form.enabled.data)
+        if form.enabled.data is True:
+            billing_api_client.create_or_update_free_sms_fragment_limit(
+                service_id, 250000
+            )
+        else:
+            billing_api_client.create_or_update_free_sms_fragment_limit(
+                service_id, 40000
+            )
         return redirect(url_for(".service_settings", service_id=service_id))
 
     return render_template(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2323,6 +2323,10 @@ def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too com
         "app.service_api_client.get_global_notification_count", side_effect=_get
     )
 
+    mocker.patch(
+        "app.billing_api_client.create_or_update_free_sms_fragment_limit", autospec=True
+    )
+
     class ClientRequest:
         @staticmethod
         @contextmanager


### PR DESCRIPTION
Added conditional check to update sms allowance when switching a service to live or restricting it.

Fixed tests with mocked call to `billing_api_client` in `client_request`.

This fix on the front end doesn't address the issue where the values aren't updating in the dashboard unless:

1. We set the sms allowance manually in the settings.
2. Switch to live mode or back to trial.