### PR TITLE
Add simulated numbers to allow list in trial mode

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -524,10 +524,10 @@ def _check_messages(service_id, template_id, upload_id, preview_row):
         for user in Users(service_id):
             allow_list.extend([user.name, user.mobile_number, user.email_address])
         # Failed sms number
-        allow_list.extend(["simulated user", "+14254147167", "simulated@simulated.gov"])
+        allow_list.extend(["simulated user (fail)", "+14254147167", "simulated@simulated.gov"])
         # Success sms number
         allow_list.extend(
-            ["simulated user two", "+14254147755", "simulatedtwo@simulated.gov"]
+            ["simulated user (success)", "+14254147755", "simulatedtwo@simulated.gov"]
         )
     else:
         allow_list = None

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1,4 +1,3 @@
-import itertools
 import time
 import uuid
 from string import ascii_uppercase
@@ -517,19 +516,27 @@ def _check_messages(service_id, template_id, upload_id, preview_row):
         current_service,
         show_recipient=False,
     )
+
+    allow_list = []
+    if current_service.trial_mode:
+        # Adding the simulated numbers to allow list
+        # so they can be sent in trial mode
+        for user in Users(service_id):
+            allow_list.extend([user.name, user.mobile_number, user.email_address])
+        # Failed sms number
+        allow_list.extend(["simulated user", "+14254147167", "simulated@simulated.gov"])
+        # Success sms number
+        allow_list.extend(
+            ["simulated user two", "+14254147755", "simulatedtwo@simulated.gov"]
+        )
+    else:
+        allow_list = None
     recipients = RecipientCSV(
         contents,
         template=template or simplifed_template,
         max_initial_rows_shown=50,
         max_errors_shown=50,
-        guestlist=(
-            itertools.chain.from_iterable(
-                [user.name, user.mobile_number, user.email_address]
-                for user in Users(service_id)
-            )
-            if current_service.trial_mode
-            else None
-        ),
+        guestlist=allow_list,
         remaining_messages=remaining_messages,
         allow_international_sms=current_service.has_permission("international_sms"),
     )
@@ -560,7 +567,9 @@ def _check_messages(service_id, template_id, upload_id, preview_row):
 
     if preview_row < len(recipients) + 2:
         template.values = recipients[preview_row - 2].recipient_and_personalisation
-        simplifed_template.values = recipients[preview_row - 2].recipient_and_personalisation
+        simplifed_template.values = recipients[
+            preview_row - 2
+        ].recipient_and_personalisation
     elif preview_row > 2:
         abort(404)
 
@@ -863,7 +872,7 @@ def _check_notification(service_id, template_id, exception=None):
         back_link_from_preview=back_link_from_preview,
         choose_time_form=choose_time_form,
         **(get_template_error_dict(exception) if exception else {}),
-        simplifed_template=simplifed_template
+        simplifed_template=simplifed_template,
     )
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2612,8 +2612,10 @@ def test_preview_notification_shows_preview(
         session["placeholders"] = {}
 
     page = client_request.post(
-        "main.preview_notification", service_id=service_one["id"], template_id=fake_uuid,
-        _expected_status=200
+        "main.preview_notification",
+        service_id=service_one["id"],
+        template_id=fake_uuid,
+        _expected_status=200,
     )
     assert page.h1.text.strip() == "Preview"
     assert (page.find_all("a", {"class": "usa-back-link"})[0]["href"]) == url_for(


### PR DESCRIPTION
## Description

This PR is paired with another one in api adding simulated sms numbers to the allow list while in trial mode.
The simulated numbers have to be added to the guest list of recipients in order to be passed through to the api.

## TODO (optional)

- [ ] Check in paired PR in api at the same time.

## Security Considerations

I don't see any concerns since we are only adding simulated numbers to the allow list. If there are potential security concerns with how the numbers are displayed in the logic I'd love to know.
