### PR TITLE
E2E Bug Fix: Get Dependabot to work properly with end-to-end tests

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -141,7 +141,7 @@
         "filename": ".github/workflows/checks.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 101,
+        "line_number": 102,
         "is_secret": false
       }
     ],
@@ -692,5 +692,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-24T14:13:02Z"
+  "generated_at": "2024-08-06T15:37:18Z"
 }

--- a/.ds.baseline
+++ b/.ds.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/checks.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 68,
         "is_secret": false
       },
       {
@@ -141,7 +141,7 @@
         "filename": ".github/workflows/checks.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 102,
+        "line_number": 103,
         "is_secret": false
       }
     ],
@@ -692,5 +692,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-06T15:37:18Z"
+  "generated_at": "2024-08-07T14:36:40Z"
 }

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,6 +54,7 @@ jobs:
         run: poetry run coverage report --fail-under=90
 
   end-to-end-tests:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       checks: write
       pull-requests: write
@@ -84,7 +85,7 @@ jobs:
         ports:
           # Maps tcp port 6379 on service container to the host
           - 6379:6379
-    if: ${{ github.actor != 'dependabot[bot]' }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,6 +84,7 @@ jobs:
         ports:
           # Maps tcp port 6379 on service container to the host
           - 6379:6379
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project


### PR DESCRIPTION
## Description

Disable the initial round of e2e tests when dependabot first makes the PR.  The e2e tests will run when the developer manually merges the PR.

## Security Considerations

N/A