### PR TITLE
added 3 day download link in activity page

### DIFF
--- a/app/main/views/activity.py
+++ b/app/main/views/activity.py
@@ -35,6 +35,13 @@ def all_jobs_activity(service_id):
             status=request.args.get("status"),
             number_of_days="one_day",
         ),
+        download_link_three_day=url_for(
+            ".download_notifications_csv",
+            service_id=current_service.id,
+            message_type=message_type,
+            status=request.args.get("status"),
+            number_of_days="three_day",
+        ),
         download_link_five_day=url_for(
             ".download_notifications_csv",
             service_id=current_service.id,

--- a/app/templates/views/activity/all-activity.html
+++ b/app/templates/views/activity/all-activity.html
@@ -135,6 +135,10 @@
         <a href="{{ download_link_one_day }}" download="download" class="usa-link">Download all data last 24 hours (<abbr title="Comma separated values">CSV</abbr>)</a>
       </p>
       <p class="font-body-sm">
+        <a href="{{ download_link_three_day }}" download="download" class="usa-link">Download all data last 3 days (<abbr title="Comma separated values">CSV</abbr>)</a>
+        &emsp;
+      </p>
+      <p class="font-body-sm">
         <a href="{{ download_link_five_day }}" download="download" class="usa-link">Download all data last 5 days (<abbr title="Comma separated values">CSV</abbr>)</a>
       </p>
       <p class="font-body-sm">


### PR DESCRIPTION
> - [x] On Activity page, for time based reports, we need to add in the 3-day report option (right now its 1,5,7 day only). 

 _Originally posted by @em-herrick in [#1843](https://github.com/GSA/notifications-admin/issues/1843#issuecomment-2289497688)_

![image](https://github.com/user-attachments/assets/259d07a5-5581-4b48-8dae-857c2c5597f2)