### PR TITLE
fix runaway report generation

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -65,10 +65,7 @@ def service_dashboard(service_id):
     active_jobs = [job for job in job_response if job["job_status"] != "cancelled"]
     sorted_jobs = sorted(active_jobs, key=lambda job: job["created_at"], reverse=True)
     job_lists = [
-        {
-            **job_dict,
-            "finished_processing": job_is_finished(job_dict)
-        }
+        {**job_dict, "finished_processing": job_is_finished(job_dict)}
         for job_dict in sorted_jobs
     ]
 
@@ -91,7 +88,7 @@ def job_is_finished(job_dict):
         "technical-failure",
         "temporary-failure",
         "permanent-failure",
-        "cancelled"
+        "cancelled",
     ]
 
     processed_count = sum(

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -128,6 +128,13 @@ def generate_notifications_csv(**kwargs):
         notifications_resp = notification_api_client.get_notifications_for_service(
             **kwargs
         )
+        # Stop if we are finished
+        if (
+            notifications_resp.get("notifications") is None
+            or len(notifications_resp["notifications"]) == 0
+        ):
+            return
+
         for notification in notifications_resp["notifications"]:
             preferred_tz_created_at = convert_report_date_to_preferred_timezone(
                 notification["created_at"]


### PR DESCRIPTION
## Description

Something changed on the front end after 1/16/2025 so that some code in csv.py that used to work but was written a little dangerously, spun off into an infinite loop.  While making calls to fetch notifications, check that we are actually still getting notifications back and have not run out of data.

## Security Considerations

N/A