### PR TITLE
optimize S3 partitioning

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1027,7 +1027,7 @@ def _send_notification(service_id, template_id):
     # on the API side to find out what happens to the message.
     current_app.logger.info(
         hilite(
-            f"One-off file: {filename} job_id: {upload_id} s3 location: service-{service_id}-notify/{upload_id}.csv"
+            f"One-off file: {filename} job_id: {upload_id} s3 location: {service_id}-service-notify/{upload_id}.csv"
         )
     )
 

--- a/app/s3_client/s3_csv_client.py
+++ b/app/s3_client/s3_csv_client.py
@@ -10,13 +10,13 @@ from app.s3_client import (
 )
 from notifications_utils.s3 import s3upload as utils_s3upload
 
-FILE_LOCATION_STRUCTURE = "service-{}-notify/{}.csv"
+NEW_FILE_LOCATION_STRUCTURE = "{}-service-notify/{}.csv"
 
 
 def get_csv_location(service_id, upload_id):
     return (
         current_app.config["CSV_UPLOAD_BUCKET"]["bucket"],
-        FILE_LOCATION_STRUCTURE.format(service_id, upload_id),
+        NEW_FILE_LOCATION_STRUCTURE.format(service_id, upload_id),
         current_app.config["CSV_UPLOAD_BUCKET"]["access_key_id"],
         current_app.config["CSV_UPLOAD_BUCKET"]["secret_access_key"],
         current_app.config["CSV_UPLOAD_BUCKET"]["region"],


### PR DESCRIPTION
## Description

We inherited a way of naming s3 objects which might have been fine in its original context, but is not optimal for AWS.  For S3, we should not be prefixing all of our s3 objects with "service-<uuid>" because it pushes everything onto one partition, which will affect search speeds as we scale.  Change the name format to "<uuid>-service"

Note:  This PR is has a matching PR on the api side.  They should be checked in at the same time.  Also, testing this is hard because we've used up our message quota on staging.

## Security Considerations

N/A
