### PR TITLE
Pin egress proxy release

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -127,13 +127,24 @@
     }
   ],
   "results": {
+    ".github/actions/deploy-proxy/action.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".github/actions/deploy-proxy/action.yml",
+        "hashed_secret": "a6c13f5da3788e8d654cd24001dc79a238723248",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
     ".github/workflows/checks.yml": [
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/checks.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 68,
+        "is_secret": false
       }
     ],
     "app/assets/js/uswds.min.js": [
@@ -633,5 +644,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-01T13:44:35Z"
+  "generated_at": "2025-05-12T16:50:20Z"
 }

--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: https://github.com/GSA-TTS/cg-egress-proxy.git
   proxy_version:
     description: git ref to be deployed
-    default: main
+    default: 1500c67157c1a7a6fbbda7a2de172b3d0a67e703
 runs:
   using: composite
   steps:


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset pins the egress proxy to a previous release to help troubleshoot a potential issue with the underlying Caddy server update.

## Security Considerations

* The hash referenced in the change to the GitHub Action is to [this specific commit](https://github.com/GSA-TTS/cg-egress-proxy/commit/1500c67157c1a7a6fbbda7a2de172b3d0a67e703) in the egress proxy repo, which is public.
* The secret baseline file had to be updated to account for this specific commit hash reference.