### PR TITLE
Update expired and cancelled service invite handling

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -251,10 +251,21 @@ def get_invited_user_email_address(invited_user_id):
 
 def invited_user_accept_invite(invited_user_id):
     invited_user = InvitedUser.by_id(invited_user_id)
+
     if invited_user.status == "expired":
         current_app.logger.error("User invitation has expired")
-        flash("Your invitation has expired.")
+        flash(
+            "Your invitation has expired; please contact the person who invited you for additional help."
+        )
         abort(401)
+
+    if invited_user.status == "cancelled":
+        current_app.logger.error("User invitation has been cancelled")
+        flash(
+            "Your invitation is no longer valid; please contact the person who invited you for additional help."
+        )
+        abort(401)
+
     invited_user.accept_invite()
 
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds a bit of extra handling for expired and cancelled service invites so that users can no longer accept them and are provided with more detailed error messages.

## Security Considerations

- New users should not be able to accept expired or cancelled invitations to Notify.gov, however they should have some indication of what to do to help rectify the problem.
- Notify.gov service administrators need to be aware and vigilant of social engineering phishing attempts.