### PR TITLE
Restore Redis instance at v7.0

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,7 +12,7 @@ applications:
       - route: ((cloud_dot_gov_route))
 
     services:
-      - notify-admin-redis-((env))
+      - notify-admin-redis-v70-((env))
       - notify-api-csv-upload-bucket-((env))
       - notify-admin-logo-upload-bucket-((env))
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -16,6 +16,20 @@ module "redis" { # default v6.2; delete after v7.0 resource is bound
   redis_plan_name  = "redis-3node-large"
 }
 
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-3node-large"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
+}
+
 module "logo_upload_bucket" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 


### PR DESCRIPTION
Same as https://github.com/GSA/notifications-api/pull/1127

Rebuild Redis previously removed as a way to update the plan name