### PR TITLE
fix 90 day email validation

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -6,6 +6,7 @@ import jwt
 import requests
 from flask import (
     Markup,
+    Response,
     abort,
     current_app,
     flash,
@@ -26,6 +27,7 @@ from app.main.views.verify import activate_user
 from app.models.user import InvitedUser, User
 from app.utils import hide_from_search_engines
 from app.utils.login import is_safe_redirect_url
+from app.utils.time import is_less_than_days_ago
 
 
 def _reformat_keystring(orig):
@@ -100,20 +102,47 @@ def _do_login_dot_gov():
             user_email, user_uuid = _get_user_email_and_uuid(access_token)
             redirect_url = request.args.get("next")
             user = user_api_client.get_user_by_uuid_or_email(user_uuid, user_email)
-            activate_user(user["id"])
+
+            # Check if the email needs to be revalidated
+            is_fresh_email = is_less_than_days_ago(
+                user["email_access_validated_at"], 90
+            )
+            if not is_fresh_email:
+                return verify_email(user, redirect_url)
+
+            usr = User.from_email_address(user["email_address"])
+            activate_user(usr.id)
         except BaseException as be:  # noqa B036
             current_app.logger.error(be)
             error(401)
-
         return redirect(url_for("main.show_accounts_or_dashboard", next=redirect_url))
 
     # end login.gov
 
 
+def verify_email(user, redirect_url):
+    user_api_client.send_verify_code(user["id"], "email", None, redirect_url)
+    title = "Email resent" if request.args.get("email_resent") else "Check your email"
+    redirect_url = request.args.get("next")
+    return render_template(
+        "views/re-validate-email-sent.html", title=title, redirect_url=redirect_url
+    )
+
+
 @main.route("/sign-in", methods=(["GET", "POST"]))
 @hide_from_search_engines
 def sign_in():
-    _do_login_dot_gov()
+    # If we have to revalidated the email, send the message
+    # via email and redirect to the "verify your email page"
+    # and don't proceed further with login
+    email_verify_template = _do_login_dot_gov()
+    if (
+        email_verify_template
+        and not isinstance(email_verify_template, Response)
+        and "Check your email" in email_verify_template
+    ):
+        return email_verify_template
+
     redirect_url = request.args.get("next")
 
     if os.getenv("NOTIFY_E2E_TEST_EMAIL"):


### PR DESCRIPTION
## Description

Adapt the 90 day email verification routine so that it works with login.gov.

1. User will log in with login.gov and be "logged in" as far as login.gov is concerned.
2. We will check and see that their email has not been validated in the last 90 days
3. We will send the "verify your email" email and redirect them to a page that tells them to check their email
4. They will click on the the link in their email that will redirect them back to the main page, and since they are already logged in, everything should be good at that point.



## Security Considerations

N/A