### PR TITLE
Added null_resource technique previously used in API repo

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -6,6 +6,14 @@ locals {
   recursive_delete = true
 }
 
+resource "null_resource" "prevent_destroy" {
+
+  lifecycle {
+    prevent_destroy = false # destroying staging is allowed
+  }
+}
+
+
 module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 


### PR DESCRIPTION
Similar to https://github.com/GSA/notifications-api/pull/1096/files use `null_resource` with `prevent_destroy`

Mostly doing this to poke Terraform 