### PR TITLE
Remove hint text and country code reference

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -40,8 +40,7 @@
   ) %}
     <div class="grid-row">
       {% set is_phone_number = form.placeholder_value.label.text == "phone number" %}
-      {% set label_text = "Country code and phone number" if current_placeholder == "phone number" else current_placeholder %}
-      {% set hint_text = "For example: +18885551234" if is_phone_number else None %}
+      {% set label_text = " phone number" if current_placeholder == "phone number" else current_placeholder %}
       {% set extra_class = "extra-tracking" if is_phone_number else "" %}
 
       <div class="grid-col-12 {{ extra_class }}">

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1264,7 +1264,7 @@ def test_send_one_off_has_correct_page_title(
         (
             0,
             {},
-            "Country code and phone number",
+            "phone number",
         ),
         (
             1,


### PR DESCRIPTION
## Description

Removing references to country code

## TODO (optional)

* [x] Remove reference to country code
* [x] Fix breaking test

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice
