### PR TITLE
Added back part that got removed that allowed png images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,9 +99,10 @@ const copyGtmHead = () => {
 
 // Task to copy images
 const copyImages = () => {
-  return src(paths.src + 'images/**/*')
+  return src(paths.src + 'images/**/*', { encoding: false })
     .pipe(dest(paths.dist + 'images/'));
 };
+
 
 // Configure USWDS paths
 uswds.settings.version = 3;


### PR DESCRIPTION
## Description

Added back code snippet for rollup update that allows png images to be copied over successfully during gulp process


<img width="1433" alt="image" src="https://github.com/user-attachments/assets/8b730afc-3f59-41ad-ade7-01bf681607c4">

