### PR TITLE
notify-api-771 fix columns in reports and fix govuk_frontend_jinja

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,6 @@ from flask_login import LoginManager, current_user
 from flask_talisman import Talisman
 from flask_wtf import CSRFProtect
 from flask_wtf.csrf import CSRFError
-from govuk_frontend_jinja.flask_ext import init_govuk_frontend
 from itsdangerous import BadSignature
 from notifications_python_client.errors import HTTPError
 from notifications_utils import logging, request_helper
@@ -114,6 +113,7 @@ from app.notify_client.template_statistics_api_client import template_statistics
 from app.notify_client.upload_api_client import upload_api_client
 from app.notify_client.user_api_client import user_api_client
 from app.url_converters import SimpleDateTypeConverter, TemplateTypeConverter
+from app.utils.govuk_frontend_jinja.flask_ext import init_govuk_frontend
 
 login_manager = LoginManager()
 csrf = CSRFProtect()

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -78,21 +78,21 @@ def generate_notifications_csv(**kwargs):
             template=get_sample_template(kwargs["template_type"]),
         )
         original_column_headers = original_upload.column_headers
-        fieldnames = (
-            ["Row number"]
-            + original_column_headers
-            + [
-                "Template",
-                "Type",
-                "Sent by",
-                "Job",
-                "Carrier",
-                "Carrier Response",
-                "Status",
-                "Time",
-            ]
-        )
+        fieldnames = [
+            "Template",
+            "Type",
+            "Sent by",
+            "Job",
+            "Carrier",
+            "Carrier Response",
+            "Status",
+            "Time",
+        ]
+        for header in original_column_headers:
+            fieldnames.append(header)
+
     else:
+        # TODO This is deprecated because everything should be a job now, is it ever invoked?
         fieldnames = [
             "Recipient",
             "Template",
@@ -104,6 +104,7 @@ def generate_notifications_csv(**kwargs):
             "Status",
             "Time",
         ]
+        current_app.logger.warning("Invoking deprecated report format")
 
     yield ",".join(fieldnames) + "\n"
 
@@ -118,26 +119,23 @@ def generate_notifications_csv(**kwargs):
 
             current_app.logger.info(f"\n\n{notification}")
             if kwargs.get("job_id"):
-                values = (
-                    [
-                        notification["row_number"],
-                    ]
-                    + [
+                values = [
+                    notification["template_name"],
+                    notification["template_type"],
+                    notification["created_by_name"],
+                    notification["job_name"],
+                    notification["carrier"],
+                    notification["provider_response"],
+                    notification["status"],
+                    preferred_tz_created_at,
+                ]
+                for header in original_column_headers:
+                    values.append(
                         original_upload[notification["row_number"] - 1].get(header).data
-                        for header in original_column_headers
-                    ]
-                    + [
-                        notification["template_name"],
-                        notification["template_type"],
-                        notification["created_by_name"],
-                        notification["job_name"],
-                        notification["carrier"],
-                        notification["provider_response"],
-                        notification["status"],
-                        preferred_tz_created_at,
-                    ]
-                )
+                    )
+
             else:
+                # TODO This is deprecated, should not be invoked.  See above
                 values = [
                     notification["recipient"],
                     notification["template_name"],

--- a/app/utils/govuk_frontend_jinja/__init__.py
+++ b/app/utils/govuk_frontend_jinja/__init__.py
@@ -1,0 +1,1 @@
+from .templates import Environment  # noqa

--- a/app/utils/govuk_frontend_jinja/flask_ext.py
+++ b/app/utils/govuk_frontend_jinja/flask_ext.py
@@ -1,0 +1,30 @@
+from flask.templating import Environment as FlaskEnvironment
+from jinja2 import select_autoescape
+
+from app.utils.govuk_frontend_jinja.templates import Environment as NunjucksEnvironment
+from app.utils.govuk_frontend_jinja.templates import (
+    NunjucksExtension,
+    NunjucksUndefined,
+)
+
+
+class Environment(NunjucksEnvironment, FlaskEnvironment):
+    pass
+
+
+def init_govuk_frontend(app):
+    """Use the govuk_frontend_jinja Jinja environment in a Flask app
+
+    >>> from flask import Flask
+    >>> app = Flask("cheeseshop_service")
+    >>> init_govuk_frontend(app)
+    """
+    app.jinja_environment = Environment
+    app.select_jinja_autoescape = select_autoescape(
+        ("html", "htm", "xml", "xhtml", "njk")
+    )
+    jinja_options = app.jinja_options.copy()
+    jinja_options["extensions"].append(NunjucksExtension)
+    jinja_options["undefined"] = NunjucksUndefined
+    app.jinja_options = jinja_options
+    return app

--- a/app/utils/govuk_frontend_jinja/templates.py
+++ b/app/utils/govuk_frontend_jinja/templates.py
@@ -1,0 +1,292 @@
+import builtins
+import os.path as path
+import re
+from collections.abc import Sized
+
+import jinja2
+import jinja2.ext
+from jinja2.lexer import Token
+from markupsafe import Markup
+
+
+def njk_to_j2(template):
+    # Some component templates (such as radios) use `items` as the key of
+    # an object element. However `items` is also the name of a dictionary
+    # method in Python, and Jinja2 will prefer to return this attribute
+    # over the dict item. Handle specially.
+    template = re.sub(r"\.items\b", ".items__njk", template)
+
+    # Some component templates (such as radios) append the loop index to a
+    # string. As the loop index is an integer this causes a TypeError in
+    # Python. Jinja2 has an operator `~` for string concatenation that
+    # converts integers to strings.
+    template = template.replace("+ loop.index", "~ loop.index")
+
+    # The Character Count component in version 3 concatenates the word count
+    # with the hint text. As the word count is an integer this causes a
+    # TypeError in Python. Jinja2 has an operator `~` for string
+    # concatenation that converts integers to strings.
+    template = template.replace(
+        "+ (params.maxlength or params.maxwords) +",
+        "~ (params.maxlength or params.maxwords) ~",
+    )
+
+    # Nunjucks uses elseif, Jinja uses elif
+    template = template.replace("elseif", "elif")
+
+    # Some component templates (such as input) call macros with params as
+    # an object which has unqoted keys. This causes Jinja to silently
+    # ignore the values.
+    template = re.sub(
+        r"""^([ ]*)([^ '"#\r\n:]+?)\s*:""", r"\1'\2':", template, flags=re.M
+    )
+
+    # govukFieldset can accept a call block argument, however the Jinja
+    # compiler does not detect this as the macro body is included from
+    # the template file. A workaround is to patch the declaration of the
+    # macro to include an explicit caller argument.
+    template = template.replace(
+        "macro govukFieldset(params)", "macro govukFieldset(params, caller=none)"
+    )
+
+    # Many components feature an attributes field, which is supposed to be
+    # a dictionary. In the template for these components, the keys and values
+    # are iterated. In Python, the default iterator for a dict is .keys(), but
+    # we want .items().
+    # This only works because our undefined implements .items()
+    # We've tested this explicitly with: govukInput, govukCheckbox, govukTable,
+    # govukSummaryList
+    template = re.sub(
+        r"for attribute, value in (params|item|cell|action).attributes",
+        r"for attribute, value in \1.attributes.items()",
+        template,
+        flags=re.M,
+    )
+
+    # Some templates try to set a variable in an outer block, which is not
+    # supported in Jinja. We create a namespace in those templates to get
+    # around this.
+    template = re.sub(
+        r"""^([ ]*)({% set describedBy =( params.*describedBy if params.*describedBy else)? "" %})""",
+        r"\1{%- set nonlocal = namespace() -%}\n\1\2",
+        template,
+        flags=re.M,
+    )
+    # Change any references to describedBy to be nonlocal.describedBy,
+    # unless describedBy is a dictionary key (i.e. quoted or dotted).
+    template = re.sub(r"""(?<!['".])describedBy""", r"nonlocal.describedBy", template)
+    # govukSummaryList
+    template = re.sub(
+        r"""^([ ]*)({% set anyRowHasActions = false %})""",
+        r"\1{%- set nonlocal = namespace() -%}\n\1\2",
+        template,
+        flags=re.M,
+    )
+    template = re.sub(
+        r"""(?<!['".])anyRowHasActions""", r"nonlocal.anyRowHasActions", template
+    )
+    # govukRadios and govukCheckboxes
+    # Since both of these templates set describedBy before isConditional, we can use
+    # the existing nonlocal.
+    template = re.sub(
+        r"""(?<!['".])isConditional""", r"nonlocal.isConditional", template
+    )
+
+    # Issue#16: some component templates test the length of an array by trying
+    # to get an attribute `.length`. We need to handle this specially because
+    # .length isn't a thing in python
+    template = re.sub(r"\.length\b", ".length__njk", template)
+
+    # see `indent_njk`
+    template = re.sub(re.escape("| indent") + r"\b", "| indent_njk", template)
+
+    return template
+
+
+def indent_njk(s, width=4, first=False, blank=False, indentfirst=None):
+    """Return a copy of the string with each line indented by 4 spaces."""
+
+    # Copied from
+    # https://github.com/pallets/jinja/blob/a2f5e2c7972c4d5148c1c75c724e24950d8605bc/jinja2/filters.py#L536-L580
+    # to include an unreleased fix for https://github.com/pallets/jinja/pull/826
+    # which causes the file upload component to escape HTML markup.
+    # TODO: Remove once jinja2 2.11 is released and in use.
+
+    if indentfirst is not None:
+        first = indentfirst
+
+    indention = " " * width
+    newline = "\n"
+
+    if isinstance(s, Markup):
+        indention = Markup(indention)
+        newline = Markup(newline)
+
+    s += newline  # this quirk is necessary for splitlines method
+
+    if blank:
+        rv = (newline + indention).join(s.splitlines())
+    else:
+        lines = s.splitlines()
+        rv = lines.pop(0)
+
+        if lines:
+            rv += newline + newline.join(
+                indention + line if line else line for line in lines
+            )
+
+    if first:
+        rv = indention + rv
+
+    return rv
+
+
+class NunjucksExtension(jinja2.ext.Extension):
+    def filter_stream(self, stream):
+        if stream.filename and stream.filename.endswith(".njk"):
+            return self.filter_njk_stream(stream)
+        else:
+            return stream
+
+    def filter_njk_stream(self, stream):
+        for token in stream:
+            # patch strict equality operator `===`
+            if token.test("eq:==") and stream.current.test("assign:="):
+                yield Token(token.lineno, "name", "is")
+                yield Token(token.lineno, "name", "sameas")
+                stream.skip(1)
+            else:
+                yield token
+
+    def preprocess(self, source, name, filename=None):
+        if filename and filename.endswith(".njk"):
+            return njk_to_j2(source)
+        else:
+            return source
+
+
+class NunjucksUndefined(jinja2.runtime.Undefined):
+    __slots__ = ()
+
+    # copied from https://github.com/pallets/jinja/commit/19133d40593ced72eb28e230588abcc70d8b9f82
+    def __getattr__(self, _):
+        """Make undefined that is chainable, where both
+        __getattr__ and __getitem__ return itself rather than
+        raising an :exc:`UndefinedError`:
+        >>> foo = ChainableUndefined(name='foo')
+        >>> str(foo.bar['baz'])
+        ''
+        >>> foo.bar['baz'] + 42
+        Traceback (most recent call last):
+          ...
+        jinja2.exceptions.UndefinedError: 'foo' is undefined
+        """
+        return self
+
+    __getitem__ = __getattr__
+
+    # Allow treating undefined as an (empty) dictionary.
+    # This works because Undefined is an iterable.
+    def items(self):
+        return self
+
+    # Allow escaping with Markup. This is required when
+    # autoescape is enabled. Debugging this issue was
+    # annoying; the error messages were not clear as to
+    # the cause of the issue (see upstream pull request
+    # for info https://github.com/pallets/jinja/pull/1047)
+    def __html__(self):
+        return str(self)
+
+    # attempt to behave a bit like js's `undefined` when concatenation is attempted
+    def __add__(self, other):
+        if isinstance(other, str):
+            return "undefined" + other
+        return super().__add__(other)
+
+    def __radd__(self, other):
+        if isinstance(other, str):
+            return other + "undefined"
+        return super().__radd__(other)
+
+
+class NunjucksCodeGenerator(jinja2.compiler.CodeGenerator):
+    def visit_CondExpr(self, node, frame):
+        if not (self.filename or "").endswith(".njk"):
+            return super().visit_CondExpr(node, frame)
+
+        # else our replacement, which is based on that in
+        # https://github.com/pallets/jinja/blob/c4c4088945a2c12535f539be7f5453b9ca94666c/jinja2/compiler.py#L1613
+        def write_expr2():
+            if node.expr2 is not None:
+                return self.visit(node.expr2, frame)
+            # rather than complaining about a missing else
+            # clause we just assume it to be the empty
+            # string for nunjucks compatibility
+            return self.write('""')
+
+        self.write("(")
+        self.visit(node.expr1, frame)
+        self.write(" if ")
+        self.visit(node.test, frame)
+        self.write(" else ")
+        write_expr2()
+        self.write(")")
+
+
+_njk_signature = "__njk"
+_builtin_function_or_method_type = type({}.keys)
+
+
+class Environment(jinja2.Environment):
+    code_generator_class = NunjucksCodeGenerator
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("extensions", [NunjucksExtension])
+        kwargs.setdefault("undefined", NunjucksUndefined)
+        super().__init__(*args, **kwargs)
+        self.filters["indent_njk"] = indent_njk
+
+    def join_path(self, template, parent):
+        """Enable the use of relative paths in template import statements"""
+        if template.startswith(("./", "../")):
+            return path.normpath(path.join(path.dirname(parent), template))
+        else:
+            return template
+
+    def _handle_njk(method_name):
+        def inner(self, obj, argument):
+            if isinstance(argument, str) and argument.endswith(_njk_signature):
+                # a njk-originated access will always be assuming a dict lookup before an attr
+                final_method_name = "getitem"
+                final_argument = argument[: -len(_njk_signature)]
+            else:
+                final_argument = argument
+                final_method_name = method_name
+
+            # pleasantly surprised that super() works in this context
+            retval = builtins.getattr(super(), final_method_name)(obj, final_argument)
+
+            if (
+                argument == f"length{_njk_signature}"
+                and isinstance(retval, jinja2.runtime.Undefined)
+                and isinstance(obj, Sized)
+            ):
+                return len(obj)
+            if (
+                isinstance(argument, str)
+                and argument.endswith(_njk_signature)
+                and isinstance(retval, _builtin_function_or_method_type)
+            ):
+                # the lookup has probably gone looking for attributes and found a builtin method. because
+                # any njk-originated lookup will have been made to prefer dict lookups over attributes, we
+                # can be fairly sure there isn't a dict key matching this - so we should just call this a
+                # failure.
+                return self.undefined(obj=obj, name=final_argument)
+            return retval
+
+        return inner
+
+    getitem = _handle_njk("getitem")
+
+    getattr = _handle_njk("getattr")

--- a/poetry.lock
+++ b/poetry.lock
@@ -930,28 +930,6 @@ files = [
 requests = "*"
 
 [[package]]
-name = "govuk-frontend-jinja"
-version = "0.5.8-alpha"
-description = "Tools to use the GOV.UK Design System with Jinja-powered Python apps"
-optional = false
-python-versions = "*"
-files = []
-develop = false
-
-[package.dependencies]
-jinja2 = "*"
-
-[package.extras]
-dev = ["pytest", "pytest-flakes", "pytest-helpers-namespace"]
-flask = ["Flask"]
-
-[package.source]
-type = "git"
-url = "https://github.com/alphagov/govuk-frontend-jinja.git"
-reference = "v0.5.8-alpha"
-resolved_reference = "15845e4cca3a05df72c6e13ec6a7e35acc682f52"
-
-[[package]]
 name = "greenlet"
 version = "3.0.1"
 description = "Lightweight in-process concurrent programming"
@@ -1428,16 +1406,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2476,7 +2444,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3088,4 +3055,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "94e6fe2e143f12eaa31f01b5a9206012a6a48908d98daa9fa2f531e986e4a6d3"
+content-hash = "be46f8e90d6213db5c54d62c3a364c0a2a7e50f5c8e5007ad662067a6191c51f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ flask-login = "^0.6"
 flask-talisman = "*"
 flask-wtf = "^1.2"
 govuk-bank-holidays = "==0.13"
-govuk-frontend-jinja = {git = "https://github.com/alphagov/govuk-frontend-jinja.git", tag = "v0.5.8-alpha"}
 gunicorn = {version = "==21.2.0", extras = ["eventlet"]}
 humanize = "~=4.9"
 itsdangerous = "~=2.1"

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -46,9 +46,6 @@ def _get_notifications_csv(
             "notifications": [
                 {
                     "row_number": row_number + i,
-                    "to": recipient,
-                    "recipient": recipient,
-                    "client_reference": "ref 1234",
                     "template_name": template_name,
                     "template_type": template_type,
                     "template": {"name": template_name, "template_type": template_type},
@@ -60,6 +57,9 @@ def _get_notifications_csv(
                     "updated_at": None,
                     "created_by_name": created_by_name,
                     "created_by_email_address": created_by_email_address,
+                    "to": recipient,
+                    "recipient": recipient,
+                    "client_reference": "ref 1234",
                 }
                 for i in range(rows)
             ],
@@ -130,8 +130,6 @@ def test_generate_notifications_csv_without_job(
             2028675309
         """,
             [
-                "Row number",
-                "phone_number",
                 "Template",
                 "Type",
                 "Sent by",
@@ -140,10 +138,9 @@ def test_generate_notifications_csv_without_job(
                 "Carrier Response",
                 "Status",
                 "Time",
+                "phone_number",
             ],
             [
-                "1",
-                "2028675309",
                 "foo",
                 "sms",
                 "Fake Person",
@@ -152,6 +149,7 @@ def test_generate_notifications_csv_without_job(
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
+                "2028675309",
             ],
         ),
         (
@@ -160,11 +158,6 @@ def test_generate_notifications_csv_without_job(
             2028675309,  🐜,🐝,🦀
         """,
             [
-                "Row number",
-                "phone_number",
-                "a",
-                "b",
-                "c",
                 "Template",
                 "Type",
                 "Sent by",
@@ -173,13 +166,12 @@ def test_generate_notifications_csv_without_job(
                 "Carrier Response",
                 "Status",
                 "Time",
+                "phone_number",
+                "a",
+                "b",
+                "c",
             ],
             [
-                "1",
-                "2028675309",
-                "🐜",
-                "🐝",
-                "🦀",
                 "foo",
                 "sms",
                 "Fake Person",
@@ -188,6 +180,10 @@ def test_generate_notifications_csv_without_job(
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
+                "2028675309",
+                "🐜",
+                "🐝",
+                "🦀",
             ],
         ),
         (
@@ -196,11 +192,6 @@ def test_generate_notifications_csv_without_job(
             "2028675309","🐜,🐜","🐝,🐝","🦀"
         """,
             [
-                "Row number",
-                "phone_number",
-                "a",
-                "b",
-                "c",
                 "Template",
                 "Type",
                 "Sent by",
@@ -209,13 +200,12 @@ def test_generate_notifications_csv_without_job(
                 "Carrier Response",
                 "Status",
                 "Time",
+                "phone_number",
+                "a",
+                "b",
+                "c",
             ],
             [
-                "1",
-                "2028675309",
-                "🐜,🐜",
-                "🐝,🐝",
-                "🦀",
                 "foo",
                 "sms",
                 "Fake Person",
@@ -224,6 +214,10 @@ def test_generate_notifications_csv_without_job(
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
+                "2028675309",
+                "🐜,🐜",
+                "🐝,🐝",
+                "🦀",
             ],
         ),
     ],


### PR DESCRIPTION
1. remove "Row number" column, not interest to users
2. put all fixed, guaranteed-to-be-there columns in a determined order, first, then append variable columns that depend on personalization.
3. copy code out of govuk_frontend_jinja package (which no longer exists on GitHub) and paste it directly into our code (in app.utils.govuk_frontend_jinja).  This is deprecated functionality anyway, and will soon be removed.