### PR TITLE
Fix serious a11y violations reported by axe-core

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -34,6 +34,11 @@ $path: '/static/images/';
 // Dependencies from GOV.UK Frontend, packaged to be specific to this application
 @import './govuk-frontend/all';
 
+// Custom overrides
+.govuk-link {
+    font-weight: bold;
+}
+
 // Specific to this application
 @import 'local/typography';
 @import 'grids';

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -46,7 +46,7 @@
       <div id="activityChart">
         <div class="chart-header">
           <div class="chart-subtitle">{{ current_service.name }} - last 7 days</div>
-          <div class="chart-legend" aria-label="Legend"></div>
+          <div class="chart-legend" role="region" aria-label="Legend"></div>
         </div>
         <div class="chart-container" id="weeklyChart"></div>
         <table id="weeklyTable" class="usa-sr-only usa-table"></table>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -63,24 +63,29 @@
           href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous
           versions</a>
         </li>
+      </ul>
         {% endif %}
         {% if current_user.has_permissions('manage_templates') and user_has_template_permission %}
         {% if not template._template.archived %}
+        <ul class="usa-list usa-list--unstyled">
         <li>
           <a class="usa-link margin-right-3"
           href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this
           template</a>
         </li>
+        </ul>
         {% endif %}
         {% if not template._template.redact_personalisation %}
+        <ul class="usa-list usa-list--unstyled">
         <li>
           <a class="usa-link" href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide all personalized and conditional content after sending</a> for increased privacy protection
         </li>
+        </ul>
         {% else %}
         <p class="hint">Personalization is hidden after sending</p>
       {% endif %}
     {% endif %}
-    </ul>
+
   </div>
 
   <!--<div class="">

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -37,5 +37,4 @@ def check_axe_report(page):
         assert violation["impact"] in [
             "minor",
             "moderate",
-            "serious",
         ], f"Accessibility violation: {violation}"


### PR DESCRIPTION
## Description

When we ran the axe-core a11y automated testing tool with the e2e tests, we got some serious a11y violations, as follows:

1. Not enough contrast on links (4.24 to 1 vs minimum of 4.5 to 1)
2. Use of aria-label without a role
3. Use of <li> component without a <ul> wrapper

I fixed all three and the UI (run locally) looks okay to me.

## Security Considerations

N/A