### PR TITLE
Add one more cert environment variable

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -44,6 +44,7 @@ applications:
 
       NOTIFY_BILLING_DETAILS: '[]'
 
+      SSL_CERT_FILE: '/etc/ssl/certs/ca-certificates.crt'
       REQUESTS_CA_BUNDLE: '/etc/ssl/certs/ca-certificates.crt'
       NEW_RELIC_CA_BUNDLE_PATH: '/etc/ssl/certs/ca-certificates.crt'
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds an additional environment variable to enforce usage of the correct CA certificate in case any libraries override it.

Please see https://cloud.gov/docs/management/container-to-container/#addressing-certificate-validation-errors for more details.

## Security Considerations

* We want to make sure the proper certificates are used on the server side.

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice
