### PR TITLE
Updated filename string into db for a notification and UI display

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -948,7 +948,9 @@ def send_notification(service_id, template_id):
     vals = ",".join(values)
     data = f"{data}\r\n{vals}"
 
-    filename = f"one-off-{current_user.name}-{uuid.uuid4()}.csv"
+    filename = (
+        f"one-off-{uuid.uuid4()}.csv"  # {current_user.name} removed from filename
+    )
     my_data = {"filename": filename, "template_id": template_id, "data": data}
     upload_id = s3upload(service_id, my_data)
     form = CsvUploadForm()

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -59,7 +59,7 @@
                 {% set notification = job.notifications[0] %}
                 <tr class="table-row" id="{{ job.job_id }}">
                   <td class="table-field file-name">
-                    {{ notification.job.original_file_name if notification.job.original_file_name else 'Manually entered number'}}
+                    {{ notification.job.original_file_name[:12] if notification.job.original_file_name else 'Manually entered number'}}
                     <br>
                     <a class="usa-link file-list-filename" href="{{ job.view_job_link }}">View Batch</a>
                   </td>


### PR DESCRIPTION
## Description
Updated the filename string of a "one-off" csv to be [one-off-uuid4].csv for notifications. The display for the filename on the dashboard was truncated to only show the first 12 characters of the string [one-off-12ab].

This should include:

![image](https://github.com/GSA/notifications-admin/assets/108748167/a56f0d83-02ff-4cc9-a8ec-f43a5d80abb6)

## Security Considerations

There are no security considerations and using the uuid4 full string should still prevent collisions in the db.
