### PR TITLE
make ChooseTimeForm time zone aware

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -70,7 +70,7 @@ from app.utils.user_permissions import all_ui_permissions, permission_options
 def get_time_value_and_label(future_time):
     preferred_tz = pytz.timezone(get_user_preferred_timezone())
     return (
-        future_time.astimezone(preferred_tz).replace(tzinfo=None).isoformat(),
+        future_time.astimezone(preferred_tz).isoformat(),
         "{} at {} {}".format(
             get_human_day(future_time.astimezone(preferred_tz)),
             get_human_time(future_time.astimezone(preferred_tz)),

--- a/tests/app/main/forms/test_choose_time_form.py
+++ b/tests/app/main/forms/test_choose_time_form.py
@@ -10,21 +10,21 @@ def test_form_contains_next_24h(notify_admin):
 
     # Friday
     assert choices[0] == ("", "Now")
-    assert choices[1] == ("2016-01-01T07:00:00", "Today at 7am US/Eastern")
-    assert choices[13] == ("2016-01-01T19:00:00", "Today at 7pm US/Eastern")
+    assert choices[1] == ("2016-01-01T07:00:00-05:00", "Today at 7am US/Eastern")
+    assert choices[13] == ("2016-01-01T19:00:00-05:00", "Today at 7pm US/Eastern")
 
     # Saturday
-    assert choices[14] == ("2016-01-01T20:00:00", "Today at 8pm US/Eastern")
-    assert choices[37] == ("2016-01-02T19:00:00", "Tomorrow at 7pm US/Eastern")
+    assert choices[14] == ("2016-01-01T20:00:00-05:00", "Today at 8pm US/Eastern")
+    assert choices[37] == ("2016-01-02T19:00:00-05:00", "Tomorrow at 7pm US/Eastern")
 
     # Sunday
-    assert choices[38] == ("2016-01-02T20:00:00", "Tomorrow at 8pm US/Eastern")
+    assert choices[38] == ("2016-01-02T20:00:00-05:00", "Tomorrow at 8pm US/Eastern")
 
     # Monday
-    assert choices[62] == ("2016-01-03T20:00:00", "Sunday at 8pm US/Eastern")
-    assert choices[80] == ("2016-01-04T14:00:00", "Monday at 2pm US/Eastern")
-    assert choices[84] == ("2016-01-04T18:00:00", "Monday at 6pm US/Eastern")
-    assert choices[85] == ("2016-01-04T19:00:00", "Monday at 7pm US/Eastern")
+    assert choices[62] == ("2016-01-03T20:00:00-05:00", "Sunday at 8pm US/Eastern")
+    assert choices[80] == ("2016-01-04T14:00:00-05:00", "Monday at 2pm US/Eastern")
+    assert choices[84] == ("2016-01-04T18:00:00-05:00", "Monday at 6pm US/Eastern")
+    assert choices[85] == ("2016-01-04T19:00:00-05:00", "Monday at 7pm US/Eastern")
 
     with pytest.raises(IndexError):
         assert choices[


### PR DESCRIPTION
The underlying date times under the ChooseTimeForm options were in timezone naive form.  Make them timezone aware for good order's sake.