### PR TITLE
Updated pip-audit ignore-vulns

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -144,8 +144,7 @@ jobs:
         with:
           inputs: requirements.txt
           ignore-vulns: |
-            PYSEC-2024-60
-            PYSEC-2022-43162
+            PYSEC-2023-312
       - name: Run npm audit
         run: make npm-audit
 

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -29,6 +29,8 @@ jobs:
     - uses: pypa/gh-action-pip-audit@v1.1.0
       with:
         inputs: requirements.txt
+        ignore-vulns: |
+            PYSEC-2023-312
     - name: Run npm audit
       run: make npm-audit
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset updates the PYSEC notices to ignore due versions that either cannot be fixed or are false positives.  Specifically, this changeset removes previously ignored vulnerability reports and adds PYSEC-2023-312 to the list because it is a false positive and refers to Redis itself, not the Python Redis client (see https://github.com/pypa/advisory-database/issues/237 for details).

## Security Considerations

* We should only ignore vulnerability reports when it is safe to do so.
* We should remove the ignore flags once the vulnerability is remediated or confirmed to be a false positive.

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice
