### PR TITLE
hide csv reports in job view if no data available (notify-admin-1254)

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -28,14 +28,14 @@
         <p class="bottom-gutter hint">
           Report is {{ "{:.0f}%".format(job.percentage_complete * 0.99) }} complete…
         </p>
-      {% elif notifications %}
+      {% elif notifications  and time_left != "Data no longer available" %}
         <p class="bottom-gutter">
           <a href="{{ download_link }}" download class="usa-link heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
           &emsp;
           <span id="time-left">{{ time_left }}</span>
         </p>
       {% endif %}
-      
+
       {% call(item, row_number) list_table(
         notifications,
         caption=uploaded_file_name,


### PR DESCRIPTION
## Description

Hide the report download link if data is expired.

Note, I was actually unable to repro this.  I tried setting my clock forward by a month and then the dashboard was completely empty, so not sure how to repro.  However, the check I'm using to prevent display is used on dashboard as well so ought to work here.

## Security Considerations

N/A