### PR TITLE
Sentence about 5 minutes til message receipts doesn't appear #1022

### DIFF
--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -38,6 +38,9 @@
       </div>
     {% endif %}
 
+    <p class="notification-status">
+      Messages will remain in pending state until carrier status is received, typically 5 minutes.
+    </p>
     {% if not job.processing_finished %}
       <div
         data-module="update-content"

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -353,10 +353,6 @@ def test_should_show_scheduled_job(
         "Sending Two week reminder today at 00:00 US/Eastern"
     )
 
-    # assert normalize_spaces(page.select_one("main p.notification-status").text) == (
-    # "Messages will remain in pending state until carrier status is received, typically 5 minutes."
-    # )
-
     assert page.select("main p a")[0]["href"] == url_for(
         "main.view_template_version",
         service_id=SERVICE_ONE_ID,
@@ -487,6 +483,7 @@ def test_should_show_updates_for_scheduled_job_as_json(
 def test_time_left(job_created_at, expected_message):
     assert get_time_left(job_created_at) == expected_message
 
+
 def test_should_show_message_note(
     client_request,
     mock_get_service_template,
@@ -502,5 +499,5 @@ def test_should_show_message_note(
     )
 
     assert normalize_spaces(page.select_one("main p.notification-status").text) == (
-    "Messages will remain in pending state until carrier status is received, typically 5 minutes."
+        "Messages will remain in pending state until carrier status is received, typically 5 minutes."
     )

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -349,9 +349,14 @@ def test_should_show_scheduled_job(
         job_id=fake_uuid,
     )
 
-    assert normalize_spaces(page.select("main p")[1].text) == (
+    assert normalize_spaces(page.select("main div p")[1].text) == (
         "Sending Two week reminder today at 00:00 US/Eastern"
     )
+
+    # assert normalize_spaces(page.select_one("main p.notification-status").text) == (
+    # "Messages will remain in pending state until carrier status is received, typically 5 minutes."
+    # )
+
     assert page.select("main p a")[0]["href"] == url_for(
         "main.view_template_version",
         service_id=SERVICE_ONE_ID,
@@ -481,3 +486,21 @@ def test_should_show_updates_for_scheduled_job_as_json(
 @freeze_time("2016-01-10 12:00:00.000000")
 def test_time_left(job_created_at, expected_message):
     assert get_time_left(job_created_at) == expected_message
+
+def test_should_show_message_note(
+    client_request,
+    mock_get_service_template,
+    mock_get_scheduled_job,
+    mock_get_service_data_retention,
+    mock_get_notifications,
+    fake_uuid,
+):
+    page = client_request.get(
+        "main.view_job",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+    )
+
+    assert normalize_spaces(page.select_one("main p.notification-status").text) == (
+    "Messages will remain in pending state until carrier status is received, typically 5 minutes."
+    )


### PR DESCRIPTION
### Ticket: https://github.com/GSA/notifications-admin/issues/1022

**Issue**:
This notification message was not visible within the individual job view. 
"Messages will remain in pending state until carrier status is received, typically 5 minutes".

### Before:
![image](https://github.com/GSA/notifications-admin/assets/53159604/aa0a779d-f17e-4bcc-928d-f29c12fa2c3f)


### After: 
![image](https://github.com/GSA/notifications-admin/assets/53159604/787a433f-61e2-42bb-8a10-84b543f44ee3)
