### PR TITLE
update gunicorn config

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,12 +1,11 @@
 import os
-import socket
 import sys
 import traceback
-
-import eventlet
+import multiprocessing
 import gunicorn
 
-workers = 5
+# Let gunicorn figure out the right number of workers
+workers = multiprocessing.cpu_count() * 2 + 1
 worker_class = "eventlet"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 disable_redirect_access_to_syslog = True
@@ -19,19 +18,21 @@ def worker_abort(worker):
         worker.log.error("".join(traceback.format_stack(stack)))
 
 
-def fix_ssl_monkeypatching():
-    """
-    eventlet works by monkey-patching core IO libraries (such as ssl) to be non-blocking. However, there's currently
-    a bug: In the normal socket library it may throw a timeout error as a `socket.timeout` exception. However
-    eventlet.green.ssl's patch raises an ssl.SSLError('timed out',) instead. redispy handles socket.timeout but not
-    ssl.SSLError, so we solve this by monkey patching the monkey patching code to raise the correct exception type
-    :scream:
-    https://github.com/eventlet/eventlet/issues/692
-    """
-    # this has probably already been called somewhere in gunicorn internals, however, to be sure, we invoke it again.
-    # eventlet.monkey_patch can be called multiple times without issue
-    eventlet.monkey_patch()
-    eventlet.green.ssl.timeout_exc = socket.timeout
+# This issue is fixed in the 22.0.0 release, which we are using
+# See github issue for details
+# def fix_ssl_monkeypatching():
+#     """
+#     eventlet works by monkey-patching core IO libraries (such as ssl) to be non-blocking. However, there's currently
+#     a bug: In the normal socket library it may throw a timeout error as a `socket.timeout` exception. However
+#     eventlet.green.ssl's patch raises an ssl.SSLError('timed out',) instead. redispy handles socket.timeout but not
+#     ssl.SSLError, so we solve this by monkey patching the monkey patching code to raise the correct exception type
+#     :scream:
+#     https://github.com/eventlet/eventlet/issues/692
+#     """
+#     # this has probably already been called somewhere in gunicorn internals, however, to be sure, we invoke it again.
+#     # eventlet.monkey_patch can be called multiple times without issue
+#     eventlet.monkey_patch()
+#     eventlet.green.ssl.timeout_exc = socket.timeout
 
 
-fix_ssl_monkeypatching()
+# fix_ssl_monkeypatching()


### PR DESCRIPTION
## Description

The issue that caused the need for the ssl monkey patching workaround was resolved in version 22.0.0, which we are using, so we no longer need that.

For the number of workers, it is possible to let gunicorn figure that out for itself, and I have done so.

I don't see any other best practices we are not using.

## Security Considerations

N/A