### PR TITLE
Handle new user case

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -50,8 +50,8 @@ class UserApiClient(NotifyAdminAPIClient):
             "/user/get-login-gov-user",
             data={"login_uuid": user_uuid, "email": email_address},
         )
-        if user_data is None:
-            raise Exception("User not found")
+        if user_data is None or user_data.get("data") is None:
+            return None
         return user_data["data"]
 
     def get_user_by_email_or_none(self, email_address):


### PR DESCRIPTION
## Description

I think there was some confusion because login_dot_gov stuff was originally implemented just for the 'sign in' case, and we were raising an exception if we did not recognize the user in our database.  But with this register case, of course we may not recognize the user, because potentially they may be a brand new user.  So return None instead of raising and exception, and if None is returned during registration then register the new user, etc.


## Security Considerations

N/A