### PR TITLE
Change phone number in Notify.gov w/o entering password

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -601,7 +601,7 @@
         "filename": "tests/app/main/views/test_user_profile.py",
         "hashed_secret": "8072d7aad32964ec43fbcb699c75dc38890792f7",
         "is_verified": false,
-        "line_number": 350,
+        "line_number": 336,
         "is_secret": false
       },
       {
@@ -609,7 +609,7 @@
         "filename": "tests/app/main/views/test_user_profile.py",
         "hashed_secret": "4c9dbb972da179e4f66f023eaa5fb9451d835030",
         "is_verified": false,
-        "line_number": 351,
+        "line_number": 337,
         "is_secret": false
       }
     ],
@@ -692,5 +692,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-15T16:29:15Z"
+  "generated_at": "2024-08-20T14:14:36Z"
 }

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -194,16 +194,12 @@ def user_profile_mobile_number_authenticate():
         return redirect(url_for(".user_profile_mobile_number"))
 
     session[NEW_MOBILE_PASSWORD_CONFIRMED] = True
-    print(f"GOING TO SEND VERIFY CODE TO {session[NEW_MOBILE]}")
     current_user.send_verify_code(to=session[NEW_MOBILE])
     create_mobile_number_change_event(
         user_id=current_user.id,
         updated_by_id=current_user.id,
         original_mobile_number=current_user.mobile_number,
         new_mobile_number=session[NEW_MOBILE],
-    )
-    print(
-        f"sent create_mobile_number_change_event original {current_user.mobile_number} new {session[NEW_MOBILE]}"
     )
     return redirect(url_for(".user_profile_mobile_number_confirm"))
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -189,32 +189,30 @@ def user_profile_mobile_number_delete():
 @main.route("/user-profile/mobile-number/authenticate", methods=["GET", "POST"])
 @user_is_logged_in
 def user_profile_mobile_number_authenticate():
-    # Validate password for form
-    def _check_password(pwd):
-        return user_api_client.verify_password(current_user.id, pwd)
-
-    form = ConfirmPasswordForm(_check_password)
 
     if NEW_MOBILE not in session:
         return redirect(url_for(".user_profile_mobile_number"))
 
-    if form.validate_on_submit():
-        session[NEW_MOBILE_PASSWORD_CONFIRMED] = True
-        current_user.send_verify_code(to=session[NEW_MOBILE])
-        create_mobile_number_change_event(
-            user_id=current_user.id,
-            updated_by_id=current_user.id,
-            original_mobile_number=current_user.mobile_number,
-            new_mobile_number=session[NEW_MOBILE],
-        )
-        return redirect(url_for(".user_profile_mobile_number_confirm"))
-
-    return render_template(
-        "views/user-profile/authenticate.html",
-        thing="mobile number",
-        form=form,
-        back_link=url_for(".user_profile_mobile_number_confirm"),
+    session[NEW_MOBILE_PASSWORD_CONFIRMED] = True
+    print(f"GOING TO SEND VERIFY CODE TO {session[NEW_MOBILE]}")
+    current_user.send_verify_code(to=session[NEW_MOBILE])
+    create_mobile_number_change_event(
+        user_id=current_user.id,
+        updated_by_id=current_user.id,
+        original_mobile_number=current_user.mobile_number,
+        new_mobile_number=session[NEW_MOBILE],
     )
+    print(
+        f"sent create_mobile_number_change_event original {current_user.mobile_number} new {session[NEW_MOBILE]}"
+    )
+    return redirect(url_for(".user_profile_mobile_number_confirm"))
+
+    # return render_template(
+    #    "views/user-profile/authenticate.html",
+    #    thing="mobile number",
+    #    form=form,
+    #    back_link=url_for(".user_profile_mobile_number_confirm"),
+    # )
 
 
 @main.route("/user-profile/mobile-number/confirm", methods=["GET", "POST"])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -203,13 +203,6 @@ def user_profile_mobile_number_authenticate():
     )
     return redirect(url_for(".user_profile_mobile_number_confirm"))
 
-    # return render_template(
-    #    "views/user-profile/authenticate.html",
-    #    thing="mobile number",
-    #    form=form,
-    #    back_link=url_for(".user_profile_mobile_number_confirm"),
-    # )
-
 
 @main.route("/user-profile/mobile-number/confirm", methods=["GET", "POST"])
 @user_is_logged_in

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -110,15 +110,13 @@ class UserApiClient(NotifyAdminAPIClient):
             raise
 
     def send_verify_code(self, user_id, code_type, to, next_string=None):
-        print(hilite("SEND VERIFY CODE"))
+
         data = {"to": to}
         if next_string:
             data["next"] = next_string
         if code_type == "email":
             data["email_auth_link_host"] = self.admin_url
-        print(hilite(f"DATA {data}"))
         endpoint = "/user/{0}/{1}-code".format(user_id, code_type)
-        print(hilite(f"ENDPOINT {endpoint}"))
         current_app.logger.warn(hilite(f"Sending verify_code {code_type} to {user_id}"))
         self.post(endpoint, data=data)
 

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -1,8 +1,8 @@
 from flask import current_app
-from app.utils import hilite
 from notifications_python_client.errors import HTTPError
 
 from app.notify_client import NotifyAdminAPIClient, cache
+from app.utils import hilite
 from app.utils.user_permissions import translate_permissions_from_ui_to_db
 
 ALLOWED_ATTRIBUTES = {

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -1,4 +1,5 @@
 from flask import current_app
+from app.utils import hilite
 from notifications_python_client.errors import HTTPError
 
 from app.notify_client import NotifyAdminAPIClient, cache
@@ -109,13 +110,16 @@ class UserApiClient(NotifyAdminAPIClient):
             raise
 
     def send_verify_code(self, user_id, code_type, to, next_string=None):
+        print(hilite("SEND VERIFY CODE"))
         data = {"to": to}
         if next_string:
             data["next"] = next_string
         if code_type == "email":
             data["email_auth_link_host"] = self.admin_url
+        print(hilite(f"DATA {data}"))
         endpoint = "/user/{0}/{1}-code".format(user_id, code_type)
-        current_app.logger.warn(f"Sending verify_code {code_type} to {user_id}")
+        print(hilite(f"ENDPOINT {endpoint}"))
+        current_app.logger.warn(hilite(f"Sending verify_code {code_type} to {user_id}"))
         self.post(endpoint, data=data)
 
     def send_verify_email(self, user_id, to):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1285,13 +1285,9 @@ files = [
     {file = "lxml-5.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:edcfa83e03370032a489430215c1e7783128808fd3e2e0a3225deee278585196"},
     {file = "lxml-5.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:28bf95177400066596cdbcfc933312493799382879da504633d16cf60bba735b"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a745cc98d504d5bd2c19b10c79c61c7c3df9222629f1b6210c0368177589fb8"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b590b39ef90c6b22ec0be925b211298e810b4856909c8ca60d27ffbca6c12e6"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b336b0416828022bfd5a2e3083e7f5ba54b96242159f83c7e3eebaec752f1716"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:c2faf60c583af0d135e853c86ac2735ce178f0e338a3c7f9ae8f622fd2eb788c"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:4bc6cb140a7a0ad1f7bc37e018d0ed690b7b6520ade518285dc3171f7a117905"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7ff762670cada8e05b32bf1e4dc50b140790909caa8303cfddc4d702b71ea184"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:57f0a0bbc9868e10ebe874e9f129d2917750adf008fe7b9c1598c0fbbfdde6a6"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:a6d2092797b388342c1bc932077ad232f914351932353e2e8706851c870bca1f"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:60499fe961b21264e17a471ec296dcbf4365fbea611bf9e303ab69db7159ce61"},
     {file = "lxml-5.2.2-cp37-cp37m-win32.whl", hash = "sha256:d9b342c76003c6b9336a80efcc766748a333573abf9350f4094ee46b006ec18f"},
     {file = "lxml-5.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b16db2770517b8799c79aa80f4053cd6f8b716f21f8aca962725a9565ce3ee40"},
@@ -1626,6 +1622,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -247,20 +247,6 @@ def test_should_redirect_after_mobile_number_change(
         assert session["new-mob"] == phone_number_to_register_with
 
 
-def test_should_show_authenticate_after_mobile_number_change(
-    client_request,
-):
-    with client_request.session_transaction() as session:
-        session["new-mob"] = "+12021234123"
-
-    page = client_request.get(
-        "main.user_profile_mobile_number_authenticate",
-    )
-
-    assert "Change your mobile number" in page.text
-    assert "Confirm" in page.text
-
-
 def test_should_redirect_after_mobile_number_authenticate(
     client_request,
     mock_verify_password,


### PR DESCRIPTION
## Description

Originally if the user wanted to change their password in the UI, they would need to provide a password.  However, passwords have been taken over by login.gov so internally we should not be checking password.  Eliminate that step.  We retain the 'verify code' step.  So, user wants to change their phone number, they will have to have access to the new phone to obtain the verify code and complete the action.

## Security Considerations

N/A