### PR TITLE
Add missing env var from cf push

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -76,6 +76,7 @@ jobs:
             --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"
             --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
             --var NR_BROWSER_KEY="$NR_BROWSER_KEY"
+            --var COMMIT_HASH="$COMMIT_HASH"
             --var LOGIN_PEM="$LOGIN_PEM"
             --var LOGIN_DOT_GOV_CLIENT_ID="$LOGIN_DOT_GOV_CLIENT_ID"
             --var LOGIN_DOT_GOV_USER_INFO_URL="$LOGIN_DOT_GOV_USER_INFO_URL"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,6 +76,7 @@ jobs:
             --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"
             --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
             --var NR_BROWSER_KEY="$NR_BROWSER_KEY"
+            --var COMMIT_HASH="$COMMIT_HASH"
             --var LOGIN_PEM="$LOGIN_PEM"
             --var LOGIN_DOT_GOV_CLIENT_ID="$LOGIN_DOT_GOV_CLIENT_ID"
             --var LOGIN_DOT_GOV_USER_INFO_URL="$LOGIN_DOT_GOV_USER_INFO_URL"

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -196,7 +196,7 @@ def sign_in():
         form=form,
         again=bool(redirect_url),
         other_device=other_device,
-        login_gov_enabled=bool(notify_env in ["development", "staging", "demo"]),
+        login_gov_enabled=True,
         password_reset_url=password_reset_url,
         initial_signin_url=initial_signin_url,
     )

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -221,7 +221,9 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
         page.select("main p")[0].text.strip(),
     ) == (
         "You need to sign in again",
-        "We signed you out because you have not used Notify for a while.",
+        # TODO:  Improve this given Login.gov configuration.
+        # "We signed you out because you have not used Notify for a while.",
+        "You have  left to use Login.gov to sign in",
     )
     # We don’t let people update `email_access_validated_at` using an
     # already-accepted invite
@@ -335,7 +337,9 @@ def test_existing_user_of_service_get_redirected_to_signin(
         page.select("main p")[0].text.strip(),
     ) == (
         "You need to sign in again",
-        "We signed you out because you have not used Notify for a while.",
+        # TODO:  Improve this given Login.gov configuration.
+        # "We signed you out because you have not used Notify for a while.",
+        "You have  left to use Login.gov to sign in",
     )
     assert mock_accept_invite.call_count == 1
 
@@ -424,7 +428,9 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
         page.select("main p")[0].text.strip(),
     ) == (
         "You need to sign in again",
-        "We signed you out because you have not used Notify for a while.",
+        # TODO:  Improve this given Login.gov configuration.
+        # "We signed you out because you have not used Notify for a while.",
+        "You have  left to use Login.gov to sign in",
     )
 
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -24,8 +24,11 @@ def test_render_sign_in_template_for_new_user(client_request):
     # TODO:  Fix this test to be less brittle! If the Login.gov link is enabled,
     #        then these indices need to be 1 instead of 0.
     #        Currently it's not enabled for the test or production environments.
-    assert page.select("main a")[0].text == "Forgot your password?"
-    assert page.select("main a")[0]["href"] == url_for("main.forgot_password")
+    assert page.select("main a")[1].text == "Forgot your password?"
+    assert page.select("main a")[1]["href"] == url_for("main.forgot_password")
+
+    # TODO:  We'll have to adjust this depending on whether Login.gov is
+    #        enabled or not; fix this in the future.
     assert "Sign in again" not in normalize_spaces(page.text)
 
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
-from flask import current_app
+from flask import Flask
 
+from app import create_app
 from app.utils import merge_jsonlike
 
 
@@ -55,4 +56,8 @@ def test_merge_jsonlike_merges_jsonlike_objects_correctly(
 def test_commit_hash():
     # Assert that we have trimmed the default (unknown) commit hash to seven characters
     # The real commit hash is supplied at deploy time.
-    assert current_app.config["COMMIT_HASH"] == "-------"
+    app = Flask("app")
+    create_app(app)
+
+    with app.app_context() as current_app:
+        assert current_app.app.config["COMMIT_HASH"] == "-------"


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds a missing environment variable in the cf push command for the production and demo deployments.

It also enables Login.gov integration for all environments.

## Security Considerations

- Login.gov is now enabled in all environments.