### PR TITLE
change vulture rules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,9 @@ py-test: ## Run python unit tests
 	poetry run coverage html -d .coverage_cache
 
 .PHONY: dead-code
-dead-code:
-	poetry run vulture ./app ./notifications_utils --min-confidence=60
+dead-code: ## 60% is our aspirational goal, but currently breaks the build
+	poetry run vulture ./app ./notifications_utils --min-confidence=100
+
 
 .PHONY: e2e-test
 e2e-test: export NEW_RELIC_ENVIRONMENT=test

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ py-test: ## Run python unit tests
 
 .PHONY: dead-code
 dead-code:
-	poetry run vulture ./app --min-confidence=100
+	poetry run vulture ./app ./notifications_utils --min-confidence=60
 
 .PHONY: e2e-test
 e2e-test: export NEW_RELIC_ENVIRONMENT=test


### PR DESCRIPTION
## Description

Right now if we set the confidence level on vulture to 65%, vulture will return no dead code in this project.  If we set vulture to 60% though, we get a number of results.  At a level of 60%, vulture is just giving an educated guess about whether some code is dead or not.  We can see some things that are definitely dead, some that definitely aren't, and a lot where we have no idea.

So we can't just update the Makefile to 60% because it will break the build.  Add a comment that the change to 60% is aspirational as a way of reminding ourselves to keep removing dead code (or whitelisting live code that looks dead).

## Security Considerations

N/A