### PR TITLE
2227 - Adding Acceptable Use Policy page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -350,6 +350,13 @@ def studio():
     )
 
 
+@main.route("/acceptable-use-policy")
+def acceptable_use_policy():
+    return render_template(
+        "views/acceptable-use-policy.html",
+    )
+
+
 # --- Redirects --- #
 
 

--- a/app/templates/components/footer.html
+++ b/app/templates/components/footer.html
@@ -55,7 +55,7 @@
               class="usa-identifier__required-link">Performance reports</a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="/acceptable-use-policy" class="usa-identifier__required-link">Acceptable Use Policy</a>
+            <a href="/acceptable-use-policy" class="usa-identifier__required-link">Acceptable use policy</a>
           </li>
           <li class="usa-identifier__required-links-item">
             <a href="https://www.gsa.gov/website-information/website-policies"

--- a/app/templates/components/footer.html
+++ b/app/templates/components/footer.html
@@ -55,6 +55,9 @@
               class="usa-identifier__required-link">Performance reports</a>
           </li>
           <li class="usa-identifier__required-links-item">
+            <a href="/acceptable-use-policy" class="usa-identifier__required-link">Acceptable Use Policy</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
             <a href="https://www.gsa.gov/website-information/website-policies"
               class="usa-identifier__required-link">Privacy policy</a>
           </li>

--- a/app/templates/components/header.html
+++ b/app/templates/components/header.html
@@ -50,7 +50,7 @@
 <header class="usa-header usa-header--extended">
   <div class="usa-nav-container">
     <div class="usa-navbar">
-      <div class="display-flex flex-align-center flex-justify">
+      <div class="display-flex flex-align-center flex-justify width-full">
         <div class="usa-logo display-flex flex-align-center flex-justify" id="-logo">
           <div class="logo-img display-flex">
             <a href="/">

--- a/app/templates/views/acceptable-use-policy.html
+++ b/app/templates/views/acceptable-use-policy.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% set page_title = "Acceptable Use Policy" %}
+
+{% block per_page_title %}{{page_title}}{% endblock %}
+
+{% block content_column_content %}
+
+<section class="usa-prose">
+  <h1>{{page_title}}</h1>
+  <p>Use of the application indicates agreement with this acceptable use policy.</p>
+  <p>Acceptable uses of Notify.gov for this trial period include:</p>
+  <ul>
+    <li>Configuring test services and sending test SMS messages to learn and demonstrate how Notify.gov works.</li>
+    <li>Reviewing data provided by Notify.gov and configuring available settings.</li>
+  </ul>
+  <p>
+    In order to help us keep Notify.gov secure, we require that you use your account appropriately. When you use Notify.gov, you agree that you’ll respect these rules of behavior:
+  </p>
+  <ul>
+    <li>Conduct only authorized business on the system.</li>
+    <li>Maintain the confidentiality of your authentication credentials; a Notify.gov operator should never ask you to reveal them. We recommend using a password manager and strong credentials.</li>
+    <li>Log out when you no longer need session access. Never leave your computer unattended while logged into Notify.gov.</li>
+    <li>Report all security incidents or suspected incidents (such as improper or suspicious acts) related to Notify.gov systems and networks to Notify.gov support.</li>
+    <li>Safeguard system resources against waste, loss, abuse, unauthorized use or disclosure, and misappropriation.</li>
+    <li>Don’t process U.S. classified national security information on the system.</li>
+    <li>Don’t browse, search or reveal information hosted by Notify.gov except as required to perform your legitimate tasks or assigned duties.</li>
+    <li>Don’t retrieve information, or in any other way disclose information, for someone who does not have authority to access that information.</li>
+    <li>Don’t intentionally use a client that makes use of obsolete or insecure encryption algorithms.</li>
+    <li>Don’t configure your browser to ignore security warnings which may involve your connection with Notify.gov; report warnings that you can’t explain to Notify.gov support.</li>
+    <li>If you believe you’ve been granted more access than necessary to perform your legitimate tasks or assigned duties, immediately notify Notify.gov support.</li>
+    <li>Don’t share your account with another person or create anonymous or group accounts. Your account is just for you.</li>
+  </ul>
+  <p>Access to systems and networks owned by Notify.gov is governed by, and subject to, all federal laws, including, but not limited to, the Privacy Act, 5 U.S.C. 552a, if the applicable Notify.gov system maintains individual Privacy Act information. Access to Notify.gov systems constitutes consent to the retrieval and disclosure of the information within the scope of your authorized access, subject to the Privacy Act, and applicable state and federal laws.</p>
+  <p>Please contact Notify.gov support if you have questions about these rules or don’t understand them.</p>
+</section>
+
+{% endblock %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -19,6 +19,7 @@ EXCLUDED_ENDPOINTS = tuple(
         {
             "about_notify",
             "about_security",
+            "acceptable_use_policy",
             "accept_invite",
             "accept_org_invite",
             "accessibility_statement",


### PR DESCRIPTION
## Description

When a partner is logged into their account, and needs detail about what's allowed for use, they should be able to find their Acceptable Use Policy (AUP) easily

## TODO (optional)

* [x] Create webpage to hold the AUP
* [x] Add footer nav link