### PR TITLE
Added errors focus to empty field

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -483,7 +483,7 @@ def send_one_off_step(service_id, template_id, step_index):
         link_to_upload=(
             request.endpoint == "main.send_one_off_step" and step_index == 0
         ),
-        errors = form.errors if form.errors else None
+        errors=form.errors if form.errors else None
     )
 
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -483,6 +483,7 @@ def send_one_off_step(service_id, template_id, step_index):
         link_to_upload=(
             request.endpoint == "main.send_one_off_step" and step_index == 0
         ),
+        errors = form.errors if form.errors else None
     )
 
 

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -2,7 +2,6 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/components/button/macro.njk" import usaButton %}
-{% from "components/components/skip-link/macro.njk" import usaSkipLink %}
 {% from "components/components/back-link/macro.njk" import usaBackLink %}
 
 {% set file_contents_header_id = 'file-preview' %}

--- a/app/templates/views/check/preview.html
+++ b/app/templates/views/check/preview.html
@@ -3,7 +3,6 @@
 {% from "components/table.html" import list_table, field, text_field, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/components/button/macro.njk" import usaButton %}
-{% from "components/components/skip-link/macro.njk" import usaSkipLink %}
 {% from "components/components/back-link/macro.njk" import usaBackLink %}
 
 {% set file_contents_header_id = 'file-preview' %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -12,6 +12,23 @@
   {{ usaBackLink({ "href": back_link }) }}
 {% endblock %}
 
+
+{% block skipLink %}
+  {% if errors %}
+    <div>
+      {{ usaSkipLink({
+      "href": '#main-content',
+      "text": 'Skip to main content'
+      }) }}
+    </div>
+  {% else %}
+    {{ usaSkipLink({
+      "href": '#main-content',
+      "text": 'Skip to main content'
+    }) }}
+  {% endif %}
+{% endblock %}
+
 {% block maincolumn_content %}
 
   {{ page_header(page_title) }}
@@ -24,7 +41,7 @@
     data_kwargs={'force-focus': True}
   ) %}
     <div class="grid-row">
-      <div class="grid-col-12 {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
+      <div class="grid-col-12 {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}" aria-live="polite" role="alert">
         {{ form.placeholder_value(param_extensions={"classes": ""}) }}
       </div>
       {% if skip_link or link_to_upload %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -14,18 +14,14 @@
 
 
 {% block skipLink %}
+  {% set skipLink = usaSkipLink({
+    "href": '#main-content',
+    "text": 'Skip to main content'
+  }) %}
   {% if errors %}
-    <div>
-      {{ usaSkipLink({
-      "href": '#main-content',
-      "text": 'Skip to main content'
-      }) }}
-    </div>
+    <div>{{ skipLink }}</div>
   {% else %}
-    {{ usaSkipLink({
-      "href": '#main-content',
-      "text": 'Skip to main content'
-    }) }}
+    {{ skipLink }}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Send Message A11Y Audit - Error messages not reading correctly in VoiceOver. Ticket: #2124

The objective is to create an alert focus when users leaves a field empty in a form. VoiceOver will announce the error without first navigating to the SkipLink.

Screenreader should read out the error 
<img width="560" alt="image" src="https://github.com/user-attachments/assets/50031bac-eb0d-4e49-b98b-dcc2b2f8faf4" />


https://github.com/user-attachments/assets/3147bb2e-d3bd-4c2b-b55e-73005aa176fa

