### PR TITLE
Added local/utc time conversion for text metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,3 +162,8 @@ upload-static:
 # 	@cf map-route notify-admin ${DNS_NAME} --hostname www
 # 	@cf unmap-route notify-admin-failwhale ${DNS_NAME} --hostname www
 # 	@echo "Failwhale is disabled"
+
+.PHONY: test-single
+test-single: export NEW_RELIC_ENVIRONMENT=test
+test-single: ## Run a single test file
+	poetry run pytest $(TEST_FILE)

--- a/app/assets/javascripts/activityChart.js
+++ b/app/assets/javascripts/activityChart.js
@@ -213,7 +213,13 @@
             return;
         }
 
-        var url = type === 'service' ? `/services/${currentServiceId}/daily-stats.json` : `/services/${currentServiceId}/daily-stats-by-user.json`;
+        var userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        var url = type === 'service'
+            ? `/services/${currentServiceId}/daily-stats.json?timezone=${encodeURIComponent(userTimezone)}`
+            : `/services/${currentServiceId}/daily-stats-by-user.json`;
+
+
         return fetch(url)
             .then(response => {
                 if (!response.ok) {

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,7 +1,8 @@
 import calendar
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 from itertools import groupby
+from zoneinfo import ZoneInfo
 
 from flask import Response, abort, jsonify, render_template, request, session, url_for
 from flask_login import current_user
@@ -80,10 +81,47 @@ def service_dashboard(service_id):
 @user_has_permissions()
 def get_daily_stats(service_id):
     date_range = get_stats_date_range()
-    stats = service_api_client.get_service_notification_statistics_by_day(
-        service_id, start_date=date_range["start_date"], days=date_range["days"]
+    days = date_range["days"]
+    user_timezone = request.args.get("timezone", "UTC")
+
+    stats_utc = service_api_client.get_service_notification_statistics_by_day(
+        service_id,
+        start_date=date_range["start_date"],
+        days=days,
     )
-    return jsonify(stats)
+
+    local_stats = get_local_daily_stats_for_last_x_days(stats_utc, user_timezone, days)
+    return jsonify(local_stats)
+
+
+def get_local_daily_stats_for_last_x_days(stats_utc, user_timezone, days):
+    tz = ZoneInfo(user_timezone)
+    today_local = datetime.now(tz).date()
+    start_local = today_local - timedelta(days=days - 1)
+
+    # Generate exactly days local dates, each with zeroed stats
+    days_list = [
+        (start_local + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(days)
+    ]
+    aggregator = {
+        d: {
+            "sms":   {"delivered": 0, "failure": 0, "pending": 0, "requested": 0},
+            "email": {"delivered": 0, "failure": 0, "pending": 0, "requested": 0},
+        }
+        for d in days_list
+    }
+
+    # Convert each UTC timestamp to local date and iterate
+    for utc_ts, data in stats_utc.items():
+        utc_dt = datetime.strptime(utc_ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=ZoneInfo("UTC"))
+        local_day = utc_dt.astimezone(tz).strftime("%Y-%m-%d")
+
+        if local_day in aggregator:
+            for msg_type in ["sms", "email"]:
+                for status in ["delivered", "failure", "pending", "requested"]:
+                    aggregator[local_day][msg_type][status] += data[msg_type][status]
+
+    return aggregator
 
 
 @main.route("/services/<uuid:service_id>/daily-stats-by-user.json")

--- a/tests/javascripts/activityChart.test.js
+++ b/tests/javascripts/activityChart.test.js
@@ -199,7 +199,7 @@ test('Fetches data and creates chart and table correctly', async () => {
 
   const data = await fetchData('service');
 
-  expect(global.fetch).toHaveBeenCalledWith(`/services/${currentServiceId}/daily-stats.json`);
+  expect(global.fetch).toHaveBeenCalledWith(`/services/${currentServiceId}/daily-stats.json?timezone=UTC`);
   expect(data).toEqual(mockResponse);
 
   const labels = Object.keys(mockResponse).map(dateString => {


### PR DESCRIPTION
Fixes issue #2204 
Related to PR - [1569](https://github.com/GSA/notifications-api/pull/1569)

## Changes
- Updated fetchData for daily_stats.json to include the user's local timezone when making requests.
- Ensures stats are displayed in the correct local time instead of defaulting to UTC.
- Verified changes with API updates to ensure correct date conversions and display.

##Testing
- To verify testing works, after merging, an text needs to be send from dev environment after 6pm est and the results should show up almost immediately for today instead of having to wait for tomorrow to see results for the wrong day. 
![Screenshot 2025-02-26 at 10 40 12 AM](https://github.com/user-attachments/assets/4410f8a8-22c7-4625-9328-80d6690adff1)




