### PR TITLE
Add youtube video to about page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -141,6 +141,10 @@ def _csp(config):
     logo_domain = config["LOGO_CDN_DOMAIN"]
     return {
         "default-src": ["'self'", asset_domain],
+        "frame-src": [
+            "https://www.youtube.com",
+            "https://www.youtube-nocookie.com",
+        ],
         "frame-ancestors": "'none'",
         "form-action": "'self'",
         "script-src": [

--- a/app/templates/views/about/about.html
+++ b/app/templates/views/about/about.html
@@ -23,8 +23,7 @@
   <p>Notify.gov is an easy-to-use, web-based platform. It requires no technical expertise or system integration — users
     can create an account and get started within minutes. We take the security and privacy of messaging data seriously
     by minimizing data retention and using modern encryption methods.</p>
-  <!-- add youtube video component here -->
-  <h2 class="padding-bottom-3">Product Highlights</h2>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fkcy_xbo0Bw?si=qNo94BwL4WCeusy5&amp;start=2" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>  <h2 class="padding-bottom-3">Product Highlights</h2>
   {% set product_highlights = [
   {
   "svg_src": "#send",


### PR DESCRIPTION
Add video to About page based on Figma design and content changes
![Image](https://github.com/user-attachments/assets/9b9dd96e-536c-4574-9597-12370b4cac60)
