### PR TITLE
1321 - Updated link on the sign-in page

### DIFF
--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -67,7 +67,7 @@
         <li>If you don’t have a Login.gov account, you must create one by April 16, 2024 to continue to access Notify.</li>
       </ul>
       <div class="border-bottom border-base-lighter margin-y-4"></div>
-      <a class="usa-link usa-button margin-bottom-3" href="{{ create_login_account_url }}">Create Login.gov account</a>
+      <a class="usa-link usa-button margin-bottom-3" href="{{ initial_signin_url }}">Create Login.gov account</a>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
## Description

BUG - "Create Login.gov account" button doesn't link to anything on the Sign in page. 

## TODO (optional)

- [x] Change link to the Login.gov landing page for Notify.gov so a user can Create an account
