### PR TITLE
change batch file report to look like full csv report

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -49,7 +49,9 @@ def service_dashboard(service_id):
         return redirect(url_for("main.choose_template", service_id=service_id))
 
     job_response = job_api_client.get_jobs(service_id)["data"]
-    notifications_response = notification_api_client.get_notifications_for_service(service_id)["notifications"]
+    notifications_response = notification_api_client.get_notifications_for_service(
+        service_id
+    )["notifications"]
     service_data_retention_days = 7
 
     aggregate_notifications_by_job = defaultdict(list)

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -71,6 +71,7 @@ def generate_notifications_csv(**kwargs):
     if "page" not in kwargs:
         kwargs["page"] = 1
 
+    # This generates the "batch" csv report
     if kwargs.get("job_id"):
         original_file_contents = s3download(kwargs["service_id"], kwargs["job_id"])
         original_upload = RecipientCSV(
@@ -79,7 +80,7 @@ def generate_notifications_csv(**kwargs):
         )
         original_column_headers = original_upload.column_headers
         fieldnames = [
-            "Recipient",
+            "Phone Number",
             "Template",
             "Sent by",
             "Batch File",
@@ -92,9 +93,9 @@ def generate_notifications_csv(**kwargs):
                 fieldnames.append(header)
 
     else:
-        # TODO This is deprecated because everything should be a job now, is it ever invoked?
+        # This generates the "full" csv report
         fieldnames = [
-            "Recipient",
+            "Phone Number",
             "Template",
             "Sent by",
             "Batch File",
@@ -102,7 +103,6 @@ def generate_notifications_csv(**kwargs):
             "Status",
             "Time",
         ]
-        current_app.logger.warning("Invoking deprecated report format")
 
     yield ",".join(fieldnames) + "\n"
 

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -79,6 +79,7 @@ def generate_notifications_csv(**kwargs):
         )
         original_column_headers = original_upload.column_headers
         fieldnames = [
+            "Recipient",
             "Template",
             "Sent by",
             "Batch File",
@@ -87,7 +88,8 @@ def generate_notifications_csv(**kwargs):
             "Time",
         ]
         for header in original_column_headers:
-            fieldnames.append(header)
+            if header.lower() != "phone number":
+                fieldnames.append(header)
 
     else:
         # TODO This is deprecated because everything should be a job now, is it ever invoked?
@@ -113,9 +115,9 @@ def generate_notifications_csv(**kwargs):
                 notification["created_at"]
             )
 
-            current_app.logger.info(f"\n\n{notification}")
             if kwargs.get("job_id"):
                 values = [
+                    notification["recipient"],
                     notification["template_name"],
                     notification["created_by_name"],
                     notification["job_name"],
@@ -124,12 +126,14 @@ def generate_notifications_csv(**kwargs):
                     preferred_tz_created_at,
                 ]
                 for header in original_column_headers:
-                    values.append(
-                        original_upload[notification["row_number"] - 1].get(header).data
-                    )
+                    if header.lower() != "phone number":
+                        values.append(
+                            original_upload[notification["row_number"] - 1]
+                            .get(header)
+                            .data
+                        )
 
             else:
-                # TODO This is deprecated, should not be invoked.  See above
                 values = [
                     notification["recipient"],
                     notification["template_name"],

--- a/poetry.lock
+++ b/poetry.lock
@@ -1729,7 +1729,7 @@ werkzeug = "^3.0.1"
 type = "git"
 url = "https://github.com/GSA/notifications-utils.git"
 reference = "HEAD"
-resolved_reference = "a48171e865eb83cf29c75751be7369f396cbe3e2"
+resolved_reference = "70ee61cd0f87113d2bd838b197dbe38cc09678f3"
 
 [[package]]
 name = "numpy"

--- a/poetry.lock
+++ b/poetry.lock
@@ -529,43 +529,43 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "42.0.2"
+version = "42.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-42.0.2-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be"},
-    {file = "cryptography-42.0.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d"},
-    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4"},
-    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2"},
-    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529"},
-    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1"},
-    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1"},
-    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929"},
-    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9"},
-    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2"},
-    {file = "cryptography-42.0.2-cp37-abi3-win32.whl", hash = "sha256:4b063d3413f853e056161eb0c7724822a9740ad3caa24b8424d776cebf98e7ee"},
-    {file = "cryptography-42.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:841ec8af7a8491ac76ec5a9522226e287187a3107e12b7d686ad354bb78facee"},
-    {file = "cryptography-42.0.2-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242"},
-    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a"},
-    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446"},
-    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90"},
-    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3"},
-    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589"},
-    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a"},
-    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea"},
-    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33"},
-    {file = "cryptography-42.0.2-cp39-abi3-win32.whl", hash = "sha256:3dbd37e14ce795b4af61b89b037d4bc157f2cb23e676fa16932185a04dfbf635"},
-    {file = "cryptography-42.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:8a06641fb07d4e8f6c7dda4fc3f8871d327803ab6542e33831c7ccfdcb4d0ad6"},
-    {file = "cryptography-42.0.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:087887e55e0b9c8724cf05361357875adb5c20dec27e5816b653492980d20380"},
-    {file = "cryptography-42.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a7ef8dd0bf2e1d0a27042b231a3baac6883cdd5557036f5e8df7139255feaac6"},
-    {file = "cryptography-42.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4383b47f45b14459cab66048d384614019965ba6c1a1a141f11b5a551cace1b2"},
-    {file = "cryptography-42.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:fbeb725c9dc799a574518109336acccaf1303c30d45c075c665c0793c2f79a7f"},
-    {file = "cryptography-42.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008"},
-    {file = "cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12"},
-    {file = "cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a"},
-    {file = "cryptography-42.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:141e2aa5ba100d3788c0ad7919b288f89d1fe015878b9659b307c9ef867d3a65"},
-    {file = "cryptography-42.0.2.tar.gz", hash = "sha256:e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888"},
+    {file = "cryptography-42.0.4-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:ffc73996c4fca3d2b6c1c8c12bfd3ad00def8621da24f547626bf06441400449"},
+    {file = "cryptography-42.0.4-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:db4b65b02f59035037fde0998974d84244a64c3265bdef32a827ab9b63d61b18"},
+    {file = "cryptography-42.0.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad9c385ba8ee025bb0d856714f71d7840020fe176ae0229de618f14dae7a6e2"},
+    {file = "cryptography-42.0.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69b22ab6506a3fe483d67d1ed878e1602bdd5912a134e6202c1ec672233241c1"},
+    {file = "cryptography-42.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e09469a2cec88fb7b078e16d4adec594414397e8879a4341c6ace96013463d5b"},
+    {file = "cryptography-42.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3e970a2119507d0b104f0a8e281521ad28fc26f2820687b3436b8c9a5fcf20d1"},
+    {file = "cryptography-42.0.4-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e53dc41cda40b248ebc40b83b31516487f7db95ab8ceac1f042626bc43a2f992"},
+    {file = "cryptography-42.0.4-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:c3a5cbc620e1e17009f30dd34cb0d85c987afd21c41a74352d1719be33380885"},
+    {file = "cryptography-42.0.4-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bfadd884e7280df24d26f2186e4e07556a05d37393b0f220a840b083dc6a824"},
+    {file = "cryptography-42.0.4-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:01911714117642a3f1792c7f376db572aadadbafcd8d75bb527166009c9f1d1b"},
+    {file = "cryptography-42.0.4-cp37-abi3-win32.whl", hash = "sha256:fb0cef872d8193e487fc6bdb08559c3aa41b659a7d9be48b2e10747f47863925"},
+    {file = "cryptography-42.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:c1f25b252d2c87088abc8bbc4f1ecbf7c919e05508a7e8628e6875c40bc70923"},
+    {file = "cryptography-42.0.4-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:15a1fb843c48b4a604663fa30af60818cd28f895572386e5f9b8a665874c26e7"},
+    {file = "cryptography-42.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1327f280c824ff7885bdeef8578f74690e9079267c1c8bd7dc5cc5aa065ae52"},
+    {file = "cryptography-42.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ffb03d419edcab93b4b19c22ee80c007fb2d708429cecebf1dd3258956a563a"},
+    {file = "cryptography-42.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1df6fcbf60560d2113b5ed90f072dc0b108d64750d4cbd46a21ec882c7aefce9"},
+    {file = "cryptography-42.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:44a64043f743485925d3bcac548d05df0f9bb445c5fcca6681889c7c3ab12764"},
+    {file = "cryptography-42.0.4-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:3c6048f217533d89f2f8f4f0fe3044bf0b2090453b7b73d0b77db47b80af8dff"},
+    {file = "cryptography-42.0.4-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6d0fbe73728c44ca3a241eff9aefe6496ab2656d6e7a4ea2459865f2e8613257"},
+    {file = "cryptography-42.0.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:887623fe0d70f48ab3f5e4dbf234986b1329a64c066d719432d0698522749929"},
+    {file = "cryptography-42.0.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ce8613beaffc7c14f091497346ef117c1798c202b01153a8cc7b8e2ebaaf41c0"},
+    {file = "cryptography-42.0.4-cp39-abi3-win32.whl", hash = "sha256:810bcf151caefc03e51a3d61e53335cd5c7316c0a105cc695f0959f2c638b129"},
+    {file = "cryptography-42.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:a0298bdc6e98ca21382afe914c642620370ce0470a01e1bef6dd9b5354c36854"},
+    {file = "cryptography-42.0.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5f8907fcf57392cd917892ae83708761c6ff3c37a8e835d7246ff0ad251d9298"},
+    {file = "cryptography-42.0.4-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:12d341bd42cdb7d4937b0cabbdf2a94f949413ac4504904d0cdbdce4a22cbf88"},
+    {file = "cryptography-42.0.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1cdcdbd117681c88d717437ada72bdd5be9de117f96e3f4d50dab3f59fd9ab20"},
+    {file = "cryptography-42.0.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0e89f7b84f421c56e7ff69f11c441ebda73b8a8e6488d322ef71746224c20fce"},
+    {file = "cryptography-42.0.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f1e85a178384bf19e36779d91ff35c7617c885da487d689b05c1366f9933ad74"},
+    {file = "cryptography-42.0.4-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d2a27aca5597c8a71abbe10209184e1a8e91c1fd470b5070a2ea60cafec35bcd"},
+    {file = "cryptography-42.0.4-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4e36685cb634af55e0677d435d425043967ac2f3790ec652b2b88ad03b85c27b"},
+    {file = "cryptography-42.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f47be41843200f7faec0683ad751e5ef11b9a56a220d57f300376cd8aba81660"},
+    {file = "cryptography-42.0.4.tar.gz", hash = "sha256:831a4b37accef30cccd34fcb916a5d7b5be3cbbe27268a02832c3e450aea39cb"},
 ]
 
 [package.dependencies]
@@ -1677,7 +1677,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "0.2.8"
+version = "0.2.9"
 description = ""
 optional = false
 python-versions = ">=3.9,<3.12"
@@ -1695,7 +1695,7 @@ certifi = "^2023.7.22"
 cffi = "^1.16.0"
 charset-normalizer = "^3.1.0"
 click = "^8.1.3"
-cryptography = "^42.0.0"
+cryptography = "^42.0.4"
 flask = "^2.3.2"
 flask-redis = "^0.4.0"
 geojson = "^3.0.1"
@@ -1729,7 +1729,7 @@ werkzeug = "^3.0.1"
 type = "git"
 url = "https://github.com/GSA/notifications-utils.git"
 reference = "HEAD"
-resolved_reference = "70ee61cd0f87113d2bd838b197dbe38cc09678f3"
+resolved_reference = "df8ece836cad303c5d161edf485cf9bbdc666688"
 
 [[package]]
 name = "numpy"

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -122,7 +122,7 @@ MOCK_JOBS_AND_NOTIFICATIONS = [
         "notification_count": MOCK_JOBS["data"][0]["notification_count"],
         "notifications": FAKE_ONE_OFF_NOTIFICATION["notifications"],
         "time_left": "Data available for 7 days",
-        "view_job_link": "/services/21b3ee3d-1cb0-4666-bfa0-9c5ac26d3fe3/jobs/463b5ecb-4e32-43e5-aa90-0234d19fceaa"
+        "view_job_link": "/services/21b3ee3d-1cb0-4666-bfa0-9c5ac26d3fe3/jobs/463b5ecb-4e32-43e5-aa90-0234d19fceaa",
     },
 ]
 

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -88,14 +88,14 @@ def get_notifications_csv_mock(
         (
             None,
             [
-                "Recipient,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
+                "Phone Number,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
                 "8005555555,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",
             ],
         ),
         (
             "Anne Example",
             [
-                "Recipient,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
+                "Phone Number,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
                 "8005555555,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",  # noqa
             ],
         ),
@@ -128,7 +128,7 @@ def test_generate_notifications_csv_without_job(
             8005555555
         """,
             [
-                "Recipient",
+                "Phone Number",
                 "Template",
                 "Sent by",
                 "Batch File",
@@ -152,7 +152,7 @@ def test_generate_notifications_csv_without_job(
             8005555555,  🐜,🐝,🦀
         """,
             [
-                "Recipient",
+                "Phone Number",
                 "Template",
                 "Sent by",
                 "Batch File",
@@ -182,7 +182,7 @@ def test_generate_notifications_csv_without_job(
             "8005555555","🐜,🐜","🐝,🐝","🦀"
         """,
             [
-                "Recipient",
+                "Phone Number",
                 "Template",
                 "Sent by",
                 "Batch File",

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -14,7 +14,7 @@ from tests.conftest import fake_uuid
 
 def _get_notifications_csv(
     row_number=1,
-    recipient="2028675309",
+    recipient="8005555555",
     template_name="foo",
     template_type="sms",
     job_name="bar.csv",
@@ -89,14 +89,14 @@ def get_notifications_csv_mock(
             None,
             [
                 "Recipient,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
-                "2028675309,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",
+                "8005555555,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",
             ],
         ),
         (
             "Anne Example",
             [
                 "Recipient,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
-                "2028675309,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",  # noqa
+                "8005555555,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",  # noqa
             ],
         ),
     ],
@@ -125,7 +125,7 @@ def test_generate_notifications_csv_without_job(
         (
             """
             phone number
-            2028675309
+            8005555555
         """,
             [
                 "Recipient",
@@ -137,7 +137,7 @@ def test_generate_notifications_csv_without_job(
                 "Time",
             ],
             [
-                "2028675309",
+                "8005555555",
                 "foo",
                 "Fake Person",
                 "bar.csv",
@@ -149,7 +149,7 @@ def test_generate_notifications_csv_without_job(
         (
             """
             phone number, a, b, c
-            2028675309,  🐜,🐝,🦀
+            8005555555,  🐜,🐝,🦀
         """,
             [
                 "Recipient",
@@ -164,7 +164,7 @@ def test_generate_notifications_csv_without_job(
                 "c",
             ],
             [
-                "2028675309",
+                "8005555555",
                 "foo",
                 "Fake Person",
                 "bar.csv",
@@ -179,7 +179,7 @@ def test_generate_notifications_csv_without_job(
         (
             """
             "phone number", "a", "b", "c"
-            "2028675309","🐜,🐜","🐝,🐝","🦀"
+            "8005555555","🐜,🐜","🐝,🐝","🦀"
         """,
             [
                 "Recipient",
@@ -194,7 +194,7 @@ def test_generate_notifications_csv_without_job(
                 "c",
             ],
             [
-                "2028675309",
+                "8005555555",
                 "foo",
                 "Fake Person",
                 "bar.csv",

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -14,7 +14,7 @@ from tests.conftest import fake_uuid
 
 def _get_notifications_csv(
     row_number=1,
-    recipient="foo@bar.com",
+    recipient="2028675309",
     template_name="foo",
     template_type="sms",
     job_name="bar.csv",
@@ -89,14 +89,14 @@ def get_notifications_csv_mock(
             None,
             [
                 "Recipient,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
-                "foo@bar.com,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",
+                "2028675309,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",
             ],
         ),
         (
             "Anne Example",
             [
                 "Recipient,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
-                "foo@bar.com,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",  # noqa
+                "2028675309,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",  # noqa
             ],
         ),
     ],
@@ -124,53 +124,53 @@ def test_generate_notifications_csv_without_job(
     [
         (
             """
-            phone_number
+            phone number
             2028675309
         """,
             [
+                "Recipient",
                 "Template",
                 "Sent by",
                 "Batch File",
                 "Carrier Response",
                 "Status",
                 "Time",
-                "phone_number",
             ],
             [
+                "2028675309",
                 "foo",
                 "Fake Person",
                 "bar.csv",
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
-                "2028675309",
             ],
         ),
         (
             """
-            phone_number, a, b, c
+            phone number, a, b, c
             2028675309,  🐜,🐝,🦀
         """,
             [
+                "Recipient",
                 "Template",
                 "Sent by",
                 "Batch File",
                 "Carrier Response",
                 "Status",
                 "Time",
-                "phone_number",
                 "a",
                 "b",
                 "c",
             ],
             [
+                "2028675309",
                 "foo",
                 "Fake Person",
                 "bar.csv",
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
-                "2028675309",
                 "🐜",
                 "🐝",
                 "🦀",
@@ -178,29 +178,29 @@ def test_generate_notifications_csv_without_job(
         ),
         (
             """
-            "phone_number", "a", "b", "c"
+            "phone number", "a", "b", "c"
             "2028675309","🐜,🐜","🐝,🐝","🦀"
         """,
             [
+                "Recipient",
                 "Template",
                 "Sent by",
                 "Batch File",
                 "Carrier Response",
                 "Status",
                 "Time",
-                "phone_number",
                 "a",
                 "b",
                 "c",
             ],
             [
+                "2028675309",
                 "foo",
                 "Fake Person",
                 "bar.csv",
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
-                "2028675309",
                 "🐜,🐜",
                 "🐝,🐝",
                 "🦀",


### PR DESCRIPTION
## Description
The ticket is missing acceptance criteria.    I changed the batch file report to match the full csv report.

Batch file report columns Before:

"Template", "Sent by", "Batch File", "Carrier Response", "Status", "Time", "phone number"

Batch file report columns after:

"Recipient", "Template", "Sent by", "Batch File", "Carrier Response", "Status", "Time"


## Security Considerations

N/A