### PR TITLE
Restore previous sign in form

### DIFF
--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -28,8 +28,14 @@
       <a class="usa-link usa-button" href="{{ initial_signin_url }}">Sign in with Login.gov</a>
     {% else %}
       <h1 class="font-body-2xl margin-bottom-3">Sign in</h1>
-      <p>Access your Notify.gov account by signing in with Login.gov:</p>
+      <p>You can access your account by signing in with one of the options below:</p>
       <a class="usa-link usa-button" href="{{ initial_signin_url }}">Sign in with Login.gov</a>
+      <p class="margin-y-3"><strong>Or:</strong></p>
+      {% call form_wrapper(autocomplete=True) %}
+        {{ form.email_address(param_extensions={"autocomplete": "email"}) }}
+        {{ form.password(param_extensions={"autocomplete": "current-password"}) }}
+        {{ page_footer("Continue", secondary_link=password_reset_url, secondary_link_text="Forgot your password?") }}
+      {% endcall %}
     {% endif %}
   </div>
     <div class="tablet:grid-col-6 tablet:grid-offset-1 margin-top-2 padding-y-2 padding-x-4 bg-base-lightest">

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -39,7 +39,7 @@
     {% endif %}
   </div>
     <div class="tablet:grid-col-6 tablet:grid-offset-1 margin-top-2 padding-y-2 padding-x-4 bg-base-lightest">
-      <h2 class="font-body-lg">Effective April 16, 2024 Notify.gov requires you sign-in through Login.gov</h2>
+      <h2 class="font-body-lg">Notify.gov is transitioning our sign-on process to Login.gov</h2>
       <p>Why are we doing this?</p>
       <ul class="usa-list">
         <li><strong>Enhanced security:</strong> Login.gov is really secure and trustworthy</li>

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -14,7 +14,9 @@ def test_render_sign_in_template_for_new_user(client_request):
     assert normalize_spaces(page.select_one("h1").text) == "Sign in"
     assert (
         page.select("main p")[0].text
-        == "Access your Notify.gov account by signing in with Login.gov:"
+        # TODO: Restore once we resolve the Login.gov account permission issue.
+        # == "Access your Notify.gov account by signing in with Login.gov:"
+        == "You can access your account by signing in with one of the options below:"
     )
     # TODO:  Fix this test to be less brittle! If the Login.gov link is enabled,
     #        then these indices need to be 1 instead of 0.

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -22,7 +22,9 @@ def test_render_sign_in_template_for_new_user(client_request):
     #        then these indices need to be 1 instead of 0.
     #        Currently it's not enabled for the test or production environments.
     assert page.select("main a")[0].text == "Sign in with Login.gov"
-    assert page.select("main a")[1].text == "Create Login.gov account"
+    # TODO: Restore once we resolve the Login.gov account permission issue.
+    # assert page.select("main a")[1].text == "Create Login.gov account"
+    assert page.select("main a")[1].text == "Forgot your password?"
 
     # TODO:  We'll have to adjust this depending on whether Login.gov is
     #        enabled or not; fix this in the future.


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset restores the original sign-in form that we hid so that folks can still sign into Notify.gov and have full access to their accounts.

There is currently an issue that we are investigating where some users do not have full account access when signing in via Login.gov, so we are providing this as a work around until we can resolve the full issue.

## Security Considerations

- This reintroduces the previous sign-in form, but none of the other code has been removed for it yet.
- Users should be able to sign in with full access to their account/service(s).
- Login.gov is still an option and the preferred sign-in mechanism.