### PR TITLE
notify-admin-1148 make sure one-off files get written to db

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -880,14 +880,20 @@ def send_notification(service_id, template_id):
         service_id, job_id=upload_id, include_one_off=True
     )
     attempts = 0
-    while notifications["total"] == 0 and attempts < 5:
+
+    # The response can come back in different forms of incompleteness
+    while (
+        notifications["total"] == 0
+        and notifications["notifications"] == []
+        and attempts < 50
+    ):
         notifications = notification_api_client.get_notifications_for_service(
             service_id, job_id=upload_id, include_one_off=True
         )
         time.sleep(0.1)
         attempts = attempts + 1
 
-    if notifications["total"] == 0 and attempts == 5:
+    if notifications["total"] == 0 and attempts == 50:
         # This shows the job we auto-generated for the user
         return redirect(
             url_for(


### PR DESCRIPTION
There were two problems:

1.  Five tries might not be enough tries once in a while.
2. More importantly, that check on whether the notification count was > 0 was not reliable.  In other words, the call to the back end could return a response that is in a messed up state (the count field is > 0 but there are no notifications in the notification field).  So we needed to do more sanity checking.

I was able to reproduce the original reported problem and after these changes I cannot.