### PR TITLE
Updated frontend call to include local timezone

### DIFF
--- a/app/assets/javascripts/activityChart.js
+++ b/app/assets/javascripts/activityChart.js
@@ -201,15 +201,22 @@
             return;
         }
 
-        var url = type === 'service' ? `/daily_stats.json` : `/daily_stats_by_user.json`;
+        // get local timezone
+        var userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        var url = type === 'service'
+        ? `/daily_stats.json?timezone=${encodeURIComponent(userTimezone)}`
+        : `/daily_stats_by_user.json`;
+
         return fetch(url)
             .then(response => {
                 if (!response.ok) {
                     throw new Error('Network response was not ok');
                 }
+                console.log(response)
                 return response.json();
             })
             .then(data => {
+                console.log(data)
                 labels = [];
                 deliveredData = [];
                 failedData = [];

--- a/app/assets/javascripts/activityChart.js
+++ b/app/assets/javascripts/activityChart.js
@@ -226,11 +226,9 @@
                 if (!response.ok) {
                     throw new Error('Network response was not ok');
                 }
-                console.log(response)
                 return response.json();
             })
             .then(data => {
-                console.log(data)
                 labels = [];
                 deliveredData = [];
                 failedData = [];

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -80,8 +80,6 @@ def service_dashboard(service_id):
 @user_has_permissions()
 def get_daily_stats(service_id):
     date_range = get_stats_date_range()
-
-    # Get timezone from request (default to UTC if not provided)
     user_timezone = request.args.get("timezone", "UTC")
 
     stats = service_api_client.get_service_notification_statistics_by_day(
@@ -94,12 +92,15 @@ def get_daily_stats(service_id):
 @user_has_permissions()
 def get_daily_stats_by_user(service_id):
     service_id = session.get("service_id")
+    user_timezone = request.args.get("timezone", "UTC")
+
     date_range = get_stats_date_range()
     stats = service_api_client.get_user_service_notification_statistics_by_day(
         service_id,
         user_id=current_user.id,
         start_date=date_range["start_date"],
         days=date_range["days"],
+        user_timezone=user_timezone,
     )
     return jsonify(stats)
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -83,7 +83,6 @@ def get_daily_stats(service_id):
 
     # Get timezone from request (default to UTC if not provided)
     user_timezone = request.args.get("timezone", "UTC")
-    print(f"Detected User Timezone test124: {user_timezone}")
 
     stats = service_api_client.get_service_notification_statistics_by_day(
         service_id, start_date=date_range["start_date"], days=date_range["days"], timezone=user_timezone

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -99,8 +99,12 @@ def get_daily_stats():
     service_id = session.get("service_id")
     date_range = get_stats_date_range()
 
+    # Get timezone from request (default to UTC if not provided)
+    user_timezone = request.args.get("timezone", "UTC")
+    print(f"Detected User Timezone test124: {user_timezone}")
+
     stats = service_api_client.get_service_notification_statistics_by_day(
-        service_id, start_date=date_range["start_date"], days=date_range["days"]
+        service_id, start_date=date_range["start_date"], days=date_range["days"], timezone=user_timezone
     )
     return jsonify(stats)
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -55,16 +55,15 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )["data"]
 
     def get_user_service_notification_statistics_by_day(
-        self, service_id, user_id, start_date=None, days=None
+        self, service_id, user_id, start_date=None, days=None, user_timezone="UTC"
     ):
         if start_date is None:
             start_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
         return self.get(
-            "/service/{0}/statistics/user/{1}/{2}/{3}".format(
-                service_id, user_id, start_date, days
-            ),
-        )["data"]
+            "/service/{0}/statistics/user/{1}/{2}/{3}?timezone={4}".format(
+            service_id, user_id, start_date, days, user_timezone
+        ))["data"]
 
     def get_services(self, params_dict=None):
         """

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -61,9 +61,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             start_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
         return self.get(
-            "/service/{0}/statistics/user/{1}/{2}/{3}?timezone={4}".format(
-            service_id, user_id, start_date, days, user_timezone
-        ))["data"]
+            "/service/{0}/statistics/user/{1}/{2}/{3}?timezone={4}".format(service_id, user_id, start_date, days, user_timezone),
+        )["data"]
 
     def get_services(self, params_dict=None):
         """

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -45,13 +45,13 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )["data"]
 
     def get_service_notification_statistics_by_day(
-        self, service_id, start_date=None, days=None
+        self, service_id, start_date=None, days=None, timezone="UTC"
     ):
         if start_date is None:
             start_date = datetime.now().strftime("%Y-%m-%d")
 
         return self.get(
-            "/service/{0}/statistics/{1}/{2}".format(service_id, start_date, days),
+            "/service/{0}/statistics/{1}/{2}?timezone={3}".format(service_id, start_date, days, timezone),
         )["data"]
 
     def get_user_service_notification_statistics_by_day(

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -61,7 +61,13 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             start_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
         return self.get(
-            "/service/{0}/statistics/user/{1}/{2}/{3}?timezone={4}".format(service_id, user_id, start_date, days, user_timezone),
+            "/service/{0}/statistics/user/{1}/{2}/{3}?timezone={4}".format(
+                service_id,
+                user_id,
+                start_date,
+                days,
+                user_timezone
+            ),
         )["data"]
 
     def get_services(self, params_dict=None):

--- a/tests/javascripts/activityChart.test.js
+++ b/tests/javascripts/activityChart.test.js
@@ -199,7 +199,9 @@ test('Fetches data and creates chart and table correctly', async () => {
 
   const data = await fetchData('service');
 
-  expect(global.fetch).toHaveBeenCalledWith(`/services/${currentServiceId}/daily-stats.json`);
+  expect(global.fetch).toHaveBeenCalledWith(
+    `/services/${currentServiceId}/daily-stats.json?timezone=UTC`
+  );
   expect(data).toEqual(mockResponse);
 
   const labels = Object.keys(mockResponse).map(dateString => {


### PR DESCRIPTION
Fixes issue #2204 
Related to PR - [1547](https://github.com/GSA/notifications-api/pull/1547)

## Changes
- Updated fetchData for daily_stats.json to include the user's local timezone when making requests.
- Ensures stats are displayed in the correct local time instead of defaulting to UTC.
- Verified changes with API updates to ensure correct date conversions and display.

##Testing
- To verify testing works, after merging, an text needs to be send from dev environment after 6pm est and the results should show up almost immediately for today instead of having to wait for tomorrow to see results for the wrong day. 