### PR TITLE
1423 - Few final updates to switch over to login.gov

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -197,7 +197,6 @@ def sign_in():
         form=form,
         again=bool(redirect_url),
         other_device=other_device,
-        login_gov_enabled=True,
         password_reset_url=password_reset_url,
         initial_signin_url=url,
     )

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -12,18 +12,6 @@
 
 {% block maincolumn_content %}
 
-{% if login_gov_enabled %}
-<div class="grid-row">
-  <div id="countdown-container" class="usa-alert usa-alert--warning width-full margin-bottom-4">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading">Login.gov is required by April 16, 2024</h4>
-      <p class="usa-alert__text">
-        You have <span id="countdown"></span> left to use Login.gov to sign in
-      </p>
-    </div>
-  </div>
-</div>
-{% endif %}
 <div class="grid-row margin-bottom-4">
   <div class="tablet:grid-col-5">
     {% if again %}
@@ -39,22 +27,12 @@
       {% endif %}
     {% else %}
       <h1 class="font-body-2xl margin-bottom-3">Sign in</h1>
-      {% if login_gov_enabled %}
-      <p>You can access your account by signing in with one of the options below:</p>
-      <a class="usa-link usa-button usa-button--outline" href="{{ initial_signin_url }}">Sign in with Login.gov</a>
-      <p class="margin-y-3"><strong>Or:</strong></p>
-      {% endif %}
+      <p>Access your Notify.gov account by signing in with Login.gov:</p>
+      <a class="usa-link usa-button" href="{{ initial_signin_url }}">Sign in with Login.gov</a>
     {% endif %}
-
-    {% call form_wrapper(autocomplete=True) %}
-      {{ form.email_address(param_extensions={"autocomplete": "email"}) }}
-      {{ form.password(param_extensions={"autocomplete": "current-password"}) }}
-      {{ page_footer("Continue", secondary_link=password_reset_url, secondary_link_text="Forgot your password?") }}
-    {% endcall %}
   </div>
-  {% if login_gov_enabled %}
     <div class="tablet:grid-col-6 tablet:grid-offset-1 margin-top-2 padding-y-2 padding-x-4 bg-base-lightest">
-      <h2 class="font-body-lg">Notify.gov is changing the sign-in experience to Login.gov effective<br>April 16, 2024</h2>
+      <h2 class="font-body-lg">Effective April 16, 2024 Notify.gov requires you sign-in through Login.gov</h2>
       <p>Why are we doing this?</p>
       <ul class="usa-list">
         <li><strong>Enhanced security:</strong> Login.gov is really secure and trustworthy</li>
@@ -64,12 +42,11 @@
       <p>What do I need to do?</p>
       <ul class="usa-list">
         <li>If you have a Login.gov account, start using it to sign in to Notify today.</li>
-        <li>If you don’t have a Login.gov account, you must create one by April 16, 2024 to continue to access Notify.</li>
+        <li>If you don’t have a Login.gov account, you must create one to continue to access Notify.</li>
       </ul>
       <div class="border-bottom border-base-lighter margin-y-4"></div>
-      <a class="usa-link usa-button margin-bottom-3" href="{{ initial_signin_url }}">Create Login.gov account</a>
+      <a class="usa-link usa-button usa-button--outline margin-bottom-3" href="{{ initial_signin_url }}">Create Login.gov account</a>
     </div>
   </div>
-{% endif %}
 
 {% endblock %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1516,7 +1516,6 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
-    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -2383,6 +2382,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -222,8 +222,7 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
     ) == (
         "You need to sign in again",
         # TODO:  Improve this given Login.gov configuration.
-        # "We signed you out because you have not used Notify for a while.",
-        "You have  left to use Login.gov to sign in",
+        "We signed you out because you have not used Notify for a while.",
     )
     # We don’t let people update `email_access_validated_at` using an
     # already-accepted invite
@@ -338,8 +337,7 @@ def test_existing_user_of_service_get_redirected_to_signin(
     ) == (
         "You need to sign in again",
         # TODO:  Improve this given Login.gov configuration.
-        # "We signed you out because you have not used Notify for a while.",
-        "You have  left to use Login.gov to sign in",
+        "We signed you out because you have not used Notify for a while.",
     )
     assert mock_accept_invite.call_count == 1
 
@@ -429,8 +427,7 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
     ) == (
         "You need to sign in again",
         # TODO:  Improve this given Login.gov configuration.
-        # "We signed you out because you have not used Notify for a while.",
-        "You have  left to use Login.gov to sign in",
+        "We signed you out because you have not used Notify for a while.",
     )
 
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -12,38 +12,19 @@ def test_render_sign_in_template_for_new_user(client_request):
     client_request.logout()
     page = client_request.get("main.sign_in")
     assert normalize_spaces(page.select_one("h1").text) == "Sign in"
-    assert normalize_spaces(page.select("label")[0].text) == "Email address"
-    assert page.select_one("#email_address").get("value") is None
-    assert page.select_one("#email_address")["autocomplete"] == "email"
-    assert normalize_spaces(page.select("label")[1].text) == "Password"
-    assert page.select_one("#password").get("value") is None
-    assert page.select_one("#password")["autocomplete"] == "current-password"
-    # Removing for the pilot
-    # assert page.select('main a')[0].text == 'create one now'
-    # assert page.select('main a')[0]['href'] == url_for('main.register')
+    assert (
+        page.select("main p")[0].text
+        == "Access your Notify.gov account by signing in with Login.gov:"
+    )
     # TODO:  Fix this test to be less brittle! If the Login.gov link is enabled,
     #        then these indices need to be 1 instead of 0.
     #        Currently it's not enabled for the test or production environments.
-    assert page.select("main a")[1].text == "Forgot your password?"
-    assert page.select("main a")[1]["href"] == url_for("main.forgot_password")
+    assert page.select("main a")[0].text == "Sign in with Login.gov"
+    assert page.select("main a")[1].text == "Create Login.gov account"
 
     # TODO:  We'll have to adjust this depending on whether Login.gov is
     #        enabled or not; fix this in the future.
     assert "Sign in again" not in normalize_spaces(page.text)
-
-
-def test_render_sign_in_template_with_next_link_for_password_reset(client_request):
-    client_request.logout()
-    page = client_request.get(
-        "main.sign_in",
-        _optional_args=f"?next=/services/{SERVICE_ONE_ID}/templates",
-        _test_page_title=False,
-    )
-    forgot_password_link = page.find("a", class_="usa-link")
-    assert forgot_password_link.text == "Forgot your password?"
-    assert forgot_password_link["href"] == url_for(
-        "main.forgot_password", next=f"/services/{SERVICE_ONE_ID}/templates"
-    )
 
 
 def test_reformat_keystring():


### PR DESCRIPTION
## Description

Final adjustments to the sign-in flow to reflect the new reality of using login.gov

- [X] Remove native user name and password fields as well as the button to Sign In
- [X] Change content to reflect that we are now using Login.gov
