### PR TITLE
Fix Terraform commands and actions

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -88,6 +88,8 @@ The below steps rely on you first configuring access to the Terraform state in s
     terraform plan
     ```
 
+    If the `terraform init` command fails, you may need to run `terraform init -upgrade` to make sure new module versions are picked up.
+
 1. Apply changes with `terraform apply`.
 
 1. Remove the space deployer service instance if it doesn't need to be used again, such as when manually running terraform once.

--- a/terraform/bootstrap/providers.tf
+++ b/terraform/bootstrap/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.15.5"
+      version = "0.53.0"
     }
   }
 }

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "redis" {
-  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -17,7 +17,7 @@ module "redis" {
 }
 
 module "logo_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name

--- a/terraform/demo/providers.tf
+++ b/terraform/demo/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.15.5"
+      version = "0.53.0"
     }
   }
 

--- a/terraform/demo/providers.tf
+++ b/terraform/demo/providers.tf
@@ -12,7 +12,6 @@ terraform {
     key     = "admin.tfstate.demo"
     encrypt = "true"
     region  = "us-gov-west-1"
-    profile = "notify-terraform-backend"
   }
 }
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,7 +11,7 @@ data "cloudfoundry_space" "dev" {
 }
 
 module "logo_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name

--- a/terraform/development/providers.tf
+++ b/terraform/development/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.50.7"
+      version = "0.53.0"
     }
   }
 }

--- a/terraform/development/reset.sh
+++ b/terraform/development/reset.sh
@@ -47,7 +47,7 @@ if [[ ! -s "secrets.auto.tfvars" ]]; then
 fi
 
 echo "Importing terraform state for $username"
-terraform init
+terraform init -upgrade
 
 key_name=$username-admin-dev-key
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "redis" {
-  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -17,7 +17,7 @@ module "redis" {
 }
 
 module "logo_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -50,7 +50,7 @@ module "api_network_route" {
 #       https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service
 ###########################################################################
 module "domain" {
-  source = "github.com/18f/terraform-cloudgov//domain?ref=v0.5.2"
+  source = "github.com/18f/terraform-cloudgov//domain?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name

--- a/terraform/production/providers.tf
+++ b/terraform/production/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.15.5"
+      version = "0.53.0"
     }
   }
 

--- a/terraform/production/providers.tf
+++ b/terraform/production/providers.tf
@@ -12,7 +12,6 @@ terraform {
     key     = "admin.tfstate.prod"
     encrypt = "true"
     region  = "us-gov-west-1"
-    profile = "notify-terraform-backend"
   }
 }
 

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "redis" {
-  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -17,7 +17,7 @@ module "redis" {
 }
 
 module "logo_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name

--- a/terraform/sandbox/providers.tf
+++ b/terraform/sandbox/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.15.5"
+      version = "0.53.0"
     }
   }
 

--- a/terraform/sandbox/providers.tf
+++ b/terraform/sandbox/providers.tf
@@ -12,7 +12,6 @@ terraform {
     key     = "admin.tfstate.sandbox"
     encrypt = "true"
     region  = "us-gov-west-1"
-    profile = "notify-terraform-backend"
   }
 }
 

--- a/terraform/shared/container_networking/providers.tf
+++ b/terraform/shared/container_networking/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = "0.53.0"
     }
   }
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "redis" {
-  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -17,7 +17,7 @@ module "redis" {
 }
 
 module "logo_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.2.0"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name

--- a/terraform/staging/providers.tf
+++ b/terraform/staging/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.15.5"
+      version = "0.53.0"
     }
   }
 

--- a/terraform/staging/providers.tf
+++ b/terraform/staging/providers.tf
@@ -12,7 +12,6 @@ terraform {
     key     = "admin.tfstate.stage"
     encrypt = "true"
     region  = "us-gov-west-1"
-    profile = "notify-terraform-backend"
   }
 }
 


### PR DESCRIPTION
This changeset updates the Cloud Foundry Terraform to its latest release.  Our file were previously referencing a very old version, which was contributing to infrastructure check and deployment failures.

There are several things at play here, though the likely culprit is a recent update to the `dflook/terraform-check@v1` action.  This pulled in an update to Terraform itself (`1.6.6` to `1.7.0`), [which may have exposed an undocumented AWS provider change](https://discuss.hashicorp.com/t/error-error-configuring-terraform-aws-provider-failed-to-get-shared-config-profile-default/39417/2).  What ended up happening was the `profile` attribute being set wasn't being found because that needed to be set to a credentials file instead of just falling back on the environment variables for AWS credentials as it had been up until the point of the failures starting.

Removing the `profile` attribute has fixed the issue and now the Terraform commands and actions run again.

As a part of this work though, we also updated all of our references of the cloudfoundry-community/cloudfoundry module to the latest release (`0.53.0`) and we updated references to the `18F/terraform-cloudgov` module to its latest release (`0.7.1`).

## Security Considerations

- We need to make sure our infrastructure checks are still fully operational.
- We need to be able to deploy to production when we're ready to update.
- Helps keep our dependencies up-to-date.