### PR TITLE
Removed text from logged in contact us page

### DIFF
--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -15,7 +15,6 @@
   <ul class="list list-bullet">
     <li>For information on personalization, see <a href={{ url_for("main.how_to") }}>How to</a>.</li>
     <li>For help interpreting delivery reports, see <a href={{ url_for("main.message_status") }}>Delivery status</a>.</li>
-    <li>For details on pricing and what counts as a message part, see <a href={{ url_for("main.pricing") }}>Pricing</a>.</li>
   </ul>
 
   <p>If you have other questions, we are available at <a class="usa-link" href="mailto:notify-support@gsa.gov">notify-support@gsa.gov</a>.</p>


### PR DESCRIPTION
Removed bullet point from Contact Us Page which is behind logging in. 

<img width="759" alt="image" src="https://github.com/user-attachments/assets/d396e4e6-f28c-4d73-8f86-7c03a9f51d81" />
