### PR TITLE
start load test work

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -169,7 +169,7 @@
         "filename": "app/config.py",
         "hashed_secret": "577a4c667e4af8682ca431857214b3a920883efc",
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 118,
         "is_secret": false
       }
     ],
@@ -692,5 +692,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-20T14:14:36Z"
+  "generated_at": "2024-09-03T17:36:57Z"
 }

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ from notifications_utils import DAILY_MESSAGE_LIMIT
 
 
 class Config(object):
+    SIMULATED_SMS_NUMBERS = ("+14254147755", "+14254147167")
     NOTIFY_APP_NAME = "admin"
     NOTIFY_ENVIRONMENT = getenv("NOTIFY_ENVIRONMENT", "development")
     API_HOST_NAME = getenv("API_HOST_NAME", "localhost")

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -34,7 +34,7 @@ from app.main.forms import (
     DateFilterForm,
     RequiredDateFilterForm,
 )
-from app.main.views.send import _send_notification, send_notification
+from app.main.views.send import _send_notification
 from app.statistics_utils import (
     get_formatted_percentage,
     get_formatted_percentage_two_dp,
@@ -46,7 +46,7 @@ from app.utils.pagination import (
     generate_previous_dict,
     get_page_from_request,
 )
-from app.utils.user import user_has_permissions, user_is_platform_admin
+from app.utils.user import user_is_platform_admin
 
 COMPLAINT_THRESHOLD = 0.02
 FAILURE_THRESHOLD = 3
@@ -851,8 +851,8 @@ def _prepare_load_test_service(service):
                 user_api_client.add_user_to_service(
                     service["id"], user["id"], ["send messages"]
                 )
-            except Exception as e:
-                current_app.logger.warning(
+            except Exception:
+                current_app.logger.exception(
                     f"Couldnt add user, may already be part of service"
                 )
                 pass

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -796,7 +796,6 @@ def load_test():
     messagese will be sent in this service.
     """
     # SIMULATED_SMS_NUMBERS = ("+14254147755", "+14254147167")
-    print(hilite("ENTER LOAD TEST"))
     service = _find_load_test_service()
     _prepare_load_test_service(service)
     example_template = _find_example_template(service)
@@ -853,6 +852,6 @@ def _prepare_load_test_service(service):
                 )
             except Exception:
                 current_app.logger.exception(
-                    f"Couldnt add user, may already be part of service"
+                    "Couldnt add user, may already be part of service"
                 )
                 pass

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -39,7 +39,6 @@ from app.statistics_utils import (
     get_formatted_percentage,
     get_formatted_percentage_two_dp,
 )
-from app.utils import hilite
 from app.utils.csv import Spreadsheet
 from app.utils.pagination import (
     generate_next_dict,

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -10,6 +10,7 @@ from flask import (
     abort,
     current_app,
     flash,
+    redirect,
     render_template,
     request,
     session,
@@ -34,6 +35,7 @@ from app.main.forms import (
     DateFilterForm,
     RequiredDateFilterForm,
 )
+from app.main.views.dashboard import get_dashboard_partials
 from app.main.views.send import _send_notification
 from app.statistics_utils import (
     get_formatted_percentage,
@@ -794,29 +796,31 @@ def load_test():
     the platform admin a member of this service if the platform is not already. All
     messagese will be sent in this service.
     """
-    # SIMULATED_SMS_NUMBERS = ("+14254147755", "+14254147167")
     service = _find_load_test_service()
     _prepare_load_test_service(service)
     example_template = _find_example_template(service)
 
-    for _ in range(0, 3):
-        session["recipient"] = "+14254147755"
+    # Simulated success
+    for _ in range(0, 250):
+        session["recipient"] = current_app.config["SIMULATED_SMS_NUMBERS"][0]
         session["placeholders"] = {
             "day of week": "Monday",
             "color": "blue",
-            "phone number": "+14254147755",
+            "phone number": current_app.config["SIMULATED_SMS_NUMBERS"][0],
         }
         _send_notification(service["id"], example_template["id"])
-    for _ in range(0, 3):
-        session["recipient"] = "+14254147167"
+    # Simulated failure
+    for _ in range(0, 250):
+        session["recipient"] = current_app.config["SIMULATED_SMS_NUMBERS"][1]
         session["placeholders"] = {
-            "day of week": "Monday",
-            "color": "blue",
-            "phone number": "+14254147167",
+            "day of week": "Wednesday",
+            "color": "orange",
+            "phone number": current_app.config["SIMULATED_SMS_NUMBERS"][1],
         }
         _send_notification(service["id"], example_template["id"])
 
-    return render_template("views/dashboard/dashboard.html")
+    # For now, just hang out on the platform admin page
+    return redirect(request.referrer)
 
 
 def _find_example_template(service):

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -10,7 +10,6 @@ from flask import (
     abort,
     current_app,
     flash,
-    redirect,
     render_template,
     request,
     session,
@@ -818,8 +817,10 @@ def load_test():
         }
         _send_notification(service["id"], example_template["id"])
 
-    # For now, just hang out on the platform admin page
-    return redirect(request.referrer)
+    # For now, just redirect to the splash page so we know it's done
+    return render_template(
+        "views/platform-admin/splash-page.html",
+    )
 
 
 def _find_example_template(service):

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -35,7 +35,6 @@ from app.main.forms import (
     DateFilterForm,
     RequiredDateFilterForm,
 )
-from app.main.views.dashboard import get_dashboard_partials
 from app.main.views.send import _send_notification
 from app.statistics_utils import (
     get_formatted_percentage,

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -944,8 +944,10 @@ def preview_notification(service_id, template_id):
 def send_notification(service_id, template_id):
     upload_id = _send_notification(service_id, template_id)
 
-    session.pop("recipient")
-    session.pop("placeholders")
+    if session.get("recipient"):
+        session.pop("recipient")
+    if session.get("placeholders"):
+        session.pop("placeholders")
 
     # We have to wait for the job to run and create the notification in the database
     time.sleep(0.1)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -7,7 +7,6 @@ from flask import (
     abort,
     current_app,
     flash,
-    json,
     redirect,
     render_template,
     request,
@@ -621,7 +620,6 @@ def _check_messages(service_id, template_id, upload_id, preview_row, **kwargs):
 )
 @user_has_permissions("send_messages", restrict_admin_usage=True)
 def check_messages(service_id, template_id, upload_id, row_index=2):
-    print(hilite("ENTER check_messages"))
     data = _check_messages(service_id, template_id, upload_id, row_index)
     data["allowed_file_extensions"] = Spreadsheet.ALLOWED_FILE_EXTENSIONS
 
@@ -1037,7 +1035,6 @@ def _send_notification(service_id, template_id):
     form.file.name = filename
     # TODO IF RUNNING LOAD TEST WE DONT NEED
     check_message_output = check_messages(service_id, template_id, upload_id, 2)
-    print(hilite(hilite(f"CHECK MESSAGE OUTPUT {check_message_output}")))
     if "You cannot send to" in check_message_output:
         return check_messages(service_id, template_id, upload_id, 2)
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -996,10 +996,8 @@ def send_notification(service_id, template_id):
 
 
 def _send_notification(service_id, template_id):
-    print(hilite(f"ENTER SEND NOTIFICATION"))
     scheduled_for = session.pop("scheduled_for", "")
     recipient = get_recipient()
-    print(hilite(f"RECIPIENT {recipient}"))
 
     if not recipient:
         return redirect(
@@ -1019,14 +1017,11 @@ def _send_notification(service_id, template_id):
     data = ",".join(keys)
     vals = ",".join(values)
     data = f"{data}\r\n{vals}"
-    print(hilite(f"DATA {data}"))
-
     filename = (
         f"one-off-{uuid.uuid4()}.csv"  # {current_user.name} removed from filename
     )
     my_data = {"filename": filename, "template_id": template_id, "data": data}
     upload_id = s3upload(service_id, my_data)
-    print(hilite(f"UPLOAD ID {upload_id}"))
     # To debug messages that the user reports have not been sent, we log
     # the csv filename and the job id.  The user will give us the file name,
     # so we can search on that to obtain the job id, which we can use elsewhere
@@ -1040,15 +1035,12 @@ def _send_notification(service_id, template_id):
     form = CsvUploadForm()
     form.file.data = my_data
     form.file.name = filename
-    print(f"POPULATED FORM")
-    print(f"USER PERMISSIONS {current_user.permissions[service_id]}")
     # TODO IF RUNNING LOAD TEST WE DONT NEED
-    # check_message_output = check_messages(service_id, template_id, upload_id, 2)
-    # print(hilite(hilite(f"CHECK MESSAGE OUTPUT {check_message_output}")))
-    # if "You cannot send to" in check_message_output:
-    #    return check_messages(service_id, template_id, upload_id, 2)
+    check_message_output = check_messages(service_id, template_id, upload_id, 2)
+    print(hilite(hilite(f"CHECK MESSAGE OUTPUT {check_message_output}")))
+    if "You cannot send to" in check_message_output:
+        return check_messages(service_id, template_id, upload_id, 2)
 
-    print(f"GOING TO CREATE JOB")
     job_api_client.create_job(
         upload_id,
         service_id,

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -944,10 +944,8 @@ def preview_notification(service_id, template_id):
 def send_notification(service_id, template_id):
     upload_id = _send_notification(service_id, template_id)
 
-    if session.get("recipient"):
-        session.pop("recipient")
-    if session.get("placeholders"):
-        session.pop("placeholders")
+    session.pop("recipient", "")
+    session.pop("placeholders", "")
 
     # We have to wait for the job to run and create the notification in the database
     time.sleep(0.1)
@@ -997,7 +995,9 @@ def send_notification(service_id, template_id):
 
 def _send_notification(service_id, template_id):
     scheduled_for = session.pop("scheduled_for", "")
+    print("GOING TO GET RECIPIENT") # noqa
     recipient = get_recipient()
+    print(f"RECIPIENT IS {recipient}, redirecting if None") # noqa
 
     if not recipient:
         return redirect(
@@ -1035,7 +1035,6 @@ def _send_notification(service_id, template_id):
     form = CsvUploadForm()
     form.file.data = my_data
     form.file.name = filename
-    # TODO IF RUNNING LOAD TEST WE DONT NEED
     check_message_output = check_messages(service_id, template_id, upload_id, 2)
     if "You cannot send to" in check_message_output:
         return check_messages(service_id, template_id, upload_id, 2)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1008,7 +1008,6 @@ def send_notification(service_id, template_id):
 def _send_notification(service_id, template_id):
     scheduled_for = session.pop("scheduled_for", "")
 
-
     keys = []
     values = []
     for k, v in session["placeholders"].items():

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -942,6 +942,18 @@ def preview_notification(service_id, template_id):
 )
 @user_has_permissions("send_messages", restrict_admin_usage=True)
 def send_notification(service_id, template_id):
+    print("GOING TO GET RECIPIENT")  # noqa
+    recipient = get_recipient()
+    print(f"RECIPIENT IS {recipient}, redirecting if None")  # noqa
+
+    if not recipient:
+        return redirect(
+            url_for(
+                ".send_one_off",
+                service_id=service_id,
+                template_id=template_id,
+            )
+        )
     upload_id = _send_notification(service_id, template_id)
 
     session.pop("recipient", "")
@@ -995,18 +1007,7 @@ def send_notification(service_id, template_id):
 
 def _send_notification(service_id, template_id):
     scheduled_for = session.pop("scheduled_for", "")
-    print("GOING TO GET RECIPIENT")  # noqa
-    recipient = get_recipient()
-    print(f"RECIPIENT IS {recipient}, redirecting if None")  # noqa
 
-    if not recipient:
-        return redirect(
-            url_for(
-                ".send_one_off",
-                service_id=service_id,
-                template_id=template_id,
-            )
-        )
 
     keys = []
     values = []

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -943,9 +943,7 @@ def preview_notification(service_id, template_id):
 )
 @user_has_permissions("send_messages", restrict_admin_usage=True)
 def send_notification(service_id, template_id):
-    print("GOING TO GET RECIPIENT")  # noqa
     recipient = get_recipient()
-    print(f"RECIPIENT IS {recipient}, redirecting if None")  # noqa
 
     if not recipient:
         return redirect(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -995,9 +995,9 @@ def send_notification(service_id, template_id):
 
 def _send_notification(service_id, template_id):
     scheduled_for = session.pop("scheduled_for", "")
-    print("GOING TO GET RECIPIENT") # noqa
+    print("GOING TO GET RECIPIENT")  # noqa
     recipient = get_recipient()
-    print(f"RECIPIENT IS {recipient}, redirecting if None") # noqa
+    print(f"RECIPIENT IS {recipient}, redirecting if None")  # noqa
 
     if not recipient:
         return redirect(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -7,6 +7,7 @@ from flask import (
     abort,
     current_app,
     flash,
+    json,
     redirect,
     render_template,
     request,
@@ -942,6 +943,10 @@ def preview_notification(service_id, template_id):
 )
 @user_has_permissions("send_messages", restrict_admin_usage=True)
 def send_notification(service_id, template_id):
+    return _send_notification(service_id, template_id)
+
+
+def _send_notification(service_id, template_id):
     scheduled_for = session.pop("scheduled_for", "")
     recipient = get_recipient()
     if not recipient:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -219,6 +219,9 @@ class User(JSONModel, UserMixin):
     def has_permissions(
         self, *permissions, restrict_admin_usage=False, allow_org_user=False
     ):
+        if self.platform_admin:
+            return True
+
         unknown_permissions = set(permissions) - all_ui_permissions
         if unknown_permissions:
             raise TypeError(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -219,7 +219,7 @@ class User(JSONModel, UserMixin):
     def has_permissions(
         self, *permissions, restrict_admin_usage=False, allow_org_user=False
     ):
-        if self.platform_admin:
+        if self.platform_admin and restrict_admin_usage is False:
             return True
 
         unknown_permissions = set(permissions) - all_ui_permissions

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 
 from flask import abort, current_app, request, session
@@ -219,7 +220,12 @@ class User(JSONModel, UserMixin):
     def has_permissions(
         self, *permissions, restrict_admin_usage=False, allow_org_user=False
     ):
-        if self.platform_admin and restrict_admin_usage is False:
+        # TODO need this for load test, but breaks unit tests
+        if self.platform_admin and os.getenv("NOTIFY_ENVIRONMENT") in (
+            "development",
+            "staging",
+            "demo",
+        ):
             return True
 
         unknown_permissions = set(permissions) - all_ui_permissions

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -30,7 +30,7 @@
             {% endif %}
             {% if service['name'] == 'Test service' %}
               <a class="usa-link" href="{{ url_for('main.load_test') }}">Load Test</a>
-              {% endif %}
+            {% endif %}
 
           {% endcall %}
 

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -28,6 +28,10 @@
             {% if not service['active'] %}
               <span class="heading-medium hint">&ensp;Archived</span>
             {% endif %}
+            {% if service['name'] == 'Test service' %}
+              <a class="usa-link" href="{{ url_for('main.load_test') }}">Load Test</a>
+              {% endif %}
+
           {% endcall %}
 
         {% endcall %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1285,13 +1285,9 @@ files = [
     {file = "lxml-5.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:edcfa83e03370032a489430215c1e7783128808fd3e2e0a3225deee278585196"},
     {file = "lxml-5.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:28bf95177400066596cdbcfc933312493799382879da504633d16cf60bba735b"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a745cc98d504d5bd2c19b10c79c61c7c3df9222629f1b6210c0368177589fb8"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b590b39ef90c6b22ec0be925b211298e810b4856909c8ca60d27ffbca6c12e6"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b336b0416828022bfd5a2e3083e7f5ba54b96242159f83c7e3eebaec752f1716"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:c2faf60c583af0d135e853c86ac2735ce178f0e338a3c7f9ae8f622fd2eb788c"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:4bc6cb140a7a0ad1f7bc37e018d0ed690b7b6520ade518285dc3171f7a117905"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7ff762670cada8e05b32bf1e4dc50b140790909caa8303cfddc4d702b71ea184"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:57f0a0bbc9868e10ebe874e9f129d2917750adf008fe7b9c1598c0fbbfdde6a6"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:a6d2092797b388342c1bc932077ad232f914351932353e2e8706851c870bca1f"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:60499fe961b21264e17a471ec296dcbf4365fbea611bf9e303ab69db7159ce61"},
     {file = "lxml-5.2.2-cp37-cp37m-win32.whl", hash = "sha256:d9b342c76003c6b9336a80efcc766748a333573abf9350f4094ee46b006ec18f"},
     {file = "lxml-5.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b16db2770517b8799c79aa80f4053cd6f8b716f21f8aca962725a9565ce3ee40"},
@@ -1626,6 +1622,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2815,14 +2815,10 @@ def test_send_notification_clears_session(
     ],
 )
 def test_send_notification_redirects_if_missing_data(
-    client_request,
-    fake_uuid,
-    session_data,
-    mocker
+    client_request, fake_uuid, session_data, mocker
 ):
     with client_request.session_transaction() as session:
         session.update(session_data)
-
 
     mocker.patch("app.main.views.send.s3upload", return_value=sample_uuid())
     client_request.post(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2823,7 +2823,8 @@ def test_send_notification_redirects_if_missing_data(
     with client_request.session_transaction() as session:
         session.update(session_data)
 
-    mocker.patch("app.main.views.send._send_notification", return_value="aaa")
+
+    mocker.patch("app.main.views.send.s3upload", return_value=sample_uuid())
     client_request.post(
         "main.send_notification",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2818,10 +2818,12 @@ def test_send_notification_redirects_if_missing_data(
     client_request,
     fake_uuid,
     session_data,
+    mocker
 ):
     with client_request.session_transaction() as session:
         session.update(session_data)
 
+    mocker.patch("app.main.views.send._send_notification", return_value="aaa")
     client_request.post(
         "main.send_notification",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2820,7 +2820,6 @@ def test_send_notification_redirects_if_missing_data(
     with client_request.session_transaction() as session:
         session.update(session_data)
 
-    mocker.patch("app.main.views.send.s3upload", return_value=sample_uuid())
     client_request.post(
         "main.send_notification",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -121,6 +121,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "link_service_to_organization",
             "live_services",
             "live_services_csv",
+            "load_test",
             "manage_org_users",
             "manage_template_folder",
             "manage_users",


### PR DESCRIPTION
## Description

Create a feature where a platform admin can perform on load test on the development, staging, or demo tier.

For now, assume that a 'Test service' exists and that it contains an 'Example text message template', and then send 250 successful messages to the AWS simulated number for success, and 250 'failed' messages to the AWS simulated number for failures.



## Security Considerations

N/A