### PR TITLE
Updated config files to split the cloud foundry and public admin routes

### DIFF
--- a/deploy-config/demo.yml
+++ b/deploy-config/demo.yml
@@ -2,6 +2,7 @@ env: demo
 instances: 1
 memory: 1G
 public_admin_route: notify-demo.app.cloud.gov
+cloud_dot_gov_route: notify-demo.app.cloud.gov
 redis_enabled: 1
 nr_agent_id: "1134302465"
 nr_app_id: "1083160688"

--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -1,7 +1,8 @@
 env: production
 instances: 2
 memory: 1G
-public_admin_route: notify.app.cloud.gov
+public_admin_route: beta.notify.gov
+cloud_dot_gov_route: notify.app.cloud.gov
 redis_enabled: 1
 nr_agent_id: "1050708682"
 nr_app_id: "1050708682"

--- a/deploy-config/sandbox.yml
+++ b/deploy-config/sandbox.yml
@@ -2,6 +2,7 @@ env: sandbox
 instances: 1
 memory: 1G
 public_admin_route: notify-sandbox.app.cloud.gov
+cloud_dot_gov_route: notify-sandbox.app.cloud.gov
 redis_enabled: 1
 ADMIN_CLIENT_USERNAME: notify-admin
 ADMIN_CLIENT_SECRET: sandbox-notify-secret-key

--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -2,6 +2,7 @@ env: staging
 instances: 1
 memory: 1G
 public_admin_route: notify-staging.app.cloud.gov
+cloud_dot_gov_route: notify-staging.app.cloud.gov
 redis_enabled: 1
 nr_agent_id: "1134291385"
 nr_app_id: "1031640326"

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,7 @@ applications:
     health-check-type: port
     health-check-invocation-timeout: 10
     routes:
-      - route: ((public_admin_route))
+      - route: ((cloud_dot_gov_route))
 
     services:
       - notify-admin-redis-((env))


### PR DESCRIPTION
## Description

The configuration files were updated to add a new variable _cloud_dot_gov_route_ which will act as the the route config variable for cloud foundry.

production.yml
demo.yml
staging.yml
sandbox.yml
manifest.yml 

This change was made to allow the splitting of the platform url, currently set using _public_admin_route_, from the one used by cloud foundry to configure application communications. The manifest.yml now calls the old and new variable from the configuration yml's to build the needed environment variables to deploy. 

## TODO (optional)

If you're opening a draft PR, it might be helpful to list any outstanding work,
especially if you're asking folks to take a look before it's ready for full
review.  In this case, create a small checklist with the outstanding items:

- [ ] TODO Test Production deployment
- [ ] TODO Test Demo deployment
- [ ] TODO Test Staging deployment
- [ ] TODO Test Sandbox deployment

## Security Considerations

This is a change to the public route of the application, we should check to make sure that anything supporting the application from a security perspective was not looking specifically for the _notify.app.cloud.gov_ url. 

