### PR TITLE
Fix endless status calls

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -65,10 +65,7 @@ def service_dashboard(service_id):
     active_jobs = [job for job in job_response if job["job_status"] != "cancelled"]
     sorted_jobs = sorted(active_jobs, key=lambda job: job["created_at"], reverse=True)
     job_lists = [
-        {
-            **job_dict,
-            "finished_processing": job_is_finished(job_dict)
-        }
+        {**job_dict, "finished_processing": job_is_finished(job_dict)}
         for job_dict in sorted_jobs
     ]
 
@@ -91,7 +88,7 @@ def job_is_finished(job_dict):
         "technical-failure",
         "temporary-failure",
         "permanent-failure",
-        "cancelled"
+        "cancelled",
     ]
 
     processed_count = sum(

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -1,10 +1,15 @@
 import json
 
 from app.extensions import redis_client
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
 
 class NotificationApiClient(NotifyAdminAPIClient):
+
+    @cache.set(
+        "notifications-{service_id}-{job_id}-{status}-{page}-{limit_days}-{include_jobs}-{include_one_off}",
+        ttl_in_seconds=30,
+    )
     def get_notifications_for_service(
         self,
         service_id,

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -38,6 +38,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         return self.get("/service/{0}".format(service_id))
 
+    @cache.set("service-stats-{service_id}-{limit_days}", ttl_in_seconds=30)
     def get_service_statistics(self, service_id, limit_days=None):
         return self.get(
             "/service/{0}/statistics".format(service_id),

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -55,6 +55,15 @@ from app.notify_client.notification_api_client import NotificationApiClient
 def test_client_gets_notifications_for_service_and_job_by_page(
     mocker, arguments, expected_call
 ):
+
+    mocker.patch(
+        "app.extensions.RedisClient.get",
+        return_value=None,
+    )
+
+    mocker.patch(
+        "app.extensions.RedisClient.set",
+    )
     mock_get = mocker.patch(
         "app.notify_client.notification_api_client.NotificationApiClient.get"
     )

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -58,14 +58,13 @@ def test_client_gets_notifications_for_service_and_job_by_page(
 
     mocker.patch(
         "app.extensions.RedisClient.get",
-        return_value=None,
+        return_value={},
     )
 
-    mocker.patch(
-        "app.extensions.RedisClient.set",
-    )
+    mocker.patch("app.extensions.RedisClient.set", return_value={})
     mock_get = mocker.patch(
-        "app.notify_client.notification_api_client.NotificationApiClient.get"
+        "app.notify_client.notification_api_client.NotificationApiClient.get",
+        return_value={},
     )
     NotificationApiClient().get_notifications_for_service("abcd1234", **arguments)
     mock_get.assert_called_once_with(**expected_call)
@@ -111,8 +110,16 @@ def test_client_gets_notifications_for_service_and_job_by_page(
 def test_client_gets_notifications_for_service_and_job_by_page_posts_for_to(
     mocker, arguments, expected_call
 ):
+
+    mocker.patch(
+        "app.extensions.RedisClient.get",
+        return_value={},
+    )
+
+    mocker.patch("app.extensions.RedisClient.set", return_value={})
     mock_post = mocker.patch(
-        "app.notify_client.notification_api_client.NotificationApiClient.post"
+        "app.notify_client.notification_api_client.NotificationApiClient.post",
+        return_value={},
     )
     NotificationApiClient().get_notifications_for_service("abcd1234", **arguments)
     mock_post.assert_called_once_with(**expected_call)


### PR DESCRIPTION
## Description

Front end is calling back end so many times for status, do some caching to take load off db.

NOTE: If Bev has a better fix (fix Ajax timing) let's do that instead.

## Security Considerations

N/A
