### PR TITLE
Update Makefile to handle pre-existing git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,20 @@ NVMSH := $(shell [ -f "$(HOME)/.nvm/nvm.sh" ] && echo "$(HOME)/.nvm/nvm.sh" || e
 ## DEVELOPMENT
 
 .PHONY: bootstrap
-bootstrap: generate-version-file ## Set up everything to run the app
+bootstrap: ## Set up everything to run the app
+	make generate-version-file
+	poetry self add poetry-dotenv-plugin
+	poetry lock --no-update
+	poetry install --sync --no-root
+	poetry run playwright install --with-deps
+	poetry run pre-commit install
+	source $(NVMSH) --no-use && nvm install && npm install
+	source $(NVMSH) && npm ci --no-audit
+	source $(NVMSH) && npm run build
+
+.PHONY: bootstrap-with-git-hooks
+bootstrap-with-git-hooks:  ## Sets everything up and accounts for pre-existing git hooks
+	make generate-version-file
 	poetry self add poetry-dotenv-plugin
 	poetry lock --no-update
 	poetry install --sync --no-root


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds a bit of extra support to the `bootstrap` command to make sure that pre-existing `git` hooks do not interfere with the installation of the `pre-commit` `git` hooks.

## Security Considerations

* This change allows us to use multiple audit/security tools that hook into `git` without them conflicting with each other.

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice
