### PR TITLE
Redis upgrade step 1

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -6,7 +6,7 @@ locals {
   recursive_delete = false
 }
 
-module "redis" {
+module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
@@ -14,6 +14,20 @@ module "redis" {
   name             = "${local.app_name}-redis-${local.env}"
   recursive_delete = local.recursive_delete
   redis_plan_name  = "redis-dev"
+}
+
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-dev"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
 }
 
 module "logo_upload_bucket" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -6,7 +6,7 @@ locals {
   recursive_delete = false
 }
 
-module "redis" {
+module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
@@ -14,6 +14,20 @@ module "redis" {
   name             = "${local.app_name}-redis-${local.env}"
   recursive_delete = local.recursive_delete
   redis_plan_name  = "redis-3node-large"
+}
+
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-dev"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
 }
 
 module "logo_upload_bucket" {

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -6,7 +6,7 @@ locals {
   recursive_delete = true
 }
 
-module "redis" {
+module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
@@ -14,6 +14,20 @@ module "redis" {
   name             = "${local.app_name}-redis-${local.env}"
   recursive_delete = local.recursive_delete
   redis_plan_name  = "redis-dev"
+}
+
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-dev"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
 }
 
 module "logo_upload_bucket" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -6,7 +6,7 @@ locals {
   recursive_delete = true
 }
 
-module "redis" {
+module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name
@@ -14,6 +14,20 @@ module "redis" {
   name             = "${local.app_name}-redis-${local.env}"
   recursive_delete = local.recursive_delete
   redis_plan_name  = "redis-dev"
+}
+
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-dev"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
 }
 
 module "logo_upload_bucket" {


### PR DESCRIPTION
Similar to https://github.com/GSA/notifications-api/pull/1104, create a new Redis resource in all environments. This is the first step of the upgrade. Next steps are to unbind the old Redis instance, bind the new, and then delete the old.

Redis v6.2 → v7.2

~~🔴 Terraform plan is failing because this PR depends upon #1649~~
🟢 checks are green and this is ready to merge