### PR TITLE
Specify version of terraform-cloudgov module

### DIFF
--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "s3" {
-  source = "github.com/18f/terraform-cloudgov//s3"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.1.0"
 
   cf_api_url      = local.cf_api_url
   cf_user         = var.cf_user
@@ -17,8 +17,4 @@ module "s3" {
 resource "cloudfoundry_service_key" "bucket_creds" {
   name             = "${local.s3_service_name}-access"
   service_instance = module.s3.bucket_id
-}
-
-output "bucket_credentials" {
-  value = cloudfoundry_service_key.bucket_creds.credentials
 }


### PR DESCRIPTION
* Specify the version `terraform-cloudgov` module which actually works with these parameters, which sadly is the very first version only
* Remove output of creds [for the same reason I did in the API app](https://github.com/GSA/notifications-api/commit/e054d9b03f6aa39b1f89abd32360bde588a5c7c0)