### PR TITLE
update login.gov stuff to use user uuid instead of email (notify-admi…

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -44,6 +44,16 @@ class UserApiClient(NotifyAdminAPIClient):
         user_data = self.post("/user/email", data={"email": email_address})
         return user_data["data"]
 
+    def get_user_by_uuid_or_email(self, user_uuid, email_address):
+
+        user_data = self.post(
+            "/user/get-login-gov-user",
+            data={"login_uuid": user_uuid, "email": email_address},
+        )
+        if user_data is None:
+            raise Exception("User not found")
+        return user_data["data"]
+
     def get_user_by_email_or_none(self, email_address):
         try:
             return self.get_user_by_email(email_address)


### PR DESCRIPTION
## Description

Add a new api for login.gov logins, which attempts to find the user by the login.gov uuid.  If the UUID is not present (this is not the normal case going forward, but we previously did not store the UUID so all existed users are lacking it), then match by email_address and write the user's UUID to the users table.  If the UUID is present and the emails don't match, assume the user has changed their email address in login.gov and update our email address accordingly.

## TODO

- [ ] TODO Check in matching PR in api at same time

## Security Considerations

N/A