### PR TITLE
clean log messages

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -401,7 +401,9 @@ def get_job_partials(job):
     )
 
     if request.referrer is not None:
-        session["arrived_from_preview_page"] = ("check" in request.referrer) or ("help=0" in request.referrer)
+        session["arrived_from_preview_page"] = ("check" in request.referrer) or (
+            "help=0" in request.referrer
+        )
     else:
         session["arrived_from_preview_page"] = False
 

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -6,16 +6,35 @@ from app.notify_client import NotifyAdminAPIClient
 
 class BillingAPIClient(NotifyAdminAPIClient):
     def get_monthly_usage_for_service(self, service_id, year):
-        return self.get(
+        monthly_usage = redis_client.get(f"monthly-usage-summary-{service_id}-{year}")
+        if monthly_usage is not None:
+            return json.loads(monthly_usage.decode("utf-8"))
+        result = self.get(
             "/service/{0}/billing/monthly-usage".format(service_id),
             params=dict(year=year),
         )
+        redis_client.set(
+            f"monthly-usage-summary-{service_id}-{year}",
+            json.dumps(result),
+            ex=30,
+        )
+        return result
 
     def get_annual_usage_for_service(self, service_id, year=None):
-        return self.get(
+        annual_usage = redis_client.get(f"yearly-usage-summary-{service_id}-{year}")
+        if annual_usage is not None:
+            return json.loads(annual_usage.decode("utf-8"))
+        result = self.get(
             "/service/{0}/billing/yearly-usage-summary".format(service_id),
             params=dict(year=year),
         )
+
+        redis_client.set(
+            f"yearly-usage-summary-{service_id}-{year}",
+            json.dumps(result),
+            ex=30,
+        )
+        return result
 
     def get_free_sms_fragment_limit_for_year(self, service_id, year=None):
         frag_limit = redis_client.get(f"free-sms-fragment-limit-{service_id}-{year}")
@@ -48,13 +67,28 @@ class BillingAPIClient(NotifyAdminAPIClient):
         )
 
     def get_data_for_billing_report(self, start_date, end_date):
-        return self.get(
+        x_start_date = str(start_date)
+        x_start_date = x_start_date.replace(" ", "_")
+        x_end_date = str(end_date)
+        x_end_date = x_end_date.replace(" ", "_")
+        billing_data = redis_client.get(
+            f"get-data-for-billing-report-{x_start_date}-{x_end_date}"
+        )
+        if billing_data is not None:
+            return json.loads(billing_data.decode("utf-8"))
+        result = self.get(
             url="/platform-stats/data-for-billing-report",
             params={
                 "start_date": str(start_date),
                 "end_date": str(end_date),
             },
         )
+        redis_client.set(
+            f"get-data-for-billing-report-{x_start_date}-{x_end_date}",
+            json.dumps(result),
+            ex=30,
+        )
+        return result
 
     def get_data_for_volumes_by_service_report(self, start_date, end_date):
         return self.get(

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -141,8 +141,15 @@ def test_get_notification(mocker):
 
 def test_get_notification_count_for_job_id(mocker):
     mock_get = mocker.patch(
-        "app.notify_client.notification_api_client.NotificationApiClient.get"
+        "app.notify_client.notification_api_client.NotificationApiClient.get",
+        return_value={"count": 0},
     )
+
+    mocker.patch(
+        "app.notify_client.notification_api_client.redis_client.get", return_value=None
+    )
+
+    mocker.patch("app.notify_client.billing_api_client.redis_client.set")
     NotificationApiClient().get_notification_count_for_job_id(
         service_id="foo", job_id="bar"
     )


### PR DESCRIPTION
## Description

UI components are requesting various counts and statuses from the backend multiple times per second, resulting in about half of the lines in the API logs being totally useless and making the logs hard to read and filter through.

Use redis on the UI side to store these values for 30 seconds, so the calls to get fresh data only hit the back end every thirty seconds (i.e. reduce calling volume by 99.9%).

## Security Considerations

N/A