### PR TITLE
cleaned up and removed from_job and notification_id from redirect

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1006,8 +1006,6 @@ def send_notification(service_id, template_id):
             ".view_job",
             service_id=service_id,
             job_id=upload_id,
-            from_job=upload_id,
-            notification_id=notifications["notifications"][0]["id"],
             # used to show the final step of the tour (help=3) or not show
             # a back link on a just sent one off notification (help=0)
             help=request.args.get("help"),


### PR DESCRIPTION
Now that we are redirecting to .view_job when user sends one-off messages, from_job and notification_id are no longer needed. 