### PR TITLE
Upgrade terraform cloudgov domain

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -1,7 +1,6 @@
 locals {
   cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-local-dev"
-  recursive_delete = true
   key_name         = "${var.username}-admin-dev-key"
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -50,16 +50,20 @@ module "api_network_route" {
 }
 
 # ##########################################################################
-# The following lines need to be commented out for the initial `terraform apply`
-# It can be re-enabled after:
-# 1) the app has first been deployed
-# 2) the route has been manually created by an OrgManager:
+# This governs the name of our main website. Because domain names are unique,
+# it only lives here in this one location in production. Resulting problem:
+# it is hard to test. Create a temporary, similar code block (with a different
+# subdomain) in Sandbox, test your changes there, and bring them here.
+#
+# Dependencies:
+# 1) an app named notify-admin-production in Cloud.gov
+# 2) this route, manually created by an OrgManager:
 #     `cf create-domain gsa-tts-benefits-studio beta.notify.gov`
-# 3) the acme-challenge CNAME record must be created
+# 3) the acme-challenge CNAME record
 #       https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service
 ###########################################################################
 module "domain" {
-  source = "github.com/18f/terraform-cloudgov//domain?ref=v0.7.1" # TODO: upgrade this
+  source = "github.com/GSA-TTS/terraform-cloudgov//domain?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -69,7 +69,6 @@ module "domain" {
   cf_space_name    = local.cf_space_name
   app_name_or_id   = "${local.app_name}-${local.env}"
   name             = "${local.app_name}-domain-${local.env}"
-  recursive_delete = false
   cdn_plan_name    = "domain"
   domain_name      = "beta.notify.gov"
 }


### PR DESCRIPTION
Upgrade `terraform-cloudgov` in the last spot: the code block that governs our domain name. There is a hitch:

:warning: This block is hard to test directly. There is some risk in this PR because it is a "test in production" situation ultimately. I did do my best to test it in an indirect way in the Sandbox.

Bonus, nix a stray unused variable from the development module

Part of issue https://github.com/GSA/notifications-api/issues/1139