### PR TITLE
Add error handling for successful Login.gov authentications without a…

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -20,6 +20,7 @@ from flask_login import current_user
 from app import login_manager, user_api_client
 from app.main import main
 from app.main.forms import LoginForm
+from app.main.views.index import error
 from app.main.views.verify import activate_user
 from app.models.user import InvitedUser, User
 from app.utils import hide_from_search_engines
@@ -77,9 +78,7 @@ def _get_user_email_and_uuid(access_token):
     return user_email, user_uuid
 
 
-@main.route("/sign-in", methods=(["GET", "POST"]))
-@hide_from_search_engines
-def sign_in():
+def _do_login_dot_gov():
     # start login.gov
     code = request.args.get("code")
     state = request.args.get("state")
@@ -90,8 +89,13 @@ def sign_in():
         redirect_url = request.args.get("next")
 
         # activate the user
-        user = user_api_client.get_user_by_uuid_or_email(user_uuid, user_email)
-        activate_user(user["id"])
+        try:
+            user = user_api_client.get_user_by_uuid_or_email(user_uuid, user_email)
+            activate_user(user["id"])
+        except BaseException as be:  # noqa B036
+            current_app.logger.error(be)
+            error(401)
+
         return redirect(url_for("main.show_accounts_or_dashboard", next=redirect_url))
 
     elif login_gov_error:
@@ -99,6 +103,11 @@ def sign_in():
         raise Exception(f"Could not login with login.gov {login_gov_error}")
     # end login.gov
 
+
+@main.route("/sign-in", methods=(["GET", "POST"]))
+@hide_from_search_engines
+def sign_in():
+    _do_login_dot_gov()
     redirect_url = request.args.get("next")
 
     if os.getenv("NOTIFY_E2E_TEST_EMAIL"):

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -4,6 +4,6 @@
   <div class="grid-row">
     <div class="grid-col-8">
     <h1>You’re not authorized to see this page</h1>
-      <p class="usa-body"><a class="usa-link" href="{{ url_for('main.sign_in' )}}">Sign in</a> to Notify.gov and try again.</p>
+      <p class="usa-body">If you have been invited to join Notify.gov, <a class="usa-link" href="{{ url_for('main.sign_in' )}}">Sign in</a> to Notify.gov using your Login.gov account and try again.</p>
   </div>
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -4,6 +4,7 @@
   <div class="grid-row">
     <div class="grid-col-8">
     <h1>You’re not authorized to see this page</h1>
-      <p class="usa-body">If you have been invited to join Notify.gov, <a class="usa-link" href="{{ url_for('main.sign_in' )}}">Sign in</a> to Notify.gov using your Login.gov account and try again.</p>
+      <p class="usa-body">If you have been invited to join Notify.gov, <a class="usa-link" href="{{ url_for('main.sign_in' )}}">sign in</a> to Notify.gov using your Login.gov account and try again.</p>
   </div>
 {% endblock %}
+e


### PR DESCRIPTION
## Description

As we move to only using Login.gov, a future use case emerges where someone with a legitimate login.gov account tries to log in, but they have never been invited to Notify.gov.   We are going to reject those users, but want something a little more clear cut than "Sorry we cannot deliver what you asked for right now" which is the generic server 500 error message.

So, enhance the 401 error page ("Not Authorized") to give a hint that a user needs to be invited to Notify.gov as well as have a Login.gov account.


## Security Considerations

We should not reveal too many specific details about what went wrong.


<img width="1728" alt="Screenshot 2024-03-21 at 9 54 02 AM" src="https://github.com/GSA/notifications-admin/assets/26859290/523fdec0-b315-4d4a-bd6d-ae579b5cc251">
