### PR TITLE
Removed canceled users from displaying in dashboard

### DIFF
--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -31,67 +31,70 @@
 
   <div class="user-list">
     {% for user in users %}
-      <div class="user-list-item">
-        <h2 class="user-list-item-heading font-body-lg margin-top-0" title="{{ user.email_address }}">
-          {%- if user.name -%}
-          <span class="heading-small live-search-relevant">{{ user.name }}</span>
-          {%- endif -%}
-          {%- if user.status == 'pending' -%}
-            <span class="live-search-relevant">{{ user.email_address }}</span><span class="hint">(invited)</span>
-          {%- elif user.status == 'cancelled' -%}
-            <span class="live-search-relevant">{{ user.email_address }}</span><span class="hint">(cancelled invite)</span>
-          {%- elif user.status == 'expired' -%}
-            <span class="live-search-relevant">{{ user.email_address }}</span><span class="hint">(expired invite)</span>
-          {%- elif user.id == current_user.id -%}
-            <span class="live-search-relevant"></span><span class="hint">(you)</span>
-          {% else %}
-            <span class="live-search-relevant">{{ user.email_address }}</span>
-          {% endif %}
-        </h2>
-        <h3 class="margin-bottom-0">Permissions</h3>
-        <ul class="tick-cross-list-permissions">
-          {% for permission, label in permissions %}
-            {{ tick_cross(
-              user.has_permission_for_service(current_service.id, permission),
-              label
-            ) }}
-          {% endfor %}
-        </ul>
-        {# only show if the service has folders #}
-        {% if current_service.all_template_folders %}
-          <p class="usa-body tick-cross-list-hint">
-            {% set folder_count = user.template_folders_for_service(current_service) | length %}
-            {% if folder_count == 0 %}
-              Cannot see any folders
-            {% elif folder_count != current_service.all_template_folders | length %}
-              Can see {{ folder_count }} folder{% if folder_count > 1 %}s{% endif %}
+      {% if user.status != 'cancelled' %}
+        <div class="user-list-item">
+          <h2 class="user-list-item-heading font-body-lg margin-top-0" title="{{ user.email_address }}">
+            {%- if user.name -%}
+            <span class="heading-small live-search-relevant">{{ user.name }}</span>
+            {%- endif -%}
+            {%- if user.status == 'pending' -%}
+              <span class="live-search-relevant">{{ user.email_address }}</span><span class="hint">(invited)</span>
+            {%- elif user.status == 'cancelled' -%}
+              <span class="live-search-relevant">{{ user.email_address }}</span><span class="hint">(cancelled invite)</span>
+            {%- elif user.status == 'expired' -%}
+              <span class="live-search-relevant">{{ user.email_address }}</span><span class="hint">(expired invite)</span>
+            {%- elif user.id == current_user.id -%}
+              <span class="live-search-relevant"></span><span class="hint">(you)</span>
             {% else %}
-              Can see all folders
-            {% endif%}
-          </p>
-        {% endif %}
-        {% if current_service.has_permission('email_auth') %}
-          <p class="usa-body tick-cross-list-hint">
-            Signs in with
-            {{ user.auth_type | format_auth_type(with_indefinite_article=True) }}
-          </p>
-        {% endif %}
-        {% if current_service.has_permission('email_auth') %}
-          <p class="usa-body tick-cross-list-hint">
-            Signs in with
-            {{ user.auth_type | format_auth_type(with_indefinite_article=True) }}
-          </p>
-          {% endif %}
-            {% if current_user.has_permissions('manage_service') %}
-              {% if user.status == 'pending' %}
-                <a class="user-list-edit-link usa-link" href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation<span class="usa-sr-only"> for {{ user.email_address }}</span></a>
-              {% elif user.status == 'expired' %}
-                <a class="user-list-edit-link usa-link" href="{{ url_for('.resend_invite', service_id=current_service.id, invited_user_id=user.id)}}">Resend invite<span class="usa-sr-only"> for {{ user.email_address }}</span></a>
-              {% elif user.is_editable_by(current_user) %}
-                <a class="user-list-edit-link usa-link" href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details<span class="usa-sr-only"> for {{ user.name }} {{ user.email_address }}</span></a>
+              <span class="live-search-relevant">{{ user.email_address }}</span>
             {% endif %}
+          </h2>
+          <h3 class="margin-bottom-0">Permissions</h3>
+          <ul class="tick-cross-list-permissions">
+            {% for permission, label in permissions %}
+              {{ tick_cross(
+                user.has_permission_for_service(current_service.id, permission),
+                label
+              ) }}
+            {% endfor %}
+          </ul>
+          {# only show if the service has folders #}
+          {% if current_service.all_template_folders %}
+            <p class="usa-body tick-cross-list-hint">
+              {% set folder_count = user.template_folders_for_service(current_service) | length %}
+              {% if folder_count == 0 %}
+                Cannot see any folders
+              {% elif folder_count != current_service.all_template_folders | length %}
+                Can see {{ folder_count }} folder{% if folder_count > 1 %}s{% endif %}
+              {% else %}
+                Can see all folders
+              {% endif%}
+            </p>
           {% endif %}
-      </div>
+          {% if current_service.has_permission('email_auth') %}
+            <p class="usa-body tick-cross-list-hint">
+              Signs in with
+              {{ user.auth_type | format_auth_type(with_indefinite_article=True) }}
+            </p>
+          {% endif %}
+          {% if current_service.has_permission('email_auth') %}
+            <p class="usa-body tick-cross-list-hint">
+              Signs in with
+              {{ user.auth_type | format_auth_type(with_indefinite_article=True) }}
+            </p>
+            {% endif %}
+              {% if current_user.has_permissions('manage_service') %}
+                {% if user.status == 'pending' or user.status == 'expired' %}
+                  <a class="user-list-edit-link usa-link" href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation<span class="usa-sr-only"> for {{ user.email_address }}</span></a>
+                {% endif %}
+                {% if user.status == 'expired' %}
+                  <a class="user-list-edit-link usa-link" href="{{ url_for('.resend_invite', service_id=current_service.id, invited_user_id=user.id)}}">Resend invite<span class="usa-sr-only"> for {{ user.email_address }}</span></a>
+                {% elif user.is_editable_by(current_user) %}
+                  <a class="user-list-edit-link usa-link" href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details<span class="usa-sr-only"> for {{ user.name }} {{ user.email_address }}</span></a>
+                {% endif %}
+            {% endif %}
+        </div>
+      {% endif %}
     {% endfor %}
   </div>
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1249,14 +1249,15 @@ def test_cancel_invited_user_doesnt_work_if_user_not_invited_to_this_service(
                 "Cancel invitation for invited_user@test.gsa.gov"
             ),
         ),
-        (
-            "cancelled",
-            (
-                "invited_user@test.gsa.gov(cancelled invite) "
-                "Permissions"
-                # all permissions are greyed out
-            ),
-        ),
+        # Test case removed due to the removal of canceled users from the dashboard
+        # (
+        #     "cancelled",
+        #     (
+        #         "invited_user@test.gsa.gov(cancelled invite) "
+        #         "Permissions"
+        #         # all permissions are greyed out
+        #     ),
+        # ),
     ],
 )
 def test_manage_users_shows_invited_user(


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our
[code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews)
to know what to keep in mind while reviewing pull requests.*

## Description

Adjusted the manage-users.html template to not display users with a canceled invite. Also, added the option to cancel a user in addition to resending the invite.

This should include:

This addressed the request in https://github.com/GSA/notifications-admin/issues/1155

![image](https://github.com/GSA/notifications-admin/assets/108748167/1954ba03-1f92-4b5b-bb84-760e78536d02)

## TODO (optional)

## Security Considerations

NA

- None; this is a documentation update with publicly available information.
