### PR TITLE
Filtered out empty notifications (related to recent batch table)

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -76,6 +76,7 @@ def service_dashboard(service_id):
             "notifications": aggregate_notifications_by_job.get(job["id"], []),
         }
         for job in job_response
+        if aggregate_notifications_by_job.get(job["id"], [])
     ]
     return render_template(
         "views/dashboard/dashboard.html",


### PR DESCRIPTION

## Description

This PR accounts for any empty notifications. For example, in the case where a user cancels a scheduled job, the table was not properly displaying jobs AND notifications. Also, because I was slicing the list to display only the first 5 items with `{% for job in job_and_notifications[:5] %}`, if all 5 of the first items' notifications are empty, nothing would be displayed.

## TODO
- [x] Display only items that have both job and notifications where job_id exist for both. 

