### PR TITLE
1967 - Remove reference to UK on error page

### DIFF
--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -68,11 +68,8 @@
           <p class="usa-body">
             Try again later.
           </p>
-          <p class="usa-body">
-            You can check our <a class="usa-link"
-              href="https://status.notifications.service.gov.uk/">system status</a> page to see if there are any known
-            issues.<br />To report a problem, email <a
-              href="mailto:gov-uk-notify-support@digital.cabinet-office.gov.uk">gov-uk-notify-support@digital.cabinet-office.gov.uk</a>
+          <p>To report a problem you can email us at <a class="usa-link" href="mailto:notify-support@gsa.gov">notify-support@gsa.gov</a>.</p>
+          <p>You can expect a response within one business day.</p>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Description

This error page still had UK links on it. Remove.

## TODO (optional)

* [ ] Create another ticket to explore when/why this page shows up. If not needed, delete.
