### PR TITLE
add carrier column to reports

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -161,7 +161,7 @@
         "filename": "app/config.py",
         "hashed_secret": "577a4c667e4af8682ca431857214b3a920883efc",
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 123,
         "is_secret": false
       }
     ],
@@ -684,5 +684,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-14T15:53:44Z"
+  "generated_at": "2024-11-21T23:08:45Z"
 }

--- a/app/config.py
+++ b/app/config.py
@@ -91,9 +91,7 @@ class Config(object):
         getenv("FEATURE_BEST_PRACTICES_ENABLED", "false") == "true"
     )
 
-    FEATURE_ABOUT_PAGE_ENABLED = (
-        getenv("FEATURE_ABOUT_PAGE_ENABLED", "false") == "true"
-    )
+    FEATURE_ABOUT_PAGE_ENABLED = getenv("FEATURE_ABOUT_PAGE_ENABLED", "false") == "true"
 
 
 def _s3_credentials_from_env(bucket_prefix):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -30,15 +30,13 @@ from notifications_utils.url_safe_token import generate_token
 # Hook to check for feature flags
 @main.before_request
 def check_feature_flags():
-    if (
-        request.path.startswith("/guides/best-practices")
-        and not current_app.config.get("FEATURE_BEST_PRACTICES_ENABLED", False)
+    if request.path.startswith("/guides/best-practices") and not current_app.config.get(
+        "FEATURE_BEST_PRACTICES_ENABLED", False
     ):
         abort(404)
 
-    if (
-        request.path.startswith("/about")
-        and not current_app.config.get("FEATURE_ABOUT_PAGE_ENABLED", False)
+    if request.path.startswith("/about") and not current_app.config.get(
+        "FEATURE_ABOUT_PAGE_ENABLED", False
     ):
         abort(404)
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -53,7 +53,7 @@ class HeaderNavigation(Navigation):
             "establish_trust",
             "write_for_action",
             "multiple_languages",
-            "benchmark_performance"
+            "benchmark_performance",
         },
         "using_notify": {
             "get_started",

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -103,6 +103,7 @@ def generate_notifications_csv(**kwargs):
             "Carrier Response",
             "Status",
             "Time",
+            "Carrier",
         ]
         for header in original_column_headers:
             if header.lower() != "phone number":
@@ -118,6 +119,7 @@ def generate_notifications_csv(**kwargs):
             "Carrier Response",
             "Status",
             "Time",
+            "Carrier",
         ]
 
     yield ",".join(fieldnames) + "\n"
@@ -140,6 +142,7 @@ def generate_notifications_csv(**kwargs):
                     notification["provider_response"],
                     notification["status"],
                     preferred_tz_created_at,
+                    notification["carrier"],
                 ]
                 for header in original_column_headers:
                     if header.lower() != "phone number":
@@ -158,6 +161,7 @@ def generate_notifications_csv(**kwargs):
                     notification["provider_response"],
                     notification["status"],
                     preferred_tz_created_at,
+                    notification["carrier"],
                 ]
             yield Spreadsheet.from_rows([map(str, values)]).as_csv_data
 

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -58,6 +58,7 @@ def _get_notifications_csv(
                     "to": recipient,
                     "recipient": recipient,
                     "client_reference": "ref 1234",
+                    "carrier": "AT&T Mobility",
                 }
                 for i in range(rows)
             ],
@@ -88,15 +89,15 @@ def get_notifications_csv_mock(
         (
             None,
             [
-                "Phone Number,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
-                "8005555555,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",
+                "Phone Number,Template,Sent by,Batch File,Carrier Response,Status,Time,Carrier\n",
+                "8005555555,foo,,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern,AT&T Mobility\r\n",
             ],
         ),
         (
             "Anne Example",
             [
-                "Phone Number,Template,Sent by,Batch File,Carrier Response,Status,Time\n",
-                "8005555555,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern\r\n",  # noqa
+                "Phone Number,Template,Sent by,Batch File,Carrier Response,Status,Time,Carrier\n",
+                "8005555555,foo,Anne Example,,Did not like it,Delivered,1943-04-19 08:00:00 AM US/Eastern,AT&T Mobility\r\n",  # noqa
             ],
         ),
     ],
@@ -135,6 +136,7 @@ def test_generate_notifications_csv_without_job(
                 "Carrier Response",
                 "Status",
                 "Time",
+                "Carrier",
             ],
             [
                 "8005555555",
@@ -144,6 +146,7 @@ def test_generate_notifications_csv_without_job(
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
+                "AT&T Mobility",
             ],
         ),
         (
@@ -159,6 +162,7 @@ def test_generate_notifications_csv_without_job(
                 "Carrier Response",
                 "Status",
                 "Time",
+                "Carrier",
                 "a",
                 "b",
                 "c",
@@ -171,6 +175,7 @@ def test_generate_notifications_csv_without_job(
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
+                "AT&T Mobility",
                 "🐜",
                 "🐝",
                 "🦀",
@@ -189,6 +194,7 @@ def test_generate_notifications_csv_without_job(
                 "Carrier Response",
                 "Status",
                 "Time",
+                "Carrier",
                 "a",
                 "b",
                 "c",
@@ -201,6 +207,7 @@ def test_generate_notifications_csv_without_job(
                 "Did not like it",
                 "Delivered",
                 "1943-04-19 08:00:00 AM US/Eastern",
+                "AT&T Mobility",
                 "🐜,🐜",
                 "🐝,🐝",
                 "🦀",


### PR DESCRIPTION
## Description

The carrier name has been saved in the notification for a long time but has not been available in the report.  Add a 'Carrier' column to the report so users can determine if the failure pattern for messages indicates a carrier outage.

## Security Considerations

N/A