### PR TITLE
clean up login.gov link

### DIFF
--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -29,10 +29,9 @@
     {% else %}
       <h1 class="font-body-2xl margin-bottom-3">Sign in</h1>
       {% if login_gov_enabled %}
-      <p>
-        Test login.gov authentication:
-        <a class="usa-link" href="{{ initial_signin_url }}">Login.gov</a>.
+        <a class="usa-link" href="{{ initial_signin_url }}">Sign in with Login.gov</a>
       </p>
+      <h4 class="margin-bottom-3">Or:</h4>
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
As we transition from our homegrown login to forcing people to use login.gov, we need to pass through a phase where login.gov is preferred but people can still login the old way.

Move the link and add the helpful word "Or:" so people will know there are currently two ways to log in.

Note that our entire login page will go away after we transition to login.gov only (when users click on "Sign In" on the landing page they will be redirected to login.gov).


After this PR:

<img width="1728" alt="Screenshot 2024-02-12 at 10 58 07 AM" src="https://github.com/GSA/notifications-admin/assets/26859290/2ee0802f-bd15-4e92-b44c-c562b698da45">
