### PR TITLE
updating the timestamp to showcase time job sent

### DIFF
--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -37,7 +37,7 @@
           <div class="usa-alert__body">
             <h4 class="usa-alert__heading">Your text has been sent</h4>
             <p class="usa-alert__text">
-              {{ job.template_name }} - {{ current_service.name }} was sent on {{ job.created_at|format_datetime_normal }} by {{ job.created_by.name }}
+              {{ job.template_name }} - {{ current_service.name }} was sent on {{ job.processing_started|format_datetime_normal }} by {{ job.created_by.name }}
             </p>
           </div>
         </div>

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -37,7 +37,9 @@
           <div class="usa-alert__body">
             <h4 class="usa-alert__heading">Your text has been sent</h4>
             <p class="usa-alert__text">
-              {{ job.template_name }} - {{ current_service.name }} was sent on {{ job.processing_started|format_datetime_normal }} by {{ job.created_by.name }}
+              {{ job.template_name }} - {{ current_service.name }} was sent on {% if job.processing_started %}
+              {{ job.processing_started|format_datetime_table }} {% else %}
+              {{ job.created_at|format_datetime_table }} {% endif %} by {{ job.created_by.name }}
             </p>
           </div>
         </div>


### PR DESCRIPTION
Ticket: https://github.com/GSA/notifications-admin/issues/1635

Quick fix to replace when a **job was created_at** to when the job processing start time. This will help to provide a more accurate timestamp for the message sent time.

![image](https://github.com/user-attachments/assets/61c0748b-059c-4add-acef-8832901fba76)
