### PR TITLE
Update cg-egress-proxy installation

### DIFF
--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -16,6 +16,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install cf-cli
+      shell: bash
+      run: |
+        curl -A "cg-deploy-action" -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v8&source=github'
+        sudo dpkg -i cf-cli_amd64.deb
+    - name: Login to cf-cli
+      shell: bash
+      run: |
+        cf api api.fr.cloud.gov
+        cf auth
     - name: Set restricted space egress
       shell: bash
       run: ./terraform/set_space_egress.sh -t -s ${{ inputs.cf_space }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
           .github/actions/deploy-proxy/action.yml
           .github/workflows/deploy.yml
     - name: Deploy egress proxy
-      if: steps.changed-egress-config.outputs.any_changed == 'true'
+      #if: steps.changed-egress-config.outputs.any_changed == 'true'
       uses: ./.github/actions/deploy-proxy
       with:
         cf_space: notify-staging


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset updates the installation of the cg-egress-proxy repo on account of the recent change to use the newer cg-cli-tools.  It also forces the update for staging to test this out for now; we will have to uncomment the check once this is working.

## Security Considerations

* We want to make sure we can update the egress proxy so that our outbound traffic is protected properly.