### PR TITLE
Removed feature flag

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -151,7 +151,7 @@
         "filename": "app/config.py",
         "hashed_secret": "577a4c667e4af8682ca431857214b3a920883efc",
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 118,
         "is_secret": false
       }
     ],
@@ -674,5 +674,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-17T23:26:44Z"
+  "generated_at": "2025-03-20T18:22:36Z"
 }

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -167,7 +167,6 @@ jobs:
         run: make run-flask &
         env:
           NOTIFY_ENVIRONMENT: scanning
-          FEATURE_ABOUT_PAGE_ENABLED: true
       - name: Run OWASP Baseline Scan
         uses: zaproxy/action-baseline@v0.14.0
         with:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -169,15 +169,15 @@ def _csp(config):
 
 
 def create_app(application):
-    @application.context_processor
+    # @application.context_processor
     # def inject_feature_flags():
-        ## this is where feature flags can be easily added as a dictionary within context
-        # feature_about_page_enabled = application.config.get(
-        #     "FEATURE_ABOUT_PAGE_ENABLED", False
-        # )
-        # return dict(
-        #     FEATURE_ABOUT_PAGE_ENABLED=feature_about_page_enabled,
-        # )
+    # this is where feature flags can be easily added as a dictionary within context
+    # feature_about_page_enabled = application.config.get(
+    # "FEATURE_ABOUT_PAGE_ENABLED", False
+    # )
+    # return dict(
+    #     FEATURE_ABOUT_PAGE_ENABLED=feature_about_page_enabled,
+    # )
 
     @application.context_processor
     def inject_initial_signin_url():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -170,13 +170,14 @@ def _csp(config):
 
 def create_app(application):
     @application.context_processor
-    def inject_feature_flags():
-        feature_about_page_enabled = application.config.get(
-            "FEATURE_ABOUT_PAGE_ENABLED", False
-        )
-        return dict(
-            FEATURE_ABOUT_PAGE_ENABLED=feature_about_page_enabled,
-        )
+    # def inject_feature_flags():
+        ## this is where feature flags can be easily added as a dictionary within context
+        # feature_about_page_enabled = application.config.get(
+        #     "FEATURE_ABOUT_PAGE_ENABLED", False
+        # )
+        # return dict(
+        #     FEATURE_ABOUT_PAGE_ENABLED=feature_about_page_enabled,
+        # )
 
     @application.context_processor
     def inject_initial_signin_url():

--- a/app/config.py
+++ b/app/config.py
@@ -88,8 +88,6 @@ class Config(object):
         ],
     }
 
-    FEATURE_ABOUT_PAGE_ENABLED = getenv("FEATURE_ABOUT_PAGE_ENABLED", "false") == "true"
-
 
 def _s3_credentials_from_env(bucket_prefix):
     return {

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -23,10 +23,11 @@ from app.utils.user import user_is_logged_in
 # Hook to check for feature flags
 @main.before_request
 def check_feature_flags():
-    if request.path.startswith("/about") and not current_app.config.get(
-        "FEATURE_ABOUT_PAGE_ENABLED", False
-    ):
-        abort(404)
+    # Placeholder for future feature flag checks
+    # Example:
+    # if request.path.startswith("/some-feature") and not current_app.config.get("FEATURE_SOME_FEATURE_ENABLED", False):
+    #     abort(404)
+    pass
 
 
 @main.route("/test/feature-flags")


### PR DESCRIPTION
Removed feature flag to prevent having to manually flip after a prod deploy. Left comments to show how feature flags might still be used in the future instead of removing all of the scaffolding code. 