### PR TITLE
Bump admin production memory to 2GB per instance

### DIFF
--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -1,6 +1,6 @@
 env: production
 instances: 2
-memory: 1.5G
+memory: 2G
 command: newrelic-admin run-program gunicorn -c /home/vcap/app/gunicorn_config.py application
 public_admin_route: beta.notify.gov
 cloud_dot_gov_route: notify.app.cloud.gov


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset bumps the admin production memory to 2GB per instance.  We were noticing that the admin app was consuming almost all of the 1.5GB memory currently.

## Security Considerations

- More memory available helps keep our application stable and resilient.
