### PR TITLE
arrow img missing

### DIFF
--- a/app/templates/views/activity/all-activity.html
+++ b/app/templates/views/activity/all-activity.html
@@ -15,7 +15,7 @@
           class="usa-pagination__link usa-pagination__previous-page"
           aria-label="Previous page"
           >
-          <img src="{{ url_for('static', filename='img/usa-icons/navigate_before.svg') }}" alt="arrow">
+          <img src="{{ asset_url('img/usa-icons/navigate_before.svg') }}" alt="arrow">
           <span class="usa-pagination__link-text">Previous</span></a
         >
       </li>
@@ -50,7 +50,7 @@
           aria-label="Next page"
         >
           <span class="usa-pagination__link-text">Next </span>
-          <img src="{{ url_for('static', filename='img/usa-icons/navigate_next.svg') }}" alt="arrow">
+          <img src="{{ asset_url('img/usa-icons/navigate_next.svg') }}" alt="arrow">
         </a>
       </li>
       {% endif %}

--- a/app/templates/views/activity/all-activity.html
+++ b/app/templates/views/activity/all-activity.html
@@ -15,7 +15,7 @@
           class="usa-pagination__link usa-pagination__previous-page"
           aria-label="Previous page"
           >
-          <img src="{{ url_for('static', filename='/img/usa-icons/navigate_before.svg') }}" alt="arrow">
+          <img src="{{ url_for('static', filename='img/usa-icons/navigate_before.svg') }}" alt="arrow">
           <span class="usa-pagination__link-text">Previous</span></a
         >
       </li>
@@ -50,7 +50,7 @@
           aria-label="Next page"
         >
           <span class="usa-pagination__link-text">Next </span>
-          <img src="{{ url_for('static', filename='/img/usa-icons/navigate_next.svg') }}" alt="arrow">
+          <img src="{{ url_for('static', filename='img/usa-icons/navigate_next.svg') }}" alt="arrow">
         </a>
       </li>
       {% endif %}


### PR DESCRIPTION
Fixing the url route for these images:
navigate_next.svg
navigate_before.svg

![image](https://github.com/user-attachments/assets/4453abf1-e82c-4360-a6d5-9df789af82bf)
