### PR TITLE
Change 18f deprecated deploy tool to CG tool

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Deploy to cloud.gov
-      uses: 18f/cg-deploy-action@main
+      uses: cloud-gov/cg-cli-tools@main
       env:
         DANGEROUS_SALT: ${{ secrets.DANGEROUS_SALT }}
         SECRET_KEY: ${{ secrets.SECRET_KEY }}


### PR DESCRIPTION
## Description

Switch out deprecated 18F deploy tool to cloud-gov/cg-cli-tools@main maintained tool.

File structure looks similar, so I don't believe there is any other specific modifications needed. Will test out with only staging workflow then switch other env workflows if successful.