### PR TITLE
pin python to 3.12.2

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -9,10 +9,10 @@ runs:
         sudo apt-get update \
         && sudo apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev
-    - name: Set up Python 3.12
+    - name: Set up Python 3.12.2
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.12.2"
     - name: Install poetry
       shell: bash
       run: pip install poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -1681,6 +1681,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -3110,5 +3111,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12.2"
-content-hash = "b45f2c38493f81bd7fc9d4bfd294b001d71e4082380eb0851d4f3ea8dcdb949c"
+python-versions = "==3.12.2"
+content-hash = "13525f32422aad8324a3bcb3629d326cc847029800d5518e1efd047b887afa8b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12.2"
+python = "==3.12.2"
 ago = "~=0.0.95"
 beautifulsoup4 = "^4.12.3"
 blinker = "~=1.8"


### PR DESCRIPTION

## Description

An incompatibility exists between python 3.12.4 and both the version of flake8 we are currently using (7.0.0) and the latest version of flake8 (7.1.0). Until this incompatibility is resolved, presumably by the flake8 folks, we need to pin our python version to 3.12.2 so we can keep builds working.

## Security Considerations

We won't be on the latest latest version of python and will have to watch for urgent new bugs