### PR TITLE
Added a "No results found"

### DIFF
--- a/app/assets/javascripts/liveSearch.js
+++ b/app/assets/javascripts/liveSearch.js
@@ -15,6 +15,7 @@
 
     let query = normalize($searchBox.val());
     let results = 0;
+    let $noResultsMessage = $('.js-live-search-no-results');
 
     $targets.each(function() {
 
@@ -38,6 +39,12 @@
       if (isMatch) { results++; }
 
     });
+
+    if (query !== '' && results === 0) {
+      $noResultsMessage.show();
+    } else {
+      $noResultsMessage.hide();
+    }
 
     if (state === 'loaded') {
       if (query !== '') {

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -36,6 +36,9 @@
   {% endif %}
 
   <div class="user-list">
+    <div class="js-live-search-no-results margin-top-3" style="display: none;">
+      <p class="usa-body margin-0">No results found</p>
+    </div>
     {% for user in users %}
       {% if user.status != 'cancelled' %}
         <div class="user-list-item width-full">


### PR DESCRIPTION
These changes add a user-friendly "No results found" message that appears when searching for team members yields no matches, improving the user experience on the team members page. 

Added a "No results found" message div with class js-live-search-no-results