### PR TITLE
handle case where existing user is invited to another service

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -160,13 +160,16 @@ def set_up_your_profile():
         # create the user
         # TODO we have to provide something for password until that column goes away
         # TODO ideally we would set the user's preferred timezone here as well
-        user = User.register(
-            name=form.name.data,
-            email_address=user_email,
-            mobile_number=form.mobile_number.data,
-            password=str(uuid.uuid4()),
-            auth_type="sms_auth",
-        )
+
+        user = user_api_client.get_user_by_uuid_or_email(user_uuid, user_email)
+        if user is None:
+            user = User.register(
+                name=form.name.data,
+                email_address=user_email,
+                mobile_number=form.mobile_number.data,
+                password=str(uuid.uuid4()),
+                auth_type="sms_auth",
+            )
 
         # activate the user
         user = user_api_client.get_user_by_uuid_or_email(user_uuid, user_email)


### PR DESCRIPTION
## Description

The login.gov work was tested by repeated wiping the local database and testing with fresh users.  But there is another use case where a user already exists and is working in Service1, but is now invited to Service2.  Code was blowing up there with an IntegrityError because the user already exists, so check if the user exists before trying to register them.

## Security Considerations

N/A