### PR TITLE
Bug: Adjust email/password Settings to reflect Login.gov

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -31,22 +31,6 @@
         {% endcall %}
 
         {% call row() %}
-          {{ text_field('Sign-in method') }}
-          {{ text_field(
-            'Email link or text message code'
-            if 'email_auth' in current_service.permissions
-            else 'Text message code'
-          ) }}
-          {{ edit_field(
-              'Change',
-              url_for('.service_set_auth_type', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='sign-in method',
-            )
-          }}
-        {% endcall %}
-
-        {% call row() %}
           {{ text_field('Send text messages') }}
           {{ boolean_field('sms' in current_service.permissions) }}
           {{ edit_field(

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -66,7 +66,8 @@
   </div>
 
   <h2>Sign-in method</h2>
-  <p>Your username, password, and multi-factor authentication options are handled by Login.gov.  To make changes, head to <a href="https://secure.login.gov/">Login.gov</a>
-    and sign-in with your credentials.  Any changes made to your Login.gov account will automatically be synced with Notify.gov.</p>
+  <p>Your username, password, and multi-factor authentication options are handled by Login.gov. </p>
+  <p>To make changes, head to <a href="https://secure.login.gov/">Login.gov</a>
+  and sign-in with your credentials.  Any changes made to your Login.gov account will automatically be synced with Notify.gov.</p>
 
 {% endblock %}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -65,4 +65,8 @@
     {% endcall %}
   </div>
 
+  <h2>Sign-in method</h2>
+  <p>Your username, password, and multi-factor authentication options are handled by Login.gov.  To make changes, head to <a href="https://secure.login.gov/">Login.gov</a>
+    and sign-in with your credentials.  Any changes made to your Login.gov account will automatically be synced with Notify.gov.</p>
+
 {% endblock %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -52,7 +52,6 @@ def _mock_get_service_settings_page_common(
             [
                 "",
                 "Service name Test Service Change service name",
-                "Sign-in method Text message code Change sign-in method",
                 "Send text messages On Change your settings for sending text messages",
                 "Start text messages with service name On Change your settings "
                 "for starting text messages with service name",
@@ -63,7 +62,6 @@ def _mock_get_service_settings_page_common(
             [
                 "",
                 "Service name Test Service Change service name",
-                "Sign-in method Text message code Change sign-in method",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message senders (Only visible to Platform Admins) GOVUK Manage text message senders",
                 "Start text messages with service name On Change your settings "
@@ -192,7 +190,6 @@ def test_send_files_by_email_row_on_settings_page(
             ["email", "sms", "international_sms"],
             [
                 "Service name service one Change service name",
-                "Sign-in method Text message code Change sign-in method",
                 "Send text messages On Change your settings for sending text messages",
                 "Start text messages with service name On Change your settings "
                 "for starting text messages with service name",
@@ -202,7 +199,6 @@ def test_send_files_by_email_row_on_settings_page(
             ["email", "sms", "email_auth"],
             [
                 "Service name service one Change service name",
-                "Sign-in method Email link or text message code Change sign-in method",
                 "Send text messages On Change your settings for sending text messages",
                 "Start text messages with service name On Change your settings "
                 "for starting text messages with service name",


### PR DESCRIPTION
## Description
These are simple content changes to reflect the new login.gov

- [x] The first is to remove a row from the service-settings menu 

![image](https://github.com/GSA/notifications-admin/assets/53159604/5601a4b3-5a27-4ba4-ba81-63fd36d54dff)

- [x] The second change is to add content verbiage to the User profile page 

![image](https://github.com/GSA/notifications-admin/assets/53159604/95d3e2e8-3fd9-4c02-b2fa-0e41c3b06ac2)
