### PR TITLE
css update pill label to show visibility 

### DIFF
--- a/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
+++ b/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
@@ -591,11 +591,25 @@ td.table-empty-message {
         .big-number-smallest {
           font-size: units(3);
         }
+        .pill-item__label {
+          color: white;
+        }
         &:not(.pill-item--selected):hover {
           background: color('blue-warm-70v');
+
+          .pill-item__label {
+            color: white;
+          }
         }
-        &.pill-item--selected:hover {
-          color: color('blue-60v');
+        &.pill-item--selected {
+          .pill-item__label {
+            color: color('blue-60v');
+          }
+          &:hover {
+            .pill-item__label {
+              color: color('blue-60v');
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
There was a bug in the css where the pill label wasn't visible. This PR addresses that issue 

### BEFORE:
![image](https://github.com/user-attachments/assets/4872d0ca-5740-44a2-b64d-a3f6cab02937)

### AFTER:
<img width="880" alt="image" src="https://github.com/user-attachments/assets/c171bee5-b54e-4ffd-acc7-786d2fbbf34f" />
