### PR TITLE
Add no_proxy environment variable

### DIFF
--- a/.profile
+++ b/.profile
@@ -6,3 +6,4 @@
 export NEW_RELIC_PROXY_HOST=$egress_proxy
 export http_proxy=$egress_proxy
 export https_proxy=$egress_proxy
+export no_proxy="apps.internal"


### PR DESCRIPTION
This changeset adds the `no_proxy` environment variable to be set at the time our app runs to exclude the internal apps running within our platform that are handled by Cloud Foundry network policies instead.  Without this in place, the egress proxy will not allow our deployed apps to talk with one another.

## Security Considerations

- Internal apps within a Cloud Foundry environment can be configured to be able to see and speak to each other via [explicitly defined network policies](https://docs.cloudfoundry.org/concepts/understand-cf-networking.html#securing-traffic) that account for secure container-to-container traffic within the platform.  We want to leverage these for our own apps, but maintain the egress proxy for any traffic going out to external resources.