### PR TITLE
add handling for 90 day email check

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -60,7 +60,12 @@ class NotifyAdminAPIClient(BaseAPIClient):
         still_signing_in = False
         for arg in args:
             arg = str(arg)
-            if "get-login-gov-user" in arg or "user/email" in arg or "/activate" or "/email-code" in arg:
+            if (
+                "get-login-gov-user" in arg
+                or "user/email" in arg
+                or "/activate" in arg
+                or "/email-code" in arg
+            ):
                 still_signing_in = True
         # TODO:  Update this once E2E tests are managed by a feature flag or some other main config option.
         if os.getenv("NOTIFY_E2E_TEST_EMAIL"):

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -60,7 +60,7 @@ class NotifyAdminAPIClient(BaseAPIClient):
         still_signing_in = False
         for arg in args:
             arg = str(arg)
-            if "get-login-gov-user" in arg or "user/email" in arg or "/activate" in arg:
+            if "get-login-gov-user" in arg or "user/email" in arg or "/activate" or "/email-code" in arg:
                 still_signing_in = True
         # TODO:  Update this once E2E tests are managed by a feature flag or some other main config option.
         if os.getenv("NOTIFY_E2E_TEST_EMAIL"):


### PR DESCRIPTION

## Description

The fix for compliance #46 did not take into account the 90 day email check, so add an exception for that as well (i.e. 90 day email check happens before user is fully signed in.)

## Security Considerations

N/A