### PR TITLE
dashboard bug

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -272,7 +272,7 @@ def get_status_filters(service, message_type, statistics):
     if message_type is None:
         stats = {
             key: sum(statistics[message_type][key] for message_type in {"email", "sms"})
-            for key in {"requested", "delivered", "failure"}
+            for key in {"requested", "delivered", "failed"}
         }
     else:
         stats = statistics[message_type]

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -269,19 +269,23 @@ def get_notifications(service_id, message_type, status_override=None):  # noqa
 
 
 def get_status_filters(service, message_type, statistics):
+    print(f"incoming statistics {statistics} and message_type {message_type}")
     if message_type is None:
         stats = {
             key: sum(statistics[message_type][key] for message_type in {"email", "sms"})
-            for key in {"requested", "delivered", "failed"}
+            for key in {"requested", "delivered", "failure"}
         }
     else:
         stats = statistics[message_type]
-    stats["sending"] = stats["requested"] - stats["delivered"] - stats["failed"]
+
+    print(f"STATS = {stats}")
+    stats["failed"] = stats["failure"]
+    stats
 
     filters = [
         # key, label, option
         ("requested", "total", "sending,delivered,failed"),
-        ("sending", "pending", "pending"),
+        ("pending", "pending", "pending"),
         ("delivered", "delivered", "delivered"),
         ("failed", "failed", "failed"),
     ]
@@ -296,7 +300,7 @@ def get_status_filters(service, message_type, statistics):
                 message_type=message_type,
                 status=option,
             ),
-            stats[key],
+            stats.get(key),
         )
         for key, label, option in filters
     ]

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -288,7 +288,7 @@ def get_status_filters(service, message_type, statistics):
     filters = [
         # key, label, option
         ("requested", "total", "sending,delivered,failed"),
-        ("sending", "pending", "pending"),
+        ("pending", "pending", "pending"),
         ("delivered", "delivered", "delivered"),
         ("failed", "failed", "failed"),
     ]

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -280,10 +280,7 @@ def get_status_filters(service, message_type, statistics):
     if stats.get("failure") is not None:
         stats["failed"] = stats["failure"]
 
-    if stats.get("pending") is None:
-        stats["pending"] = 0
-    if stats.get("sending") is None:
-        stats["sending"] = 0
+    stats["pending"] = stats["requested"] - stats["delivered"] - stats["failed"]
 
     filters = [
         # key, label, option

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -272,7 +272,7 @@ def get_status_filters(service, message_type, statistics):
     if message_type is None:
         stats = {
             key: sum(statistics[message_type][key] for message_type in {"email", "sms"})
-            for key in {"requested", "delivered", "failed"}
+            for key in {"requested", "delivered", "failure"}
         }
     else:
         stats = statistics[message_type]

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -269,23 +269,26 @@ def get_notifications(service_id, message_type, status_override=None):  # noqa
 
 
 def get_status_filters(service, message_type, statistics):
-    print(f"incoming statistics {statistics} and message_type {message_type}")
     if message_type is None:
         stats = {
             key: sum(statistics[message_type][key] for message_type in {"email", "sms"})
-            for key in {"requested", "delivered", "failure"}
+            for key in {"requested", "delivered", "failed"}
         }
     else:
         stats = statistics[message_type]
 
-    print(f"STATS = {stats}")
-    stats["failed"] = stats["failure"]
-    stats
+    if stats.get("failure") is not None:
+        stats["failed"] = stats["failure"]
+
+    if stats.get("pending") is None:
+        stats["pending"] = 0
+    if stats.get("sending") is None:
+        stats["sending"] = 0
 
     filters = [
         # key, label, option
         ("requested", "total", "sending,delivered,failed"),
-        ("pending", "pending", "pending"),
+        ("sending", "pending", "pending"),
         ("delivered", "delivered", "delivered"),
         ("failed", "failed", "failed"),
     ]

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -531,12 +531,13 @@ def test_time_left(job_created_at, expected_message):
     assert get_time_left(job_created_at) == expected_message
 
 
-STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1, "pending": 3}}
+STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1}}
 
 
 def test_get_status_filters_calculates_stats(client_request):
     ret = get_status_filters(Service({"id": "foo"}), "sms", STATISTICS)
 
+    # TODO WHY DO WE THINK THE PENDING COUNT SHOULD BE 3?  HOW DID THIS WORK BEFORE?
     assert {label: count for label, _option, _link, count in ret} == {
         "total": 6,
         "pending": 3,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -531,7 +531,7 @@ def test_time_left(job_created_at, expected_message):
     assert get_time_left(job_created_at) == expected_message
 
 
-STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1}}
+STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1, "pending": 3}}
 
 
 def test_get_status_filters_calculates_stats(client_request):

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -531,7 +531,7 @@ def test_time_left(job_created_at, expected_message):
     assert get_time_left(job_created_at) == expected_message
 
 
-STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1, "pending": 3}}
+STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1}}
 
 
 def test_get_status_filters_calculates_stats(client_request):

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -531,13 +531,12 @@ def test_time_left(job_created_at, expected_message):
     assert get_time_left(job_created_at) == expected_message
 
 
-STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1}}
+STATISTICS = {"sms": {"requested": 6, "failed": 2, "delivered": 1, "pending": 3}}
 
 
 def test_get_status_filters_calculates_stats(client_request):
     ret = get_status_filters(Service({"id": "foo"}), "sms", STATISTICS)
 
-    # TODO WHY DO WE THINK THE PENDING COUNT SHOULD BE 3?  HOW DID THIS WORK BEFORE?
     assert {label: count for label, _option, _link, count in ret} == {
         "total": 6,
         "pending": 3,


### PR DESCRIPTION
## Description

Recent code related to main/view/jobs.py made the assumption that service statistics coming from the back end would have a property called 'failed', when in fact they have a property called 'failure'.  This resulted in a key error which completely blew up the dashboard.

## Security Considerations

N/A