### PR TITLE
1319 - BUG - adjusting the js to only run when the targeted DOM element exists

### DIFF
--- a/app/assets/javascripts/loginAlert.js
+++ b/app/assets/javascripts/loginAlert.js
@@ -3,22 +3,28 @@
 // Set the target date (10 days before March 15th, 2024)
   const targetDate = new Date("April 16, 2024 00:00:00").getTime();
 
+// Set a const for the container to write a conditional statement and only run if it exists
+  const countdownContainer = document.getElementById("countdown-container");
+
  // Function to update the countdown display
   function updateCountdown() {
-    const now = new Date().getTime();
-    const difference = targetDate - now;
 
-    // Time calculations for days only
-    const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+    if (countdownContainer) {
+       const now = new Date().getTime();
+      const difference = targetDate - now;
 
-    // Visibility logic
-    if (days < 0 || days > 10) {
-      // Hide if more than 10 days away OR if already past the date
-      document.getElementById("countdown-container").style.display = "none";
-    } else {
-      // Show if 10 days or less remaining
-      document.getElementById("countdown-container").style.display = "block";
-      document.getElementById("countdown").innerHTML = days + " days ";
+      // Time calculations for days only
+      const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+
+      // Visibility logic
+      if (days < 0 || days > 10) {
+        // Hide if more than 10 days away OR if already past the date
+        countdownContainer.style.display = "none";
+      } else {
+        // Show if 10 days or less remaining
+        countdownContainer.style.display = "block";
+        document.getElementById("countdown").innerHTML = days + " days ";
+      }
     }
 
   }

--- a/app/assets/javascripts/loginAlert.js
+++ b/app/assets/javascripts/loginAlert.js
@@ -10,7 +10,7 @@
   function updateCountdown() {
 
     if (countdownContainer) {
-       const now = new Date().getTime();
+      const now = new Date().getTime();
       const difference = targetDate - now;
 
       // Time calculations for days only


### PR DESCRIPTION
## Description

Noticed a javascript bug on pages that were not the new sign in page prompting users to use login.gov 

## TODO (optional)

- [x] Fix JS to only run when the container for the login.gov code exists