### PR TITLE
Fix commit hash

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -54,7 +54,7 @@ jobs:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
-          COMMIT_HASH: $(git rev-parse --short "$GITHUB_SHA")
+          COMMIT_HASH: ${{ github.sha }}
           LOGIN_PEM: ${{ secrets.LOGIN_PEM }}
           LOGIN_DOT_GOV_CLIENT_ID: "urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov"
           LOGIN_DOT_GOV_USER_INFO_URL: "https://secure.login.gov/api/openid_connect/userinfo"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,7 +54,7 @@ jobs:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
-          COMMIT_HASH: $(git rev-parse --short "$GITHUB_SHA")
+          COMMIT_HASH: ${{ github.sha }}
           LOGIN_PEM: ${{ secrets.LOGIN_PEM }}
           LOGIN_DOT_GOV_CLIENT_ID: "urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov"
           LOGIN_DOT_GOV_USER_INFO_URL: "https://secure.login.gov/api/openid_connect/userinfo"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           ADMIN_CLIENT_SECRET: ${{ secrets.ADMIN_CLIENT_SECRET }}
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           NR_BROWSER_KEY: ${{ secrets.NR_BROWSER_KEY }}
-          COMMIT_HASH: $(git rev-parse --short "$GITHUB_SHA")
+          COMMIT_HASH: ${{ github.sha }}
           LOGIN_PEM: ${{ secrets.LOGIN_PEM }}
           LOGIN_DOT_GOV_CLIENT_ID: "urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov"
           LOGIN_DOT_GOV_USER_INFO_URL: "https://secure.login.gov/api/openid_connect/userinfo"

--- a/app/config.py
+++ b/app/config.py
@@ -36,7 +36,7 @@ class Config(object):
     NR_BROWSER_KEY = getenv("NR_BROWSER_KEY")
     settings = newrelic.agent.global_settings()
     NR_MONITOR_ON = settings and settings.monitor_mode
-    COMMIT_HASH = getenv("COMMIT_HASH", "-----")
+    COMMIT_HASH = getenv("COMMIT_HASH", "--------")[0:7]
 
     TEMPLATE_PREVIEW_API_HOST = getenv(
         "TEMPLATE_PREVIEW_API_HOST", "http://localhost:9999"

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -524,7 +524,9 @@ def _check_messages(service_id, template_id, upload_id, preview_row):
         for user in Users(service_id):
             allow_list.extend([user.name, user.mobile_number, user.email_address])
         # Failed sms number
-        allow_list.extend(["simulated user (fail)", "+14254147167", "simulated@simulated.gov"])
+        allow_list.extend(
+            ["simulated user (fail)", "+14254147167", "simulated@simulated.gov"]
+        )
         # Success sms number
         allow_list.extend(
             ["simulated user (success)", "+14254147755", "simulatedtwo@simulated.gov"]

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -49,3 +49,8 @@ def test_merge_jsonlike_merges_jsonlike_objects_correctly(
 ):
     merge_jsonlike(source_object, destination_object)
     assert source_object == expected_result
+
+def test_commit_hash():
+    # Assert that we have trimmed the default (unknown) commit hash to seven characters
+    # The real commit hash is supplied at deploy time.
+    assert current_app.config["COMMIT_HASH"] == "-------"

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import current_app
 
 from app.utils import merge_jsonlike
 
@@ -49,6 +50,7 @@ def test_merge_jsonlike_merges_jsonlike_objects_correctly(
 ):
     merge_jsonlike(source_object, destination_object)
     assert source_object == expected_result
+
 
 def test_commit_hash():
     # Assert that we have trimmed the default (unknown) commit hash to seven characters


### PR DESCRIPTION
## Description

The previous attempt to obtain the commit hash failed.  It is only obtainable at deploy time.  The previous attempt used a command so as to obtain the short 7 letter commit hash as opposed to the full one.

The new approach obtains the full commit hash using a handy dandy pre-defined GitHub variable, and then chops it to seven characters once it inside our app.

## Security Considerations

N/A