### PR TITLE
Bundle stats with service object

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -381,6 +381,10 @@ def load_service_before_request():
                 request_ctx.service = Service(
                     service_api_client.get_service(service_id)["data"]
                 )
+                stats = service_api_client.get_service_statistics(
+                    service_id, limit_days=7
+                )
+                request_ctx.service.stats = stats
             except HTTPError as exc:
                 # if service id isn't real, then 404 rather than 500ing later because we expect service to be set
                 if exc.status_code == 404:

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -325,6 +325,7 @@ def test_route_permissions(
         def _get(mocker):
             return {"count": 0}
 
+        mocker.patch("app.service_api_client.get_service_statistics")
         mocker.patch(
             "app.service_api_client.get_global_notification_count", side_effect=_get
         )
@@ -357,6 +358,8 @@ def test_route_invalid_permissions(
 
         def _get(mocker):
             return {"count": 0}
+
+        mocker.patch("app.service_api_client.get_service_statistics")
 
         mocker.patch(
             "app.service_api_client.get_global_notification_count", side_effect=_get

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2319,6 +2319,8 @@ def client_request(logged_in_client, mocker, service_one):  # noqa (C901 too com
     def _get(mocker):
         return {"count": 0}
 
+    mocker.patch("app.service_api_client.get_service_statistics")
+
     mocker.patch(
         "app.service_api_client.get_global_notification_count", side_effect=_get
     )


### PR DESCRIPTION
Used `get_service_statistics` `get` route to grab the stats for the service. Then attached the stats to the service object before the request when the service is loaded.

<img width="1920" alt="Screen Shot 2024-02-01 at 10 37 20 AM" src="https://github.com/GSA/notifications-admin/assets/90117200/2b3f615f-bf43-41a7-982a-7ba4a7eae97e">
