### PR TITLE
Uncomment network policy resource

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -34,12 +34,6 @@ module "logo_upload_bucket" {
   name          = "${local.app_name}-logo-upload-bucket-${local.env}"
 }
 
-# ##########################################################################
-# The following lines need to be commented out for the initial `terraform apply`
-# It can be re-enabled after:
-# 1) the api app has first been deployed
-# 2) the admin app has first been deployed
-###########################################################################
 module "api_network_route" {
   source = "../shared/container_networking"
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -34,12 +34,6 @@ module "logo_upload_bucket" {
   name          = "${local.app_name}-logo-upload-bucket-${local.env}"
 }
 
-# ##########################################################################
-# The following lines need to be commented out for the initial `terraform apply`
-# It can be re-enabled after:
-# 1) the api app has first been deployed
-# 2) the admin app has first been deployed
-###########################################################################
 module "api_network_route" {
   source = "../shared/container_networking"
 

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -34,13 +34,7 @@ module "logo_upload_bucket" {
   name          = "${local.app_name}-logo-upload-bucket-${local.env}"
 }
 
-# ##########################################################################
-# Connection the allows notify-admin-sandbox and notify-api-sandbox to talk.
-# https://cloud.gov/docs/management/container-to-container/
-# Terraform block will fail to apply unless both apps exist in Cloud.gov.
-# See also: /docs/all.md#api-request-failed
-###########################################################################
-module "api_network_route" {
+module "api_network_route" { # API and Admin apps must both exist in Cloud
   source = "../shared/container_networking"
 
   cf_org_name          = local.cf_org_name

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -35,12 +35,12 @@ module "logo_upload_bucket" {
 }
 
 # ##########################################################################
-# The following lines need to be commented out for the initial `terraform apply`
-# It can be re-enabled after:
-# 1) the api app has first been deployed
-# 2) the admin app has first been deployed
+# Connection the allows notify-admin-sandbox and notify-api-sandbox to talk.
+# https://cloud.gov/docs/management/container-to-container/
+# Terraform block will fail to apply unless both apps exist in Cloud.gov.
+# See also: /docs/all.md#api-request-failed
 ###########################################################################
-module "api_network_route" { # experiment with uncommenting
+module "api_network_route" {
   source = "../shared/container_networking"
 
   cf_org_name          = local.cf_org_name

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -40,11 +40,11 @@ module "logo_upload_bucket" {
 # 1) the api app has first been deployed
 # 2) the admin app has first been deployed
 ###########################################################################
-# module "api_network_route" {
-#   source = "../shared/container_networking"
+module "api_network_route" { # experiment with uncommenting
+  source = "../shared/container_networking"
 
-#   cf_org_name          = local.cf_org_name
-#   cf_space_name        = local.cf_space_name
-#   source_app_name      = "${local.app_name}-${local.env}"
-#   destination_app_name = "notify-api-${local.env}"
-# }
+  cf_org_name          = local.cf_org_name
+  cf_space_name        = local.cf_space_name
+  source_app_name      = "${local.app_name}-${local.env}"
+  destination_app_name = "notify-api-${local.env}"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -34,12 +34,6 @@ module "logo_upload_bucket" {
   name          = "${local.app_name}-logo-upload-bucket-${local.env}"
 }
 
-# ##########################################################################
-# The following lines need to be commented out for the initial `terraform apply`
-# It can be re-enabled after:
-# 1) the api app has first been deployed
-# 2) the admin app has first been deployed
-###########################################################################
 module "api_network_route" {
   source = "../shared/container_networking"
 


### PR DESCRIPTION
* Uncomment a resource providing [Container-to-Container Networking](https://cloud.gov/docs/management/container-to-container/), allowing Sandbox Admin and API to talk
* Remove boilerplate code comments left over from the early days

This PR is a pair with https://github.com/GSA/notifications-api/pull/1217
A part of issue https://github.com/GSA/notifications-api/issues/883