### PR TITLE
fix /verify/code

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -65,6 +65,7 @@ class NotifyAdminAPIClient(BaseAPIClient):
                 or "user/email" in arg
                 or "/activate" in arg
                 or "/email-code" in arg
+                or "/verify/code" in arg
             ):
                 still_signing_in = True
 


### PR DESCRIPTION


## Description

Play whack-a-mole finding the remaining internal URLs needed to get a 90 day old email address verified.

## Security Considerations

N/A