### PR TITLE
Verify state for login.gov

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -41,7 +41,7 @@ def index():
         current_app.config["SECRET_KEY"],
         current_app.config["DANGEROUS_SALT"],
     )
-    state_key = f"login-nonce-{unquote(state)}"
+    state_key = f"login-state-{unquote(state)}"
     redis_client.set(state_key, state)
 
     # make and store the nonce

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -17,14 +17,12 @@ def accept_invite(token):
         and current_user.email_address.lower() != invited_user.email_address.lower()
     ):
         message = Markup(
-            """
-            You’re signed in as {}.
+            f"""
+            You’re signed in as {current_user.email_address}.
             This invite is for another email address.
-            <a href={} class="usa-link">Sign out</a>
+            <a href={url_for("main.sign_out")} class="usa-link">Sign out</a>
             and click the link again to accept this invite.
-            """.format(
-                current_user.email_address, url_for("main.sign_out")
-            )
+            """
         )
 
         flash(message=message)

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -38,9 +38,9 @@ def accept_invite(token):
         )
     if invited_user.status == "accepted":
         session.pop("invited_user_id", None)
-        service = Service.from_id(invited_user.service)
+        service = Service.from_id(invited_user.service_id)
         return redirect(
-            url_for("main.service_dashboard", service_id=invited_user.service)
+            url_for("main.service_dashboard", service_id=invited_user.service_id)
         )
 
     session["invited_user_id"] = invited_user.id

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -38,9 +38,9 @@ def accept_invite(token):
         )
     if invited_user.status == "accepted":
         session.pop("invited_user_id", None)
-        service = Service.from_id(invited_user.service_id)
+        service = Service.from_id(invited_user.service)
         return redirect(
-            url_for("main.service_dashboard", service_id=invited_user.service_id)
+            url_for("main.service_dashboard", service_id=invited_user.service)
         )
 
     session["invited_user_id"] = invited_user.id

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import uuid
 from datetime import datetime, timedelta
@@ -171,15 +170,8 @@ def set_up_your_profile():
 
     login_gov_error = request.args.get("error")
 
-    invite_data = json.loads(redis_client.get(f"invitedata-{state}"))
-    user_email = redis_client.get(f"user_email-{state}").decode("utf8")
-    user_uuid = redis_client.get(f"user_uuid-{state}").decode("utf8")
-    # invite_data = json.loads(redis_client.get(f"invitedata-{state}"))
-    # user_email = redis_client.get(f"user_email-{state}").decode("utf8")
-    # user_uuid = redis_client.get(f"user_uuid-{state}").decode("utf8")
-    # invited_user_email_address = redis_client.get(
-    #     f"invited_user_email_address-{state}"
-    # ).decode("utf8")
+    user_email = redis_client.get(f"user_email-{state}")
+    user_uuid = redis_client.get(f"user_uuid-{state}")
 
     if user_email is None or user_uuid is None:  # invite path
         access_token = sign_in._get_access_token(code)
@@ -189,11 +181,10 @@ def set_up_your_profile():
         debug_msg(
             f"Got the user_email {user_email} and user_uuid {user_uuid} from login.gov"
         )
-        # invite_data = state.encode("utf8")
-        # invite_data = base64.b64decode(invite_data)
-        # invite_data = json.loads(invite_data)
+        invite_data = redis_client.get(f"invitedata-{state}")
+        invite_data = json.loads(invite_data)
         debug_msg(f"final state {invite_data}")
-        invited_user_id = invite_data["invited_user_id"]
+        invited_user_id = invite_data["user_id"]
         invited_user_email_address = get_invited_user_email_address(invited_user_id)
         debug_msg(f"email address from the invite_date is {invited_user_email_address}")
         check_invited_user_email_address_matches_expected(

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -186,7 +186,7 @@ def set_up_your_profile():
         invite_data = redis_client.get(f"invitedata-{state}")
         invite_data = json.loads(invite_data)
         debug_msg(f"final state {invite_data}")
-        invited_user_id = invite_data["id"]
+        invited_user_id = invite_data["invited_user_id"]
         invited_user_email_address = get_invited_user_email_address(invited_user_id)
         debug_msg(f"email address from the invite_date is {invited_user_email_address}")
         check_invited_user_email_address_matches_expected(
@@ -195,7 +195,7 @@ def set_up_your_profile():
 
         invited_user_accept_invite(invited_user_id)
         debug_msg(
-            f"accepted invite user {invited_user_email_address} to service {invite_data['service']}"
+            f"accepted invite user {invited_user_email_address} to service {invite_data['service_id']}"
         )
         # We need to avoid taking a second trip through the login.gov code because we cannot pull the
         # access token twice.  So once we retrieve these values, let's park them in redis for 15 minutes
@@ -230,16 +230,19 @@ def set_up_your_profile():
         activate_user(user["id"])
         debug_msg("activated user")
         usr = User.from_id(user["id"])
+
         usr.add_to_service(
-            invite_data["service"],
+            invite_data["service_id"],
             invite_data["permissions"],
             invite_data["folder_permissions"],
-            invite_data["from_user"],
+            invite_data["from_user_id"],
         )
-        debug_msg(f"Added user {usr.email_address} to service {invite_data['service']}")
+        debug_msg(
+            f"Added user {usr.email_address} to service {invite_data['service_id']}"
+        )
         # notify-admin-1766
         # redirect new users to templates area of new service instead of dashboard
-        service_id = invite_data["service"]
+        service_id = invite_data["service_id"]
         url = url_for(".service_dashboard", service_id=service_id)
         url = f"{url}/templates"
         return redirect(url)

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -2,6 +2,7 @@ import base64
 import json
 import uuid
 from datetime import datetime, timedelta
+from urllib.parse import unquote
 
 from flask import (
     abort,
@@ -161,6 +162,13 @@ def set_up_your_profile():
     debug_msg(f"Enter set_up_your_profile with request.args {request.args}")
     code = request.args.get("code")
     state = request.args.get("state")
+
+    state_key = f"login-state-{unquote(state)}"
+    stored_state = redis_client.get(state_key).decode("utf8")
+    if state != stored_state:
+        current_app.logger.error(f"State Error: {state} != {stored_state}")
+        abort(403)
+
     login_gov_error = request.args.get("error")
 
     if redis_client.get(f"invitedata-{state}") is None:

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -164,7 +164,7 @@ def set_up_your_profile():
     login_gov_error = request.args.get("error")
 
     if redis_client.get(f"invitedata-{state}") is None:
-        access_token = sign_in._get_access_token(code, state)
+        access_token = sign_in._get_access_token(code)
 
         debug_msg("Got the access token for login.gov")
         user_email, user_uuid = sign_in._get_user_email_and_uuid(access_token)

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -39,7 +39,7 @@ def _reformat_keystring(orig):  # pragma: no cover
     return new_keystring
 
 
-def _get_access_token(code, state):  # pragma: no cover
+def _get_access_token(code):  # pragma: no cover
     client_id = os.getenv("LOGIN_DOT_GOV_CLIENT_ID")
     access_token_url = os.getenv("LOGIN_DOT_GOV_ACCESS_TOKEN_URL")
     keystring = os.getenv("LOGIN_PEM")
@@ -110,7 +110,7 @@ def _do_login_dot_gov():  # $ pragma: no cover
 
         # activate the user
         try:
-            access_token = _get_access_token(code, state)
+            access_token = _get_access_token(code)
             user_email, user_uuid = _get_user_email_and_uuid(access_token)
             if not is_gov_user(user_email):
                 current_app.logger.error(
@@ -211,7 +211,7 @@ def sign_in():  # pragma: no cover
     url = os.getenv("LOGIN_DOT_GOV_INITIAL_SIGNIN_URL")
 
     nonce = secrets.token_urlsafe()
-    redis_key = f"-{unquote(nonce)}"
+    redis_key = f"login-nonce-{unquote(nonce)}"
     redis_client.set(redis_key, nonce)
 
     # handle unit tests

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -99,11 +99,6 @@ def _do_login_dot_gov():  # $ pragma: no cover
     # start login.gov
     code = request.args.get("code")
     state = request.args.get("state")
-    state_key = f"login-state-{unquote(state)}"
-    stored_state = redis_client.get(state_key).decode("utf8")
-    if state != stored_state:
-        current_app.logger.error(f"State Error: {state} != {stored_state}")
-        abort(403)
 
     login_gov_error = request.args.get("error")
 
@@ -113,6 +108,11 @@ def _do_login_dot_gov():  # $ pragma: no cover
         )
         raise Exception(f"Could not login with login.gov {login_gov_error}")
     elif code and state:
+        state_key = f"login-state-{unquote(state)}"
+        stored_state = redis_client.get(state_key).decode("utf8")
+        if state != stored_state:
+            current_app.logger.error(f"State Error: {state} != {stored_state}")
+            abort(403)
 
         # activate the user
         try:

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -109,7 +109,7 @@ def _do_login_dot_gov():  # $ pragma: no cover
         raise Exception(f"Could not login with login.gov {login_gov_error}")
     elif code and state:
         state_key = f"login-state-{unquote(state)}"
-        stored_state = redis_client.get(state_key).decode("utf8")
+        stored_state = unquote(redis_client.get(state_key).decode("utf8"))
         if state != stored_state:
             current_app.logger.error(f"State Error: {state} != {stored_state}")
             abort(403)

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -62,7 +62,8 @@ class InviteApiClient(NotifyAdminAPIClient):
 
         resp_data = resp["data"]
         invite_data_key = f"invitedata-{unquote(state)}"
-        redis_invite_data = json.dumps(resp_data)
+        redis_invite_data = resp["invite"]
+        redis_invite_data = json.dumps(redis_invite_data)
         redis_client.set(invite_data_key, redis_invite_data)
 
         return resp_data

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -62,16 +62,7 @@ class InviteApiClient(NotifyAdminAPIClient):
 
         resp_data = resp["data"]
         invite_data_key = f"invitedata-{unquote(state)}"
-        remap_keys = {
-            "service": "service_id",
-            "from_user": "from_user_id",
-            "id": "user_id",
-        }
-        redis_invite_data = {
-            remap_keys[key] if key in remap_keys else key: value
-            for key, value in resp_data.items()
-        }
-        redis_invite_data = json.dumps(redis_invite_data)
+        redis_invite_data = json.dumps(resp_data)
         redis_client.set(invite_data_key, redis_invite_data)
 
         return resp_data

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -115,9 +115,14 @@ class InviteApiClient(NotifyAdminAPIClient):
             "nonce": nonce,
             "state": state,
         }
-        self.post(
+        resp = self.post(
             url=f"/service/{service_id}/invite/{invited_user_id}/resend", data=data
         )
+
+        invite_data_key = f"invitedata-{unquote(state)}"
+        redis_invite_data = resp["invite"]
+        redis_invite_data = json.dumps(redis_invite_data)
+        redis_client.set(invite_data_key, redis_invite_data)
 
     @cache.delete("service-{service_id}")
     @cache.delete("user-{invited_user_id}")

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -51,8 +51,12 @@ class InviteApiClient(NotifyAdminAPIClient):
 
         # make and store the nonce
         nonce = secrets.token_urlsafe()
-        redis_key = f"login-nonce-{unquote(nonce)}"
-        redis_client.set(f"{redis_key}", nonce)  # save the nonce to redis.
+        nonce_key = f"login-nonce-{unquote(nonce)}"
+        redis_client.set(f"{nonce_key}", nonce)  # save the nonce to redis.
+
+        redis_invite_data = json.dumps(data)
+        redis_client.set(f"invitedata-{state}", json.dumps(invite_data), ex=ttl)
+
         data["nonce"] = nonce  # This is passed to api for the invite url.
         data["state"] = state  # This is passed to api for the invite url.
 

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -1,3 +1,4 @@
+import json
 import secrets
 from urllib.parse import unquote
 
@@ -52,10 +53,11 @@ class InviteApiClient(NotifyAdminAPIClient):
         # make and store the nonce
         nonce = secrets.token_urlsafe()
         nonce_key = f"login-nonce-{unquote(nonce)}"
-        redis_client.set(f"{nonce_key}", nonce)  # save the nonce to redis.
+        redis_client.set(nonce_key, nonce)  # save the nonce to redis.
 
+        invite_data_key = f"invitedata-{state}"
         redis_invite_data = json.dumps(data)
-        redis_client.set(f"invitedata-{state}", json.dumps(invite_data), ex=ttl)
+        redis_client.set(invite_data_key, redis_invite_data)
 
         data["nonce"] = nonce  # This is passed to api for the invite url.
         data["state"] = state  # This is passed to api for the invite url.

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -168,7 +168,7 @@ class UserApiClient(NotifyAdminAPIClient):
     @cache.delete("user-{user_id}")
     def add_user_to_service(self, service_id, user_id, permissions, folder_permissions):
         # permissions passed in are the combined UI permissions, not DB permissions
-        endpoint = "/service/{}/users/{}".format(service_id, user_id)
+        endpoint = f"/service/{service_id}/users/{user_id}"
         data = {
             "permissions": [
                 {"permission": x}

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -30,7 +30,8 @@ def test_client_creates_invite(
                     "nonce",
                     "state",
                 }
-            )
+            ),
+            "invite": {},
         },
     )
 

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -10,6 +10,7 @@ def test_client_creates_invite(
     sample_invite,
 ):
     mocker.patch("app.notify_client.current_user")
+    mocker.patch("flask.request")
 
     mock_post = mocker.patch(
         "app.invite_api_client.post",
@@ -26,6 +27,7 @@ def test_client_creates_invite(
                     "auth_type",
                     "folder_permissions",
                     "nonce",
+                    "state",
                 }
             )
         },
@@ -33,7 +35,11 @@ def test_client_creates_invite(
 
     mock_token_urlsafe = mocker.patch("secrets.token_urlsafe")
     fake_nonce = "1234567890"
+    fake_state = "0987654321"
     mock_token_urlsafe.return_value = fake_nonce
+
+    mock_generate_token = mocker.patch("notifications_utils.url_safe_token.generate_token")
+    mock_generate_token.return_value = fake_state
 
     invite_api_client.create_invite(
         "12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid]
@@ -51,6 +57,7 @@ def test_client_creates_invite(
             "invite_link_host": "http://localhost:6012",
             "folder_permissions": [fake_uuid],
             "nonce": fake_nonce,
+            "state": fake_state,
         },
     )
 

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -1,5 +1,7 @@
 from unittest.mock import ANY
 
+from flask import current_app
+
 from app import invite_api_client
 
 
@@ -10,7 +12,6 @@ def test_client_creates_invite(
     sample_invite,
 ):
     mocker.patch("app.notify_client.current_user")
-    mocker.patch("flask.request")
 
     mock_post = mocker.patch(
         "app.invite_api_client.post",
@@ -38,15 +39,23 @@ def test_client_creates_invite(
     fake_state = "0987654321"
     mock_token_urlsafe.return_value = fake_nonce
 
-    mock_generate_token = mocker.patch("notifications_utils.url_safe_token.generate_token")
+    mock_generate_token = mocker.patch(
+        "app.notify_client.invite_api_client.generate_token"
+    )
     mock_generate_token.return_value = fake_state
 
-    invite_api_client.create_invite(
-        "12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid]
-    )
+    with current_app.test_request_context("/whatever"):
+        invite_api_client.create_invite(
+            "12345",
+            "67890",
+            "test@example.com",
+            {"send_messages"},
+            "sms_auth",
+            [fake_uuid],
+        )
 
     mock_post.assert_called_once_with(
-        url="/service/{}/invite".format("67890"),
+        url=f"/service/{"67890"}/invite",
         data={
             "auth_type": "sms_auth",
             "email_address": "test@example.com",


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

the state was largely unused by our system, and was seen as a necessity for working with login.gov. Now we are checking that the state is correct on return from login.gov. It is sent as a query parameter back from login.gov, and we are now simply checking that it matches a value we have stored in redis.

This also is now generated from the admin, and then passed into the api endpoints for both creating a new invitation, and resending an expired invitation. As such, everything from login.gov is now checked for both state and nonce (the previous work I had done). This will help eliminate possible ingresses from bad actors.

https://github.com/GSA/us-notify-compliance/issues/51

This must only be merged when both this ticket and the one linked here is finished: https://github.com/GSA/notifications-api/pull/1386

## Security Considerations

Checking state, like nonce, is important for the security of the login process.