### PR TITLE
Hard-code recursive_delete to false

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -65,7 +65,7 @@ module "domain" {
   cf_space_name    = local.cf_space_name
   app_name_or_id   = "${local.app_name}-${local.env}"
   name             = "${local.app_name}-domain-${local.env}"
-  recursive_delete = local.recursive_delete
+  recursive_delete = false
   cdn_plan_name    = "domain"
   domain_name      = "beta.notify.gov"
 }


### PR DESCRIPTION
Hard-code a remaining `recursive_delete` param, having previously eliminated the variable

* A fix to a mistake in https://github.com/GSA/notifications-admin/pull/1738/files
* Addressing this deployment failure: https://github.com/GSA/notifications-admin/actions/runs/10082552717/job/27877102478