### PR TITLE
BUG: Fix UI Time Sent column to match time the message was created_at

### DIFF
--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -67,7 +67,7 @@
                   {{ notification.template.name }}
                 </th>
                 <th class="table-field">
-                  {{ (notification.updated_at or notification.created_at)| format_datetime_short_america }}
+                  {{ notification.created_at | format_datetime_short_america }}
                 </th>
                 <th class="table-field">
                   {{ notification.created_by.name }}


### PR DESCRIPTION
This PR is to fix the UI Recent Batch to reflect the created_at time and not updated_at time. 

![image](https://github.com/GSA/notifications-admin/assets/53159604/932c818e-e3c8-4959-8c90-4c9f80ee88ff)
