### PR TITLE
Exception Investigation: app.notify_client:InviteTokenError

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -244,9 +244,11 @@ def get_invited_user_email_address(invited_user_id):
 
 
 def invited_user_accept_invite(invited_user_id):
-    # InvitedUser is an unhashable type and hard to mock in tests
-    # so this convenience method is a workaround for that
     invited_user = InvitedUser.by_id(invited_user_id)
+    if invited_user.status == "expired":
+        current_app.logger.error("User invitation has expired")
+        flash("Your invitation has expired.")
+        abort(401)
     invited_user.accept_invite()
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1278,6 +1278,7 @@ files = [
     {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c38d7b9a690b090de999835f0443d8aa93ce5f2064035dfc48f27f02b4afc3d0"},
     {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5670fb70a828663cc37552a2a85bf2ac38475572b0e9b91283dc09efb52c41d1"},
     {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:958244ad566c3ffc385f47dddde4145088a0ab893504b54b52c041987a8c1863"},
+    {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b6241d4eee5f89453307c2f2bfa03b50362052ca0af1efecf9fef9a41a22bb4f"},
     {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:2a66bf12fbd4666dd023b6f51223aed3d9f3b40fef06ce404cb75bafd3d89536"},
     {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:9123716666e25b7b71c4e1789ec829ed18663152008b58544d95b008ed9e21e9"},
     {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:0c3f67e2aeda739d1cc0b1102c9a9129f7dc83901226cc24dd72ba275ced4218"},
@@ -1594,6 +1595,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 


### PR DESCRIPTION
## Description

The investigation of this exception showed that the original issue no longer exists.  However, it also showed that changing the invitation flow to use login.gov removed the check to see if invitations had expired, and that it was possible to use an expired invitation successfully.

The reason for this is that the previous approach used two different, parallel mechanisms to track invitation expirations:

1.  The status and created_at columns in the invited_users table were updated by a scheduled task that changed the status to 'expired' after 48 hours if an invitation had not been accepted.
2.  The actually check of expiration time was inside an encrypted token that was passed in the original invite URL.  When this URL was replaced with the login.gov URL, this token went away.

The new approach uses just one way to check if invitations have expired -- the invited users table and its status and created_at columns.

## Security Considerations

N/A