### PR TITLE
Added link to /studio and made some small style updates

### DIFF
--- a/app/templates/views/about/about.html
+++ b/app/templates/views/about/about.html
@@ -68,7 +68,7 @@
     {% endfor %}
   </ul>
   <p><a href="/join-notify">See if Notify is right for you</a></p>
-  <p>Notify.gov is a product of the <a href="#">Public Benefits Studio</a>, a product accelerator inside
+  <p>Notify.gov is a product of the <a href="/studio">Public Benefits Studio</a>, a product accelerator inside
     the federal government. </p>
 </section>
 {% endblock %}

--- a/app/templates/views/about/why-text-messaging.html
+++ b/app/templates/views/about/why-text-messaging.html
@@ -72,7 +72,7 @@
   ] %}
   {% for item in card_contents %}
   <div class="radius-lg border-2px maxw-tablet">
-    <div class="grid-row grid-gap-4 padding-4 padding-y-3 flex-align-center">
+    <div class="grid-row grid-gap-4 padding-2 padding-x-3 flex-align-center">
       <div class="grid-col flex-3">
         <p><b>{{item.card_heading}}</b></p>
         <p>{{item.p_text}}</p>

--- a/app/templates/views/contact.html
+++ b/app/templates/views/contact.html
@@ -15,7 +15,7 @@
     aria-label="For partnership inquiries">
     <div class="usa-summary-box__body">
       <div class="usa-summary-box__text">
-        <p>If you are a current Notify.gov partner and have technical issues or questions, we are available at <a
+        <p class="margin-0">If you are a current Notify.gov partner and have technical issues or questions, we are available at <a
             href="mailto:notify-support@gsa.gov"
             aria-label="Email Notify for technical questions at notify-support@gsa.gov">notify-support@gsa.gov</a></p>
       </div>

--- a/app/templates/views/join-notify.html
+++ b/app/templates/views/join-notify.html
@@ -72,14 +72,14 @@
     aria-labelledby="summary-box-how-to-get-started">
     <div class="usa-summary-box__body">
       <div class="usa-summary-box__text">
-        <p>Interested in trying Notify.gov before signing an agreement? We can provide qualifying partners with access
+        <p class="margin-0">Interested in trying Notify.gov before signing an agreement? We can provide qualifying partners with access
           to Trial Mode to review Notify.gov features before deciding. In Trial Mode, you can test sending messages,
           explore the personalization and customization features, and review sample delivery reports.</p>
       </div>
     </div>
   </div>
 
-  <h4>Tell us about your program</h4>
+  <h3 class="font-body-md">Tell us about your program</h3>
   <p class="padding-bottom-3">
     Let’s determine if Notify.gov is a good fit for your organization. To <b>get started</b>, we’ll ask you for
     information such as:


### PR DESCRIPTION
## Description

Noticed the link wasn't going to /studio at the bottom of the about page, remedied. Also made some style updates. 