### PR TITLE
Fix formatting in production main.tf file

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -59,10 +59,10 @@ module "api_network_route" {
 module "domain" {
   source = "github.com/GSA-TTS/terraform-cloudgov//domain?ref=v1.0.0"
 
-  cf_org_name      = local.cf_org_name
-  cf_space_name    = local.cf_space_name
-  app_name_or_id   = "${local.app_name}-${local.env}"
-  name             = "${local.app_name}-domain-${local.env}"
-  cdn_plan_name    = "domain"
-  domain_name      = "beta.notify.gov"
+  cf_org_name    = local.cf_org_name
+  cf_space_name  = local.cf_space_name
+  app_name_or_id = "${local.app_name}-${local.env}"
+  name           = "${local.app_name}-domain-${local.env}"
+  cdn_plan_name  = "domain"
+  domain_name    = "beta.notify.gov"
 }


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset fixes formatting in the production main.tf file.  The `terraform fmt -check` command is currently failing because of extra whitespace.

## Security Considerations

* None with this change; it's purely code formatting in a file.