### PR TITLE
Added line to allow encoding which prevent png

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,7 +149,7 @@ const images = () => {
     paths.govuk_frontend + 'assets/images/**/*',
     paths.src + 'images/**/*',
     paths.src + 'img/**/*',
-  ])
+  ], {encoding: false})
     .pipe(dest(paths.dist + 'images/'))
 };
 


### PR DESCRIPTION
This PR addresses an issue where .png files were not being properly loaded after upgrading gulp to 5.0. 

Details on this issue has been recording on the GULP repo - https://github.com/gulpjs/gulp/issues/2779

A hotfix before was to change .png files to .svg (if they exist). We no longer need to do that and can use .png files now. 

Image working locally - Here is the link of this branch working in the sandbox account - https://notify-sandbox.app.cloud.gov/
![image](https://github.com/user-attachments/assets/59e91221-0701-4b18-8780-022f2e0c3abc)
