### PR TITLE
Use USWDS error formatting for file too big error (notify-admin-1237)

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1226,7 +1226,11 @@ class CsvUploadForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Please pick a file"),
             CsvFileValidator(),
-            FileSize(max_size=10e6, message="File must be smaller than 10Mb"),  # 10Mb
+            FileSize(
+                max_size=10e6,
+                message="File must be smaller than 10Mb.  If you are trying to upload an Excel file, \
+                please export the contents in the CSV format and then try again.",
+            ),  # 10Mb
         ],
     )
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -6,6 +6,7 @@ from zipfile import BadZipFile
 
 from flask import abort, flash, redirect, render_template, request, session, url_for
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.insensitive_dict import InsensitiveDict
@@ -151,8 +152,11 @@ def send_messages(service_id, template_id):
         # just show the first error, as we don't expect the form to have more
         # than one, since it only has one field
         first_field_errors = list(form.errors.values())[0]
-        flash(first_field_errors[0])
-
+        error_message = '<span class="usa-error-message">'
+        error_message = f"{error_message}{first_field_errors[0]}"
+        error_message = f"{error_message}</span>"
+        error_message = Markup(error_message)
+        flash(error_message)
     column_headings = get_spreadsheet_column_headings_from_template(template)
 
     return render_template(


### PR DESCRIPTION
## Description

When a user currently uploads a CSV file that is too big, the error is displayed in regular black text and is not very noticeable.  In order to apply the user-error-message USWDS formatting to the error, we need to wrap the message in a span and then use Markup to protect the formatting as it makes its way through flask.

## Security Considerations

N/A