### PR TITLE
1706 updaterevise status banner on confirmation page

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -57,7 +57,6 @@ def view_job(service_id, job_id):
 
     filter_args = parse_filter_args(request.args)
     filter_args["status"] = set_status_filters(filter_args)
-    # updates_url
     return render_template(
         "views/jobs/job.html",
         job=job,
@@ -111,7 +110,7 @@ def cancel_job(service_id, job_id):
 @user_has_permissions()
 def view_job_updates(service_id, job_id):
     job = Job.from_id(job_id, service_id=service_id)
-# this could help
+
     return jsonify(**get_job_partials(job))
 
 
@@ -407,7 +406,7 @@ def get_job_partials(job):
         session["arrived_from_preview_page"] = False
 
     arrived_from_preview_page_url = session.get("arrived_from_preview_page", False)
-    # partials here
+
     return {
         "counts": counts,
         "notifications": render_template(

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -57,7 +57,7 @@ def view_job(service_id, job_id):
 
     filter_args = parse_filter_args(request.args)
     filter_args["status"] = set_status_filters(filter_args)
-
+    # updates_url
     return render_template(
         "views/jobs/job.html",
         job=job,
@@ -111,7 +111,7 @@ def cancel_job(service_id, job_id):
 @user_has_permissions()
 def view_job_updates(service_id, job_id):
     job = Job.from_id(job_id, service_id=service_id)
-
+# this could help
     return jsonify(**get_job_partials(job))
 
 
@@ -407,8 +407,7 @@ def get_job_partials(job):
         session["arrived_from_preview_page"] = False
 
     arrived_from_preview_page_url = session.get("arrived_from_preview_page", False)
-    print('job', dir(job))
-
+    # partials here
     return {
         "counts": counts,
         "notifications": render_template(

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -407,6 +407,7 @@ def get_job_partials(job):
         session["arrived_from_preview_page"] = False
 
     arrived_from_preview_page_url = session.get("arrived_from_preview_page", False)
+    print('job', dir(job))
 
     return {
         "counts": counts,

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -401,7 +401,7 @@ def get_job_partials(job):
     )
 
     if request.referrer is not None:
-        session["arrived_from_preview_page"] = "check" in request.referrer
+        session["arrived_from_preview_page"] = ("check" in request.referrer) or ("help=0" in request.referrer)
     else:
         session["arrived_from_preview_page"] = False
 

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -10,7 +10,8 @@
   <div>
     <ul class="usa-icon-list">
       <li class="usa-icon-list__item">
-        <img src="{{ url_for('static', filename='img/material-icons/description.svg') }}" alt="">
+        <img src="{{asset_url('img/material-icons/description.svg')}}" alt="">
+        <!-- fix this image reload on ajax -->
         <div class="usa-icon-list__content">
           <h3>{{ job.original_file_name }}</h3>
         </div>
@@ -20,13 +21,9 @@
 {% endif %}
 <h2>Delivery Status</h2>
 {% endset %}
-{{ ajax_block(
-  partials,
-  url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
-  'job'
-) }}
 <div class="ajax-block-container">
   <p class='bottom-gutter'>
+    <!-- do we need not job.finished_processing or arrived_from_preview_page_url?  -->
     {% if not job.finished_processing or arrived_from_preview_page_url %}
       {% if job.scheduled_for %}
         <div class="usa-alert usa-alert--info">

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -11,7 +11,6 @@
     <ul class="usa-icon-list">
       <li class="usa-icon-list__item">
         <img src="{{asset_url('img/material-icons/description.svg')}}" alt="">
-        <!-- fix this image reload on ajax -->
         <div class="usa-icon-list__content">
           <h3>{{ job.original_file_name }}</h3>
         </div>
@@ -23,7 +22,6 @@
 {% endset %}
 <div class="ajax-block-container">
   <p class='bottom-gutter'>
-    <!-- do we need not job.finished_processing or arrived_from_preview_page_url?  -->
     {% if not job.finished_processing or arrived_from_preview_page_url %}
       {% if job.scheduled_for %}
         <div class="usa-alert usa-alert--info">

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,3 +1,5 @@
+{% from "components/ajax-block.html" import ajax_block %}
+
 {% set display_message_status %}
 {% if job.template.content %}
   <h2 class="sms-message-header">Message</h2>
@@ -18,14 +20,18 @@
 {% endif %}
 <h2>Delivery Status</h2>
 {% endset %}
-
+{{ ajax_block(
+  partials,
+  url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
+  'job'
+) }}
 <div class="ajax-block-container">
   <p class='bottom-gutter'>
     {% if not job.finished_processing or arrived_from_preview_page_url %}
       {% if job.scheduled_for %}
         <div class="usa-alert usa-alert--info">
           <div class="usa-alert__body">
-            <h2 class="usa-alert__heading">Your text has been scheduled</h2>
+            <h2 class="usa-alert__heading">Your message has been scheduled</h2>
             <p class="usa-alert__text">
               {{ job.template_name }} - {{ current_service.name }} was scheduled on {{ job.scheduled_for|format_datetime_normal }} by {{ job.created_by.name }}
             </p>
@@ -38,9 +44,9 @@
             <div class="usa-alert__body">
               <h2 class="usa-alert__heading">
                 {% if job.finished_processing %}
-                  Your text has been sent
+                  Your message has been sent
                 {% else %}
-                  Your text is sending
+                  Your message is sending
                 {% endif %}
               </h2>
               <p class="usa-alert__text">
@@ -57,7 +63,7 @@
           <div class="usa-alert usa-alert--info">
             <div class="usa-alert__body">
               <h2 class="usa-alert__heading">
-                Your text is pending
+                Your message is pending
               </h2>
               <p class="usa-alert__text">
                 {{ job.template_name }} - {{ current_service.name }}

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,5 +1,3 @@
-{% from "components/ajax-block.html" import ajax_block %}
-
 {% set display_message_status %}
 {% if job.template.content %}
   <h2 class="sms-message-header">Message</h2>
@@ -10,7 +8,7 @@
   <div>
     <ul class="usa-icon-list">
       <li class="usa-icon-list__item">
-        <img src="{{asset_url('img/material-icons/description.svg')}}" alt="">
+        <img src="{{ url_for('static', filename='img/material-icons/description.svg') }}" alt="">
         <div class="usa-icon-list__content">
           <h3>{{ job.original_file_name }}</h3>
         </div>
@@ -20,9 +18,10 @@
 {% endif %}
 <h2>Delivery Status</h2>
 {% endset %}
+
 <div class="ajax-block-container">
   <p class='bottom-gutter'>
-    {% if not job.finished_processing or arrived_from_preview_page_url %}
+    {% if not job.finished_processing %}
       {% if job.scheduled_for %}
         <div class="usa-alert usa-alert--info">
           <div class="usa-alert__body">
@@ -34,23 +33,15 @@
         </div>
         {{display_message_status}}
       {% else %}
-        {% if job.finished_processing or job.processing_started %}
+        {% if job.processing_started %}
           <div class="usa-alert usa-alert--success">
             <div class="usa-alert__body">
               <h2 class="usa-alert__heading">
-                {% if job.finished_processing %}
-                  Your message has been sent
-                {% else %}
-                  Your message is sending
-                {% endif %}
+                Your message is sending
               </h2>
               <p class="usa-alert__text">
                 {{ job.template_name }} - {{ current_service.name }}
-                {% if job.finished_processing %}
-                  was sent on {{job.processing_started|format_datetime_normal}}
-                {% else %}
-                  has been sending since {{job.processing_started| format_datetime_normal}}
-                {% endif %} by {{ job.created_by.name }}
+                has been sending since {{job.processing_started| format_datetime_normal}} by {{ job.created_by.name }}
               </p>
             </div>
           </div>
@@ -69,6 +60,19 @@
         {% endif %}
         {{display_message_status}}
       {% endif %}
+    {% elif arrived_from_preview_page_url %}
+      <div class="usa-alert usa-alert--success">
+        <div class="usa-alert__body">
+          <h2 class="usa-alert__heading">
+              Your message has been sent
+          </h2>
+          <p class="usa-alert__text">
+            {{ job.template_name }} - {{ current_service.name }}
+              was sent on {{job.processing_started|format_datetime_normal}} by {{ job.created_by.name }}
+          </p>
+        </div>
+      </div>
+      {{display_message_status}}
     {% endif %}
   </p>
   {% if job.status == 'sending limits exceeded'%}

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -21,7 +21,7 @@
 
 <div class="ajax-block-container">
   <p class='bottom-gutter'>
-    {% if job.still_processing or arrived_from_preview_page_url %}
+    {% if not job.finished_processing or arrived_from_preview_page_url %}
       {% if job.scheduled_for %}
         <div class="usa-alert usa-alert--info">
           <div class="usa-alert__body">
@@ -33,16 +33,39 @@
         </div>
         {{display_message_status}}
       {% else %}
-        <div class="usa-alert usa-alert--success">
-          <div class="usa-alert__body">
-            <h2 class="usa-alert__heading">Your text has been sent</h2>
-            <p class="usa-alert__text">
-              {{ job.template_name }} - {{ current_service.name }} was sent on {% if job.processing_started %}
-              {{ job.processing_started|format_datetime_table }} {% else %}
-              {{ job.created_at|format_datetime_table }} {% endif %} by {{ job.created_by.name }}
-            </p>
+        {% if job.finished_processing or job.processing_started %}
+          <div class="usa-alert usa-alert--success">
+            <div class="usa-alert__body">
+              <h2 class="usa-alert__heading">
+                {% if job.finished_processing %}
+                  Your text has been sent
+                {% else %}
+                  Your text is sending
+                {% endif %}
+              </h2>
+              <p class="usa-alert__text">
+                {{ job.template_name }} - {{ current_service.name }}
+                {% if job.finished_processing %}
+                  was sent on {{job.processing_started|format_datetime_normal}}
+                {% else %}
+                  has been sending since {{job.processing_started| format_datetime_normal}}
+                {% endif %} by {{ job.created_by.name }}
+              </p>
+            </div>
           </div>
-        </div>
+        {% else %}
+          <div class="usa-alert usa-alert--info">
+            <div class="usa-alert__body">
+              <h2 class="usa-alert__heading">
+                Your text is pending
+              </h2>
+              <p class="usa-alert__text">
+                {{ job.template_name }} - {{ current_service.name }}
+                has been pending since {{job.created_at|format_datetime_normal}} by {{ job.created_by.name }}
+              </p>
+            </div>
+          </div>
+        {% endif %}
         {{display_message_status}}
       {% endif %}
     {% endif %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -11,7 +11,19 @@
 {% block maincolumn_content %}
 
     {{ page_header("Message status") }}
-    {{ partials['status']|safe }}
+    <!-- do i need arrived_from_preview_page_url? -->
+    {% if not job.processing_finished %}
+      <div
+        data-module="update-content"
+        data-resource="{{ updates_url }}"
+        data-key="status"
+        data-form=""
+      >
+    {% endif %}
+      {{ partials['status']|safe }}
+    {% if not job.processing_finished %}
+      </div>
+    {% endif %}
     {% if not finished %}
       <div
         data-module="update-content"

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -11,6 +11,18 @@
 {% block maincolumn_content %}
 
     {{ page_header("Message status") }}
+    {% if not job.processing_finished %}
+      <div
+        data-module="update-content"
+        data-resource="{{ updates_url }}"
+        data-key="status"
+        data-form=""
+      >
+    {% endif %}
+      {{ partials['status']|safe }}
+    {% if not job.processing_finished  %}
+      </div>
+    {% endif %}
     {% if not finished %}
       <div
         data-module="update-content"

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -11,19 +11,6 @@
 {% block maincolumn_content %}
 
     {{ page_header("Message status") }}
-    <!-- do i need arrived_from_preview_page_url? -->
-    {% if not job.processing_finished %}
-      <div
-        data-module="update-content"
-        data-resource="{{ updates_url }}"
-        data-key="status"
-        data-form=""
-      >
-    {% endif %}
-      {{ partials['status']|safe }}
-    {% if not job.processing_finished %}
-      </div>
-    {% endif %}
     {% if not finished %}
       <div
         data-module="update-content"

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -269,7 +269,7 @@ def test_should_show_job_with_sending_limit_exceeded_status(
         pytest.param(
             datetime(2020, 1, 1, 0, 0, 0),
             datetime(2020, 1, 9, 6, 0, 1),
-            ("No messages to show yet…"),
+            ("These messages have been deleted because they were sent more than 7 days ago"),
         ),
         # Created a while ago, started exactly 24h ago
         # ---

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -269,7 +269,7 @@ def test_should_show_job_with_sending_limit_exceeded_status(
         pytest.param(
             datetime(2020, 1, 1, 0, 0, 0),
             datetime(2020, 1, 9, 6, 0, 1),
-            ("These messages have been deleted because they were sent more than 7 days ago"),
+            ("No messages to show yet…"),
         ),
         # Created a while ago, started exactly 24h ago
         # ---


### PR DESCRIPTION
Ticket: https://github.com/GSA/notifications-admin/issues/1706

This ticket is to fix our issue around confirmation banner to provide more status updates. 
### New status updates: 
**Scheduled for**: Displays the time the user scheduled the job to send a future message.
**Sending since**: Indicates the time the job started processing.
**Pending since**: Displays the time the job was created if it has not started or finished processing.
**Sent on**: Shows the time the job was completed.

![image](https://github.com/user-attachments/assets/276288df-0ec7-459e-8aa7-8667d29fcf98)
![image](https://github.com/user-attachments/assets/03bc8ac4-b481-418f-b713-8a17c1942f99)
![image](https://github.com/user-attachments/assets/57dcaa86-0438-488f-94f4-91ebedfa9d23)
![image](https://github.com/user-attachments/assets/5ce1e550-d317-47f9-a910-aba337017a82)