### PR TITLE
another tweak for session management

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -67,6 +67,10 @@ class NotifyAdminAPIClient(BaseAPIClient):
                 or "/email-code" in arg
             ):
                 still_signing_in = True
+
+            # This seems to be a weird edge case that happens intermittently with invites
+            if str(arg) == "()":
+                still_signing_in = True
         # TODO:  Update this once E2E tests are managed by a feature flag or some other main config option.
         if os.getenv("NOTIFY_E2E_TEST_EMAIL"):
             # allow end-to-end tests to skip check

--- a/poetry.lock
+++ b/poetry.lock
@@ -1681,6 +1681,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 


### PR DESCRIPTION
## Description

There is an intermittent issue where the arg that is supposed to contain the referring URL can be empty (timing issue)? during the processing of invitations, which was resulting (intermittently) in "you are not authorized errors".  Provide special handling for this.

## Security Considerations

N/A