### PR TITLE
2398 - broken TTS link

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -94,10 +94,10 @@
     {% block footer %}
 
       {% if current_service and current_service.research_mode %}
-        {% set meta_suffix = 'Built by the <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions" class="usa-link">Technology Transformation Services</a><span id="research-mode" class="research-mode">research mode</span>' %}
+        {% set meta_suffix = 'Built by the <a href="https://tts.gsa.gov/" class="usa-link">Technology Transformation Services</a><span id="research-mode" class="research-mode">research mode</span>' %}
       {% else %}
         {% set commit_hash = ", Latest version: " + config['COMMIT_HASH'] %}
-        {% set long_link = '<a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions" class="usa-link">Technology Transformation Services</a>' %}
+        {% set long_link = '<a href="https://tts.gsa.gov/" class="usa-link">Technology Transformation Services</a>' %}
         {% set meta_suffix = "Built by the " + long_link + commit_hash %}
       {% endif %}
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

Updating the TTS link on the footer, maybe the link used to go to a page that was removed

## TODO (optional)

* [x] Update the TTS link

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice
