### PR TITLE
get rid of some noise in status updates

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -555,7 +555,7 @@
         "filename": "tests/app/main/views/test_register.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 199,
         "is_secret": false
       },
       {
@@ -563,7 +563,7 @@
         "filename": "tests/app/main/views/test_register.py",
         "hashed_secret": "bb5b7caa27d005d38039e3797c3ddb9bcd22c3c8",
         "is_verified": false,
-        "line_number": 273,
+        "line_number": 272,
         "is_secret": false
       }
     ],
@@ -684,5 +684,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-13T20:16:58Z"
+  "generated_at": "2025-01-16T16:38:48Z"
 }

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -32,11 +32,7 @@ def check_feature_flags():
 @main.route("/test/feature-flags")
 def test_feature_flags():
     return jsonify(
-        {
-            "FEATURE_ABOUT_PAGE_ENABLED": current_app.config[
-                "FEATURE_ABOUT_PAGE_ENABLED"
-            ]
-        }
+        {"FEATURE_ABOUT_PAGE_ENABLED": current_app.config["FEATURE_ABOUT_PAGE_ENABLED"]}
     )
 
 
@@ -235,7 +231,6 @@ def contact():
     return render_template(
         "views/contact.html",
         navigation_links=about_notify_nav(),
-
     )
 
 
@@ -268,7 +263,6 @@ def join_notify():
     return render_template(
         "views/join-notify.html",
         navigation_links=about_notify_nav(),
-
     )
 
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -122,9 +122,7 @@ def test_static_pages(client_request, mock_get_organization_by_domain, view, moc
         session["user_id"] = None
     request(
         _expected_status=302,
-        _expected_redirect="/sign-in?next={}".format(
-            url_for("main.{}".format(view))
-        ),
+        _expected_redirect="/sign-in?next={}".format(url_for("main.{}".format(view))),
     )
 
 

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -144,9 +144,8 @@ def test_should_return_200_when_email_is_not_gov_uk(
         _expected_status=200,
     )
 
-    assert (
-        "Enter a public sector email address."
-        in normalize_spaces(page.select_one(".usa-error-message").text)
+    assert "Enter a public sector email address." in normalize_spaces(
+        page.select_one(".usa-error-message").text
     )
 
 

--- a/tests/app/notify_client/test_billing_client.py
+++ b/tests/app/notify_client/test_billing_client.py
@@ -10,10 +10,15 @@ def test_get_free_sms_fragment_limit_for_year_correct_endpoint(mocker, api_user_
     expected_url = "/service/{}/billing/free-sms-fragment-limit".format(service_id)
     client = BillingAPIClient()
 
-    mock_get = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.get")
+    mock_get = mocker.patch(
+        "app.notify_client.billing_api_client.BillingAPIClient.get",
+        return_value={"free_sms_fragment_limit": 0},
+    )
     mocker.patch(
         "app.notify_client.billing_api_client.redis_client.get", return_value=None
     )
+
+    mocker.patch("app.notify_client.billing_api_client.redis_client.set")
 
     client.get_free_sms_fragment_limit_for_year(service_id, year=1999)
     mock_get.assert_called_once_with(

--- a/tests/app/notify_client/test_billing_client.py
+++ b/tests/app/notify_client/test_billing_client.py
@@ -11,6 +11,9 @@ def test_get_free_sms_fragment_limit_for_year_correct_endpoint(mocker, api_user_
     client = BillingAPIClient()
 
     mock_get = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.get")
+    mocker.patch(
+        "app.notify_client.billing_api_client.redis_client.get", return_value=None
+    )
 
     client.get_free_sms_fragment_limit_for_year(service_id, year=1999)
     mock_get.assert_called_once_with(
@@ -28,6 +31,11 @@ def test_post_free_sms_fragment_limit_for_current_year_endpoint(
     )
     client = BillingAPIClient()
 
+    mocker.patch(
+        "app.notify_client.billing_api_client.redis_client.get", return_value=None
+    )
+
+    mocker.patch("app.notify_client.billing_api_client.redis_client.set")
     client.create_or_update_free_sms_fragment_limit(
         service_id=service_id, free_sms_fragment_limit=1111
     )


### PR DESCRIPTION
## Description

The front end is making many many redundant calls to the back end for status.  Use redis to cache so that the backend only gets hit every 30 seconds.

NOTE: Some files are formatting changes only, don't know why they are there.

## Security Considerations

N/A