### PR TITLE
Bugfix: Recent Batches table repeats #1189

### DIFF
--- a/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
+++ b/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
@@ -378,28 +378,29 @@ td.table-empty-message {
 }
 
 .job-table {
-   .usa-table {
-      thead th.file-name {
-         width: 25%;
-      }
-      thead th.template {
-         width: 20%;
-      }
-      thead th.time-sent {
-         width: 30%;
-      }
-      thead th.sender {
-         width: 15%;
-      }
-      thead th.\#-of-recipients {
-         width: 5%;
-      }
-      thead th.report {
-         width: 5%;
-      }
-      th {
-         padding: 0.5rem 0.5rem;
-      }
+   width: 100%;
+   border-collapse: collapse;
+   td.file-name {
+      width: 25%;
+      overflow-wrap: anywhere;
+   }
+   td.template {
+      width: 20%;
+   }
+   td.time-sent {
+      width: 20%;
+   }
+   td.sender {
+      width: 15%;
+   }
+   td.count-of-recipients {
+      width: 5%;
+   }
+   td.report {
+      width: 5%;
+   }
+   th {
+      padding: 0.5rem 0.5rem;
    }
 }
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -48,10 +48,8 @@ def service_dashboard(service_id):
     if not current_user.has_permissions("view_activity"):
         return redirect(url_for("main.choose_template", service_id=service_id))
 
-    notifications_response = notification_api_client.get_notifications_for_service(
-        service_id=service_id,
-    )["notifications"]
-    job_response = job_api_client.get_jobs(service_id)
+    job_response = job_api_client.get_jobs(service_id)["data"]
+    notifications_response = notification_api_client.get_notifications_for_service(service_id)["notifications"]
     service_data_retention_days = 7
 
     aggregate_notifications_by_job = defaultdict(list)
@@ -70,11 +68,12 @@ def service_dashboard(service_id):
             "view_job_link": url_for(
                 ".view_job", service_id=current_service.id, job_id=job["id"]
             ),
+            "created_at": job["created_at"],
             "notification_count": job["notification_count"],
             "created_by": job["created_by"],
             "notifications": aggregate_notifications_by_job.get(job["id"], []),
         }
-        for job in job_response["data"]
+        for job in job_response
     ]
     return render_template(
         "views/dashboard/dashboard.html",

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -54,7 +54,7 @@ def service_dashboard(service_id):
 
     aggregate_notifications_by_job = defaultdict(list)
     for notification in notifications_response:
-        job_id = notification.get("job", {}).get("id")
+        job_id = notification.get("job", {}).get("id", None)
         if job_id:
             aggregate_notifications_by_job[job_id].append(notification)
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -32,7 +32,6 @@ from app.utils.time import get_current_financial_year
 from app.utils.user import user_has_permissions
 
 
-
 @main.route("/services/<uuid:service_id>/dashboard")
 @user_has_permissions("view_activity", "send_messages")
 def old_service_dashboard(service_id):

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,4 +1,5 @@
 import calendar
+from collections import defaultdict
 from datetime import datetime
 from functools import partial
 from itertools import groupby
@@ -29,7 +30,7 @@ from app.utils.csv import Spreadsheet
 from app.utils.pagination import generate_next_dict, generate_previous_dict
 from app.utils.time import get_current_financial_year
 from app.utils.user import user_has_permissions
-from collections import defaultdict
+
 
 
 @main.route("/services/<uuid:service_id>/dashboard")

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -28,7 +28,6 @@
     {{ ajax_block(partials, updates_url, 'totals') }}
 
     {{ ajax_block(partials, updates_url, 'template-statistics') }}
-
     <h2 class="margin-top-4 margin-bottom-1">Recent Batches</h2>
     <div class='job-table'>
       <table class="usa-table usa-table--borderless width-full">
@@ -55,37 +54,37 @@
           </tr>
         </thead>
         <tbody>
-          {% for notification in notifications[:5] %}
-            {% if notification %}
-              <tr class="table-row" id="{{ notification.job.id }}">
-                <th class="table-field">
-                  {{ notification.job.original_file_name if notification.job.original_file_name else 'Manually entered number'}}
-                  <br>
-                  <a class="usa-link file-list-filename" href="/services/{{ notification.service }}/jobs/{{ notification.job.id }}">View Batch</a>
-                </th>
-                <th class="table-field">
-                  {{ notification.template.name }}
-                </th>
-                <th class="table-field">
-                  {{ notification.created_at | format_datetime_short_america }}
-                </th>
-                <th class="table-field">
-                  {{ notification.created_by.name }}
-                </th>
-                {% set job_available = jobs|selectattr('job_id', 'equalto', notification.job.id)|first %}
-                <th class="table-field">
-                  {{ job_available.notification_count if job_available else ''}}
-                </th>
-                <th class="table-field">
-                  {% if job_available and job_available.time_left != "Data no longer available" %}
-                    <a class="usa-link file-list-filename" href="{{ job_available.download_link }}">
-                      {{ "Download" if job_available.job_id else '' }}</a>
-                    <span class="usa-hint">{{ job_available.time_left }}</span>
-                  {% elif job_available %}
-                    <span>{{ job_available.time_left }}</span>
-                  {% endif %}
-                </th>
-              </tr>
+          {% for job in job_and_notifications[:5] %}
+            {% if job.job_id and job.notifications %}
+              {% for notification in job.notifications %}
+                <tr class="table-row" id="{{ job.job_id }}">
+                  <th class="table-field">
+                    {{ notification.job.original_file_name if notification.job.original_file_name else 'Manually entered number'}}
+                    <br>
+                    <a class="usa-link file-list-filename" href="{{ job.view_job_link }}">View Batch</a>
+                  </th>
+                  <th class="table-field">
+                    {{ notification.template.name }}
+                  </th>
+                  <th class="table-field">
+                    {{ notification.created_at | format_datetime_short_america }}
+                  </th>
+                  <th class="table-field">
+                    {{ notification.created_by.name }}
+                  </th>
+                  <th class="table-field">
+                    {{ job.notification_count}}
+                  </th>
+                  <th class="table-field">
+                    {% if notification and job.time_left != "Data no longer available" %}
+                      <a class="usa-link file-list-filename" href="{{ job.download_link }}">Download</a>
+                      <span class="usa-hint">{{ job.time_left }}</span>
+                    {% elif job %}
+                      <span>{{ job.time_left }}</span>
+                    {% endif %}
+                  </th>
+                </tr>
+              {% endfor %}
             {% endif %}
           {% endfor %}
         </tbody>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -55,7 +55,7 @@
         </thead>
         <tbody>
           {% if job_and_notifications %}
-            {% for job in job_and_notifications %}
+            {% for job in job_and_notifications[:5] %}
               {% if job.job_id and job.notifications %}
                 {% set notification = job.notifications[0] %}
                 <tr class="table-row" id="{{ job.job_id }}">

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -29,8 +29,8 @@
 
     {{ ajax_block(partials, updates_url, 'template-statistics') }}
     <h2 class="margin-top-4 margin-bottom-1">Recent Batches</h2>
-    <div class='job-table'>
-      <table class="usa-table usa-table--borderless width-full">
+    <div>
+      <table class="usa-table usa-table--borderless job-table">
         <thead class="table-field-headings">
           <tr>
             <th scope="col" class="table-field-heading-first file-name">
@@ -54,39 +54,44 @@
           </tr>
         </thead>
         <tbody>
-          {% for job in job_and_notifications[:5] %}
-            {% if job.job_id and job.notifications %}
-              {% for notification in job.notifications %}
+          {% if job_and_notifications %}
+            {% for job in job_and_notifications %}
+              {% if job.job_id and job.notifications %}
+                {% set notification = job.notifications[0] %}
                 <tr class="table-row" id="{{ job.job_id }}">
-                  <th class="table-field">
+                  <td class="table-field">
                     {{ notification.job.original_file_name if notification.job.original_file_name else 'Manually entered number'}}
                     <br>
                     <a class="usa-link file-list-filename" href="{{ job.view_job_link }}">View Batch</a>
-                  </th>
-                  <th class="table-field">
+                  </td>
+                  <td class="table-field">
                     {{ notification.template.name }}
-                  </th>
-                  <th class="table-field">
-                    {{ notification.created_at | format_datetime_short_america }}
-                  </th>
-                  <th class="table-field">
+                  </td>
+                  <td class="table-field">
+                    {{ job.created_at | format_datetime_short_america }}
+                  </td>
+                  <td class="table-field">
                     {{ notification.created_by.name }}
-                  </th>
-                  <th class="table-field">
+                  </td>
+                  <td class="table-field">
                     {{ job.notification_count}}
-                  </th>
-                  <th class="table-field">
+                  </td>
+                  <td class="table-field">
                     {% if notification and job.time_left != "Data no longer available" %}
                       <a class="usa-link file-list-filename" href="{{ job.download_link }}">Download</a>
                       <span class="usa-hint">{{ job.time_left }}</span>
                     {% elif job %}
                       <span>{{ job.time_left }}</span>
                     {% endif %}
-                  </th>
+                  </td>
                 </tr>
-              {% endfor %}
-            {% endif %}
-          {% endfor %}
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            <tr class="table-row">
+              <td class="table-empty-message" colspan="10">No batched job messages found &thinsp;(messages are kept for {{ service_data_retention_days }} days).</td>
+            </tr>
+        {% endif %}
         </tbody>
       </table>
     </div>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -33,22 +33,22 @@
       <table class="usa-table usa-table--borderless job-table">
         <thead class="table-field-headings">
           <tr>
-            <th scope="col" class="table-field-heading-first file-name">
+            <th scope="col" class="table-field-heading-first">
               <span>File name</span>
             </th>
-            <th scope="col" class="table-field-heading template">
+            <th scope="col" class="table-field-heading">
               <span>Template</span>
             </th>
-            <th scope="col" class="table-field-heading time-sent">
+            <th scope="col" class="table-field-heading">
               <span>Time sent</span>
             </th>
-            <th scope="col" class="table-field-heading sender">
+            <th scope="col" class="table-field-heading">
               <span>Sender</span>
             </th>
-            <th scope="col" class="table-field-heading #-of-recipients">
+            <th scope="col" class="table-field-heading">
               <span># of Recipients</span>
             </th>
-            <th scope="col" class="table-field-heading report">
+            <th scope="col" class="table-field-heading">
               <span>Report</span>
             </th>
           </tr>
@@ -59,24 +59,24 @@
               {% if job.job_id and job.notifications %}
                 {% set notification = job.notifications[0] %}
                 <tr class="table-row" id="{{ job.job_id }}">
-                  <td class="table-field">
+                  <td class="table-field file-name">
                     {{ notification.job.original_file_name if notification.job.original_file_name else 'Manually entered number'}}
                     <br>
                     <a class="usa-link file-list-filename" href="{{ job.view_job_link }}">View Batch</a>
                   </td>
-                  <td class="table-field">
+                  <td class="table-field template">
                     {{ notification.template.name }}
                   </td>
-                  <td class="table-field">
+                  <td class="table-field time-sent">
                     {{ job.created_at | format_datetime_short_america }}
                   </td>
-                  <td class="table-field">
+                  <td class="table-field sender">
                     {{ notification.created_by.name }}
                   </td>
-                  <td class="table-field">
+                  <td class="table-field count-of-recipients">
                     {{ job.notification_count}}
                   </td>
-                  <td class="table-field">
+                  <td class="table-field report">
                     {% if notification and job.time_left != "Data no longer available" %}
                       <a class="usa-link file-list-filename" href="{{ job.download_link }}">Download</a>
                       <span class="usa-hint">{{ job.time_left }}</span>

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -40,7 +40,7 @@ FAKE_ONE_OFF_NOTIFICATION = {
             "created_by": {
                 "email_address": "grsrbsrgsrf@fake.gov",
                 "id": "de059e0a-42e5-48bb-939e-4f76804ab739",
-                "name": "grsrbsrgsrf",
+                "name": "mocked_user",
             },
             "document_download_count": None,
             "id": "a3442b43-0ba1-4854-9e0a-d2fba1cc9b81",
@@ -71,7 +71,7 @@ FAKE_ONE_OFF_NOTIFICATION = {
             "template": {
                 "content": "((day of week)) and ((fave color))",
                 "id": "bd9caa7e-00ee-4c5a-839e-10ae1a7e6f73",
-                "name": "personalized",
+                "name": "Template Testing",
                 "redact_personalisation": False,
                 "subject": None,
                 "template_type": "sms",
@@ -94,7 +94,7 @@ MOCK_JOBS = {
                 "id": "mocked_user_id",
                 "name": "mocked_user",
             },
-            "id": "mocked_notification_id",
+            "id": "55b242b5-9f62-4271-aff7-039e9c320578",
             "job_status": "finished",
             "notification_count": 1,
             "original_file_name": "mocked_file.csv",
@@ -112,6 +112,19 @@ MOCK_JOBS = {
         }
     ]
 }
+
+MOCK_JOBS_AND_NOTIFICATIONS = [
+    {
+        "created_at": MOCK_JOBS["data"][0]["created_at"],
+        "created_by": MOCK_JOBS["data"][0]["created_by"],
+        "download_link": "/services/21b3ee3d-1cb0-4666-bfa0-9c5ac26d3fe3/jobs/463b5ecb-4e32-43e5-aa90-0234d19fceaa.csv",
+        "job_id": "55b242b5-9f62-4271-aff7-039e9c320578",
+        "notification_count": MOCK_JOBS["data"][0]["notification_count"],
+        "notifications": FAKE_ONE_OFF_NOTIFICATION["notifications"],
+        "time_left": "Data available for 7 days",
+        "view_job_link": "/services/21b3ee3d-1cb0-4666-bfa0-9c5ac26d3fe3/jobs/463b5ecb-4e32-43e5-aa90-0234d19fceaa"
+    },
+]
 
 stub_template_stats = [
     {
@@ -1855,11 +1868,11 @@ def test_service_dashboard_shows_batched_jobs(
 
     page = client_request.get("main.service_dashboard", service_id=SERVICE_ONE_ID)
 
-    job_table = page.find("div", class_="job-table")
+    job_table_body = page.find("table", class_="job-table")
 
-    # Check if the "Job" table exists
-    assert job_table is not None
+    rows = job_table_body.find_all("tbody")[0].find_all("tr")
 
-    table_rows = job_table.find_all("tbody")[0].find_all("tr")
+    # # Check if the "Job" table exists
+    assert job_table_body is not None
 
-    assert len(table_rows) == 1
+    assert len(rows) == 1


### PR DESCRIPTION
This PR is to fix bug around duplicate rows inside of the Recent Batch table. 
![image](https://github.com/GSA/notifications-admin/assets/53159604/dcff6de7-f38c-4f0c-ab00-9cd90a798a19)

Because it's a one to many relationship between job and notification, in order to fix this issue, I aggregated all notifications that share the same job_id. This way, there should only be one job_id for a group of notification, reducing duplicate rows in the table. 

Bug: Norfolk Batches table repeats one batch
[#1189](https://github.com/GSA/notifications-admin/issues/1189)

- [x] Aggregate notification. For each notification, it should be combined based on the job_id
- [x] Update the html table 
- [x] Update the css for column widths
