### PR TITLE
1213 - Removed the Usage page and updated the Dashboard Landing page

### DIFF
--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -14,7 +14,7 @@
       <li class="usa-sidenav__item"><a class="{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
-      <li class="usa-sidenav__item"><a class="{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+      {# <li class="usa-sidenav__item"><a class="{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li> #}
     {% endif %}
     <!-- {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
       <li class="usa-sidenav__item"><a class="{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -7,7 +7,7 @@
       </caption>
       <thead>
         <tr>
-          <th scope="col">Usage</th>
+          <th scope="col">Sent</th>
           <th scope="col">Remaining</th>
         </tr>
       </thead>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -96,36 +96,16 @@
       </table>
     </div>
 
-    <h2 class="margin-top-4 margin-bottom-1">Usage</h2>
-    <h3 class="margin-bottom-0">Daily</h3>
-    <p class="margin-0">Across all services</p>
-    <table class="usage-table usa-table usa-table--borderless margin-top-1 margin-bottom-5">
-      <caption class="usa-sr-only">
-        Daily
-      </caption>
-      <thead>
-        <tr>
-          <th scope="col">Usage</th>
-          <th scope="col">Remaining</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{{ global_message_limit - daily_global_messages_remaining }}</td>
-          <td>
-            {{ daily_global_messages_remaining }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
+    <h2 class="margin-top-4 margin-bottom-1">Message count</h2>
     {% if current_user.has_permissions('manage_service') %}
       <h3 class='margin-bottom-0' id="current-year"></h3>
       {{ ajax_block(partials, updates_url, 'usage') }}
-      <a
-        href="{{ url_for('.usage', service_id=current_service['id']) }}"
-        class="usa-link show-more"
-      ><span>See all usage</span></a>
+      <p class="margin-top-0">During the pilot period, each service has an allowance of 250,000 message parts. Once this allowance is met, the
+      application will stop delivering messages. There's no monthly charge, no setup fee, and no procurement cost.</p>
+      <p class="align-with-heading-copy">
+        What counts as 1 text message part?<br />
+        See <a class="usa-link" href="{{ url_for('.pricing') }}">pricing</a>.
+      </p>
     {% endif %}
   </div>
 

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -21,9 +21,6 @@
       <div class='grid-row'>
 
         <div class='grid-col-12'>
-          <h2 class="heading-small margin-bottom-1">Daily messages across all services</h2>
-          <p class="margin-0">You have sent {{ global_message_limit - daily_global_messages_remaining }} of your {{ global_message_limit }} daily messages allowance.</p>
-          <p class="margin-0"></p>You have {{ daily_global_messages_remaining }} messages remaining.</p>
           <h2 class='heading-small margin-bottom-1'>Text message parts</h2>
           <div class="keyline-block">
             You have sent
@@ -82,8 +79,8 @@
             empty_message='',
             field_headings=[
               'By month',
-              hidden_field_heading('Text messages'),
-              hidden_field_heading('Cost'),
+              'Text message parts',
+              'Total message allowance',
             ],
             field_headings_visible=True
           ) %}
@@ -109,14 +106,9 @@
               {% endcall %}
             {% endfor %}
             {% call field(align='left') %}
-              {{ big_number(
-                item.sms_cost,
-                currency="$",
-                smallest=True
-              ) }}
               <ul>
               {% if item.sms_free_allowance_used %}
-                <li class="tabular-numbers">{{ item.sms_free_allowance_used|format_thousands }} free {{ item.sms_free_count|message_count_label('sms', suffix='') }}</li>
+                <li class="tabular-numbers">{{ item.sms_free_allowance_used|format_thousands }} total {{ item.sms_free_count|message_count_label('parts', suffix='') }}</li>
               {% endif %}
               {% for sms in item.sms_breakdown %}
                   <li class="tabular-numbers">{{ sms.charged_units|message_count('sms') }} at

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -133,7 +133,6 @@ def test_service_navigation_for_org_user(
             (
                 "Send messages",
                 "Sent messages",
-                "Usage",
             ),
             200,
         ),

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -363,7 +363,7 @@ def test_should_show_back_to_service_if_user_belongs_to_service(
 ):
     mock_get_service.return_value = service_one
     expected_page_text = (
-        "Test Service Switch service " "Send messages " "Dashboard " "Usage"
+        "Test Service Switch service " "Send messages " "Dashboard"
     )  # TODO: set sidebar variables in common test module
 
     page = client_request.get(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -40,7 +40,7 @@ from tests.conftest import (
             {"message_type": "sms"},
             "/sms.json",
             7,
-            "Text messages",
+            "Text message",
         ),
         (
             create_active_caseworking_user(),

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1045,17 +1045,8 @@ def test_usage_page_monthly_breakdown(
     monthly_breakdown = normalize_spaces(page.find("table").text)
 
     assert "October" in monthly_breakdown
-    assert "249,860 free text messages" in monthly_breakdown
-
     assert "February" in monthly_breakdown
-    assert "$16.40" in monthly_breakdown
-    assert "140 free text messages" in monthly_breakdown
-    assert "960 text messages at 1.65p" in monthly_breakdown
-    assert "33 text messages at 1.70p" in monthly_breakdown
-
     assert "March" in monthly_breakdown
-    assert "$20.91" in monthly_breakdown
-    assert "1,230 text messages at 1.70p" in monthly_breakdown
 
 
 @pytest.mark.parametrize(
@@ -1804,15 +1795,8 @@ def test_service_dashboard_shows_usage(
 
     usage_table = page.find("table", class_="usage-table")
 
-    # Check if the "Usage" table exists
-    assert usage_table is not None
-
-    table_rows = usage_table.find_all("tbody")[0].find_all("tr")
-
-    assert len(table_rows) == 1
-
-    assert "500" in table_rows[0].find_all("td")[0].text
-    assert "9500" in table_rows[0].find_all("td")[1].text
+    # Check if the "Usage" table doesn't exist
+    assert usage_table is None
 
 
 def test_service_dashboard_shows_free_allowance(
@@ -1847,7 +1831,7 @@ def test_service_dashboard_shows_free_allowance(
 
     usage_text = normalize_spaces(page.select_one("[data-key=usage]").text)
     assert "spent on text messages" not in usage_text
-    assert "Daily Usage Remaining 1,000 249,000" in usage_text
+    assert "Daily Sent Remaining 1,000 249,000" in usage_text
 
 
 def test_service_dashboard_shows_batched_jobs(

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -401,7 +401,7 @@ def test_navigation_urls(
     assert [a["href"] for a in page.select(".nav a")] == [
         "/services/{}/templates".format(SERVICE_ONE_ID),
         "/services/{}".format(SERVICE_ONE_ID),
-        "/services/{}/usage".format(SERVICE_ONE_ID),
+        # "/services/{}/usage".format(SERVICE_ONE_ID),
         # "/services/{}/users".format(SERVICE_ONE_ID),
         # "/services/{}/service-settings".format(SERVICE_ONE_ID),
         # '/services/{}/api'.format(SERVICE_ONE_ID),


### PR DESCRIPTION
## Description

- Dashboard: Delete Daily limits and updated 2024 limits to 250,000, having them increment with use.
- Usage: This page is inaccurate in many ways. If revising this isn't a short-term priority, I recommend deleted it to avoid confusion.

## TODO

- [x] Deleted daily limits from Dashboard page as this isn't a thing that truly exists
- [x] Added context and changed some content on the "Usage" table at the bottom of the Dashboard page
- [x] The Usage page in the dashboard area has a table with math for the text messages/text message parts that was incorrect, so for the time being we're removing the link to this page so that it can not be accessed from the Dashboard page.