### PR TITLE
enable login.gov link on demo and adjust test

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -56,12 +56,12 @@ jobs:
           NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
           LOGIN_PEM: ${{ secrets.LOGIN_PEM }}
           LOGIN_DOT_GOV_CLIENT_ID: "urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov"
-          LOGIN_DOT_GOV_USER_INFO_URL: "https://idp.int.identitysandbox.gov/api/openid_connect/userinfo"
-          LOGIN_DOT_GOV_ACCESS_TOKEN_URL: "https://idp.int.identitysandbox.gov/api/openid_connect/token"
-          LOGIN_DOT_GOV_LOGOUT_URL: "https://idp.int.identitysandbox.gov/openid_connect/logout?client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&post_logout_redirect_uri=https://notify-demo.app.cloud.gov/sign-out"
-          LOGIN_DOT_GOV_BASE_LOGOUT_URL: "https://idp.int.identitysandbox.gov/openid_connect/logout?"
+          LOGIN_DOT_GOV_USER_INFO_URL: "https://secure.login.gov/api/openid_connect/userinfo"
+          LOGIN_DOT_GOV_ACCESS_TOKEN_URL: "https://secure.login.gov/api/openid_connect/token"
+          LOGIN_DOT_GOV_LOGOUT_URL: "https://secure.login.gov/openid_connect/logout?client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&post_logout_redirect_uri=https://notify-demo.app.cloud.gov/sign-out"
+          LOGIN_DOT_GOV_BASE_LOGOUT_URL: "https://secure.login.gov/openid_connect/logout?"
           LOGIN_DOT_GOV_SIGNOUT_REDIRECT: "https://notify-demo.app.cloud.gov/sign-out"
-          LOGIN_DOT_GOV_INITIAL_SIGNIN_URL: "https://idp.int.identitysandbox.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&nonce=01234567890123456789012345&prompt=select_account&redirect_uri=https://notify-demo.app.cloud.gov/sign-in&response_type=code&scope=openid+email&state=abcdefghijklmnopabcdefghijklmnop"
+          LOGIN_DOT_GOV_INITIAL_SIGNIN_URL: "https://secure.login.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&nonce=01234567890123456789012345&prompt=select_account&redirect_uri=https://notify-demo.app.cloud.gov/sign-in&response_type=code&scope=openid+email&state=abcdefghijklmnopabcdefghijklmnop"
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,12 +62,12 @@ jobs:
           NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
           LOGIN_PEM: ${{ secrets.LOGIN_PEM }}
           LOGIN_DOT_GOV_CLIENT_ID: "urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov"
-          LOGIN_DOT_GOV_USER_INFO_URL: "https://idp.int.identitysandbox.gov/api/openid_connect/userinfo"
-          LOGIN_DOT_GOV_ACCESS_TOKEN_URL: "https://idp.int.identitysandbox.gov/api/openid_connect/token"
-          LOGIN_DOT_GOV_LOGOUT_URL: "https://idp.int.identitysandbox.gov/openid_connect/logout?client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&post_logout_redirect_uri=https://notify-staging.app.cloud.gov/sign-out"
-          LOGIN_DOT_GOV_BASE_LOGOUT_URL: "https://idp.int.identitysandbox.gov/openid_connect/logout?"
+          LOGIN_DOT_GOV_USER_INFO_URL: "https://secure.login.gov/api/openid_connect/userinfo"
+          LOGIN_DOT_GOV_ACCESS_TOKEN_URL: "https://secure.login.gov/api/openid_connect/token"
+          LOGIN_DOT_GOV_LOGOUT_URL: "https://secure.login.gov/openid_connect/logout?client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&post_logout_redirect_uri=https://notify-staging.app.cloud.gov/sign-out"
+          LOGIN_DOT_GOV_BASE_LOGOUT_URL: "https://secure.login.gov/openid_connect/logout?"
           LOGIN_DOT_GOV_SIGNOUT_REDIRECT: "https://notify-staging.app.cloud.gov/sign-out"
-          LOGIN_DOT_GOV_INITIAL_SIGNIN_URL: "https://idp.int.identitysandbox.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&nonce=01234567890123456789012345&prompt=select_account&redirect_uri=https://notify-staging.app.cloud.gov/sign-in&response_type=code&scope=openid+email&state=abcdefghijklmnopabcdefghijklmnop"
+          LOGIN_DOT_GOV_INITIAL_SIGNIN_URL: "https://secure.login.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&nonce=01234567890123456789012345&prompt=select_account&redirect_uri=https://notify-staging.app.cloud.gov/sign-in&response_type=code&scope=openid+email&state=abcdefghijklmnopabcdefghijklmnop"
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -198,7 +198,7 @@ def sign_in():
         form=form,
         again=bool(redirect_url),
         other_device=other_device,
-        login_gov_enabled=True,
+        login_gov_enabled=bool(notify_env in ["development", "staging", "demo"]),
         password_reset_url=password_reset_url,
         initial_signin_url=initial_signin_url,
     )

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -198,7 +198,7 @@ def sign_in():
         form=form,
         again=bool(redirect_url),
         other_device=other_device,
-        login_gov_enabled=bool(notify_env in ["development", "staging"]),
+        login_gov_enabled=True,
         password_reset_url=password_reset_url,
         initial_signin_url=initial_signin_url,
     )

--- a/deploy-config/egress_proxy/notify-admin-demo.allow.acl
+++ b/deploy-config/egress_proxy/notify-admin-demo.allow.acl
@@ -1,2 +1,4 @@
 gov-collector.newrelic.com
 egress-proxy-notify-admin-demo.apps.internal
+idp.int.identitysandbox.gov
+secure.login.gov

--- a/deploy-config/egress_proxy/notify-admin-production.allow.acl
+++ b/deploy-config/egress_proxy/notify-admin-production.allow.acl
@@ -1,2 +1,4 @@
 gov-collector.newrelic.com
 egress-proxy-notify-admin-production.apps.internal
+idp.int.identitysandbox.gov
+secure.login.gov

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -21,8 +21,8 @@ def test_render_sign_in_template_for_new_user(client_request):
     # Removing for the pilot
     # assert page.select('main a')[0].text == 'create one now'
     # assert page.select('main a')[0]['href'] == url_for('main.register')
-    assert page.select("main a")[0].text == "Forgot your password?"
-    assert page.select("main a")[0]["href"] == url_for("main.forgot_password")
+    assert page.select("main a")[1].text == "Forgot your password?"
+    assert page.select("main a")[1]["href"] == url_for("main.forgot_password")
     assert "Sign in again" not in normalize_spaces(page.text)
 
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -23,6 +23,7 @@ def test_render_sign_in_template_for_new_user(client_request):
     # assert page.select('main a')[0]['href'] == url_for('main.register')
     # TODO:  Fix this test to be less brittle! If the Login.gov link is enabled,
     #        then these indices need to be 1 instead of 0.
+    #        Currently it's not enabled for the test or production environments.
     assert page.select("main a")[0].text == "Forgot your password?"
     assert page.select("main a")[0]["href"] == url_for("main.forgot_password")
     assert "Sign in again" not in normalize_spaces(page.text)

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -21,8 +21,10 @@ def test_render_sign_in_template_for_new_user(client_request):
     # Removing for the pilot
     # assert page.select('main a')[0].text == 'create one now'
     # assert page.select('main a')[0]['href'] == url_for('main.register')
-    assert page.select("main a")[1].text == "Forgot your password?"
-    assert page.select("main a")[1]["href"] == url_for("main.forgot_password")
+    # TODO:  Fix this test to be less brittle! If the Login.gov link is enabled,
+    #        then these indices need to be 1 instead of 0.
+    assert page.select("main a")[0].text == "Forgot your password?"
+    assert page.select("main a")[0]["href"] == url_for("main.forgot_password")
     assert "Sign in again" not in normalize_spaces(page.text)
 
 


### PR DESCRIPTION

## Description

We were previously hiding the login.gov link on demo and production by checking what environment we were running in.  Hardcode the variable to always be true.  Fix the test that is looking for the "Forgot your password?" link because now there is a new link ahead of it in the page order.

## Security Considerations

N/A