### PR TITLE
remove uk bank holidays

### DIFF
--- a/notifications_utils/letter_timings.py
+++ b/notifications_utils/letter_timings.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 from datetime import datetime, time, timedelta
 
 import pytz
-from govuk_bank_holidays.bank_holidays import BankHolidays
 
 from notifications_utils.countries.data import Postage
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
@@ -18,16 +17,6 @@ CANCELLABLE_JOB_LETTER_STATUSES = [
 ]
 
 
-non_working_days_dvla = BankHolidays(
-    use_cached_holidays=True,
-    weekend=(5, 6),
-)
-non_working_days_royal_mail = BankHolidays(
-    use_cached_holidays=True,
-    weekend=(6,),  # Only Sunday (day 6 of the week) is a non-working day
-)
-
-
 def set_gmt_hour(day, hour):
     return (
         day.astimezone(pytz.timezone("Europe/London"))
@@ -36,28 +25,27 @@ def set_gmt_hour(day, hour):
     )
 
 
-def get_next_work_day(date, non_working_days):
+def get_next_work_day(date, non_working_days=None):
     next_day = date + timedelta(days=1)
-    if non_working_days.is_work_day(
+    if non_working_days and non_working_days.is_work_day(
         date=next_day.date(),
-        division=BankHolidays.ENGLAND_AND_WALES,
     ):
         return next_day
-    return get_next_work_day(next_day, non_working_days)
+    return get_next_work_day(next_day)
 
 
 def get_next_dvla_working_day(date):
     """
     Printing takes place monday to friday, excluding bank holidays
     """
-    return get_next_work_day(date, non_working_days=non_working_days_dvla)
+    return get_next_work_day(date)
 
 
 def get_next_royal_mail_working_day(date):
     """
     Royal mail deliver letters on monday to saturday
     """
-    return get_next_work_day(date, non_working_days=non_working_days_royal_mail)
+    return get_next_work_day(date)
 
 
 def get_delivery_day(date, *, days_to_deliver):

--- a/poetry.lock
+++ b/poetry.lock
@@ -967,20 +967,6 @@ files = [
 ]
 
 [[package]]
-name = "govuk-bank-holidays"
-version = "0.14"
-description = "Tool to load UK bank holidays from GOV.UK"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "govuk-bank-holidays-0.14.tar.gz", hash = "sha256:ce85102423b72908957d25981f616494729686515d5d66c09a1d35a354ce20a6"},
-    {file = "govuk_bank_holidays-0.14-py3-none-any.whl", hash = "sha256:da485c4a40c6c874c925916e492e3f20b807cffba7eed5f07fb69327aef6b10b"},
-]
-
-[package.dependencies]
-requests = "*"
-
-[[package]]
 name = "greenlet"
 version = "3.0.3"
 description = "Lightweight in-process concurrent programming"
@@ -3102,4 +3088,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12.2"
-content-hash = "6420327e4cabd4b5e6b7903607f5c435c53f98b10b3da42da988a18da5fd1717"
+content-hash = "b271104f669ce0a8e78fb09299b61cf0502cc81a18213dda00f77c759b6e0209"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ flask-basicauth = "~=0.2"
 flask-login = "^0.6"
 flask-talisman = "*"
 flask-wtf = "^1.2"
-govuk-bank-holidays = "^0.14"
 gunicorn = {version = "==22.0.0", extras = ["eventlet"]}
 humanize = "~=4.10"
 itsdangerous = "~=2.2"


### PR DESCRIPTION
## Description

govuk-frontend-jinja seems to already have been addressed at some point.  It is no longer in the pyproject.toml

It seems acceptable to get notificiations-python-client from Pypi, so leaving that as is.

For the govuk-bank-holidays, they were only used in "letter timings", so removing that completely.


## Security Considerations

N/A