### PR TITLE
fix sent time

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -172,7 +172,7 @@
       <p class="status-hint margin-0 width-card ">
         {{ notification.status|format_notification_status_as_time(
           notification.created_at|format_datetime_short,
-          (notification.updated_at or notification.created_at)|format_datetime_short
+          (notification.sent_at or notification.created_at)|format_datetime_short
         ) }}
         </p>
       {% if displayed_on_single_line %}</span>{% endif %}


### PR DESCRIPTION
Right now the notification.updated_at field is broken on the back end.  It is updating every minute, forever.  No idea why.  I will write a ticket to investigate and fix this, but to get the front end working in the meantime we can replace 'updated_at' with 'sent_at'.   