### PR TITLE
Swap out config variables for env variables

### DIFF
--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -1,12 +1,6 @@
 name: Deploy egress proxy
 description: Set egress space security groups and deploy proxy
 inputs:
-  cf_username:
-    description: The username to authenticate with.
-    required: true
-  cf_password:
-    description: The password to authenticate with.
-    required: true
   cf_org:
     description: The org the target app exists in.
     required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,9 +109,10 @@ jobs:
     - name: Deploy egress proxy
       #if: steps.changed-egress-config.outputs.any_changed == 'true'
       uses: ./.github/actions/deploy-proxy
+      env:
+          CF_USERNAME: ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
       with:
-        cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
-        cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
         cf_org: gsa-tts-benefits-studio
         cf_space: notify-staging
         app: notify-admin-staging


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset swaps the CF_USERNAME and CF_PASSWORD config vars to be proper env vars so they can be read in as expected.

## Security Considerations

* We need to be mindful of not exposing sensitive credentials and env vars.