### PR TITLE
manually roll python back to 3.12.2

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -9,10 +9,10 @@ runs:
         sudo apt-get update \
         && sudo apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev
-    - name: Set up Python 3.13.2
+    - name: Set up Python 3.12.2
       uses: actions/setup-python@v4
       with:
-        python-version: "3.13.2"
+        python-version: "3.12.2"
     - name: Install poetry
       shell: bash
       run: pip install poetry==2.1.3

--- a/README.md
+++ b/README.md
@@ -186,12 +186,12 @@ session to make the changes take effect.
 Now we're ready to install the Python version we need with `pyenv`, like so:
 
 ```sh
-pyenv install 3.13
+pyenv install 3.12
 ```
 
-This will install the latest version of Python 3.13.
+This will install the latest version of Python 3.12.
 
-_NOTE: This project currently runs on Python 3.13.x._
+_NOTE: This project currently runs on Python 3.12.x._
 
 #### [API Step] Python Dependency Installation
 
@@ -243,12 +243,12 @@ git clone git@github.com:GSA/notifications-admin.git
 
 Now go into the project directory (`notifications-admin` by default), create a
 virtual environment, and set the local Python version to point to the virtual
-environment (assumes version Python `3.13.2` is what is installed on your
+environment (assumes version Python `3.12.2` is what is installed on your
 machine):
 
 ```sh
 cd notifications-admin
-pyenv virtualenv 3.13.2 notify-admin
+pyenv virtualenv 3.12.2 notify-admin
 pyenv local notify-admin
 ```
 
@@ -281,10 +281,10 @@ If you're upgrading an existing project to a newer version of Python, you can
 follow these steps to get yourself up-to-date.
 
 First, use `pyenv` to install the newer version of Python you'd like to use;
-we'll use `3.13` in our example here since we recently upgraded to this version:
+we'll use `3.12` in our example here since we recently upgraded to this version:
 
 ```sh
-pyenv install 3.13
+pyenv install 3.12
 ```
 
 Next, delete the virtual environment you previously had set up. If you followed
@@ -299,7 +299,7 @@ environment with the newer version of Python you just installed:
 
 ```sh
 cd notifications-admin
-pyenv virtualenv 3.13.2 notify-admin
+pyenv virtualenv 3.12.2 notify-admin
 pyenv local notify-admin
 ```
 

--- a/app/utils/api_health.py
+++ b/app/utils/api_health.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import ssl
 
 import requests
 from requests.exceptions import RequestException
@@ -8,17 +7,10 @@ from requests.exceptions import RequestException
 logger = logging.getLogger(__name__)
 
 
-# Is this right and can we use it anywhere?
-def get_no_x509_strict_context():
-    context = ssl.create_default_context()
-    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
-    return context
-
-
 def is_api_down():
     api_base_url = os.getenv("API_HOST_NAME")
     try:
-        response = requests.get(api_base_url, timeout=2, verify=False)  # nosec
+        response = requests.get(api_base_url, timeout=2)
         is_down = response.status_code != 200
         if is_down:
             logger.warning(

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,6 +27,7 @@ files = [
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
@@ -959,6 +960,9 @@ files = [
     {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
 ]
 
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
+
 [package.extras]
 test = ["pytest (>=6)"]
 
@@ -1757,8 +1761,11 @@ files = [
     {file = "lxml-5.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7ce1a171ec325192c6a636b64c94418e71a1964f56d002cc28122fceff0b6121"},
     {file = "lxml-5.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:795f61bcaf8770e1b37eec24edf9771b307df3af74d1d6f27d812e15a9ff3872"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29f451a4b614a7b5b6c2e043d7b64a15bd8304d7e767055e8ab68387a8cacf4e"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f7f991a68d20c75cb13c5c9142b2a3f9eb161f1f12a9489c82172d1f133c0"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4aa412a82e460571fad592d0f93ce9935a20090029ba08eca05c614f99b0cc92"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:ac7ba71f9561cd7d7b55e1ea5511543c0282e2b6450f122672a2694621d63b7e"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:c5d32f5284012deaccd37da1e2cd42f081feaa76981f0eaa474351b68df813c5"},
+    {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:ce31158630a6ac85bddd6b830cffd46085ff90498b397bd0a259f59d27a12188"},
     {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:31e63621e073e04697c1b2d23fcb89991790eef370ec37ce4d5d469f40924ed6"},
     {file = "lxml-5.4.0-cp37-cp37m-win32.whl", hash = "sha256:be2ba4c3c5b7900246a8f866580700ef0d538f2ca32535e991027bdaba944063"},
     {file = "lxml-5.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:09846782b1ef650b321484ad429217f5154da4d6e786636c38e434fa32e94e49"},
@@ -4176,5 +4183,5 @@ cffi = ["cffi (>=1.11)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.13.2"
-content-hash = "a4e59aab0b9c95ba66d024e0187ae34bf8e42875e20a5e721c6d03b8481c1605"
+python-versions = "^3.12.2"
+content-hash = "6f58a9c3cb0dd017d6f72710dd1a123b6d7b82f5fed1e001945dd8f5b8d83d8a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 axe-core-python = "^0.1.0"
-python = "^3.13.2"
+python = "^3.12.2"
 ago = "~=0.1.0"
 beautifulsoup4 = "^4.13.3"
 blinker = "~=1.8"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.13.x
+python-3.12.x

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1745,92 +1745,92 @@ def test_can_create_email_template_with_emoji(
     assert mock_create_service_template.called is True
 
 
-# @pytest.mark.parametrize(
-#     ("template_type", "expected_error"),
-#     [
-#         (
-#             "sms",
-#             (
-#                 "Please remove the unaccepted character 🍜 in your message, then save again"
-#             ),
-#         ),
-#     ],
-# )
-# def test_should_not_create_sms_template_with_emoji(
-#     client_request,
-#     service_one,
-#     mock_create_service_template,
-#     template_type,
-#     expected_error,
-# ):
-#     service_one["permissions"] += [template_type]
-#     page = client_request.post(
-#         ".add_service_template",
-#         service_id=SERVICE_ONE_ID,
-#         template_type=template_type,
-#         _data={
-#             "name": "new name",
-#             "template_content": "here are some noodles 🍜",
-#             "template_type": "sms",
-#             "service": SERVICE_ONE_ID,
-#             "process_type": "normal",
-#         },
-#         _expected_status=200,
-#     )
-#     # print(page.main.prettify())
-#     assert expected_error in normalize_spaces(
-#         page.select_one("#template_content-error").text
-#     )
-#     assert mock_create_service_template.called is False
+@pytest.mark.parametrize(
+    ("template_type", "expected_error"),
+    [
+        (
+            "sms",
+            (
+                "Please remove the unaccepted character 🍜 in your message, then save again"
+            ),
+        ),
+    ],
+)
+def test_should_not_create_sms_template_with_emoji(
+    client_request,
+    service_one,
+    mock_create_service_template,
+    template_type,
+    expected_error,
+):
+    service_one["permissions"] += [template_type]
+    page = client_request.post(
+        ".add_service_template",
+        service_id=SERVICE_ONE_ID,
+        template_type=template_type,
+        _data={
+            "name": "new name",
+            "template_content": "here are some noodles 🍜",
+            "template_type": "sms",
+            "service": SERVICE_ONE_ID,
+            "process_type": "normal",
+        },
+        _expected_status=200,
+    )
+    # print(page.main.prettify())
+    assert expected_error in normalize_spaces(
+        page.select_one("#template_content-error").text
+    )
+    assert mock_create_service_template.called is False
 
 
-# @pytest.mark.asyncio
-# @pytest.mark.parametrize(
-#     ("template_type", "expected_error"),
-#     [
-#         (
-#             "sms",
-#             (
-#                 "Please remove the unaccepted character 🍔 in your message, then save again"
-#             ),
-#         ),
-#     ],
-# )
-# async def test_should_not_update_sms_template_with_emoji(
-#     mocker,
-#     client_request,
-#     service_one,
-#     mock_get_service_template,
-#     mock_update_service_template,
-#     fake_uuid,
-#     template_type,
-#     expected_error,
-# ):
-#     service_one["permissions"] += [template_type]
-#     return mocker.patch(
-#         "app.service_api_client.get_service_template",
-#         return_value=template_json(
-#             SERVICE_ONE_ID,
-#             fake_uuid,
-#             type_=template_type,
-#         ),
-#     )
-#     page = client_request.post(
-#         ".edit_service_template",
-#         service_id=SERVICE_ONE_ID,
-#         template_id=fake_uuid,
-#         _data={
-#             "id": fake_uuid,
-#             "name": "new name",
-#             "template_content": "here's a burger 🍔",
-#             "service": SERVICE_ONE_ID,
-#             "template_type": template_type,
-#             "process_type": "normal",
-#         },
-#         _expected_status=200,
-#     )
-#     assert expected_error in page.text
-#     assert mock_update_service_template.called is False
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("template_type", "expected_error"),
+    [
+        (
+            "sms",
+            (
+                "Please remove the unaccepted character 🍔 in your message, then save again"
+            ),
+        ),
+    ],
+)
+async def test_should_not_update_sms_template_with_emoji(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_service_template,
+    mock_update_service_template,
+    fake_uuid,
+    template_type,
+    expected_error,
+):
+    service_one["permissions"] += [template_type]
+    return mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value=template_json(
+            SERVICE_ONE_ID,
+            fake_uuid,
+            type_=template_type,
+        ),
+    )
+    page = client_request.post(
+        ".edit_service_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _data={
+            "id": fake_uuid,
+            "name": "new name",
+            "template_content": "here's a burger 🍔",
+            "service": SERVICE_ONE_ID,
+            "template_type": template_type,
+            "process_type": "normal",
+        },
+        _expected_status=200,
+    )
+    assert expected_error in page.text
+    assert mock_update_service_template.called is False
 
 
 @pytest.mark.parametrize(

--- a/tests/end_to_end/test_create_new_template.py
+++ b/tests/end_to_end/test_create_new_template.py
@@ -1,4 +1,5 @@
 # import datetime
+import datetime
 import os
 import re
 import uuid
@@ -98,85 +99,84 @@ async def create_new_template(page):
     assert "Test message for e2e test" in page.content()
 
 
-# @pytest.mark.asyncio
-# async def test_create_new_template(end_to_end_context):
-#     page = end_to_end_context.new_page()
-#     page.goto(f"{E2E_TEST_URI}/sign-in")
-#     # Wait for the next page to fully load.
-#     page.wait_for_load_state("domcontentloaded")
-#     check_axe_report(page)
+async def test_create_new_template(end_to_end_context):
+    page = end_to_end_context.new_page()
+    page.goto(f"{E2E_TEST_URI}/sign-in")
+    # Wait for the next page to fully load.
+    page.wait_for_load_state("domcontentloaded")
+    check_axe_report(page)
 
-#     current_date_time = datetime.datetime.now()
-#     new_service_name = "E2E Federal Test Service {now} - {browser_type}".format(
-#         now=current_date_time.strftime("%m/%d/%Y %H:%M:%S"),
-#         browser_type=page.context.browser.browser_type.name,
-#     )
-#     page.goto(f"{E2E_TEST_URI}/accounts")
+    current_date_time = datetime.datetime.now()
+    new_service_name = "E2E Federal Test Service {now} - {browser_type}".format(
+        now=current_date_time.strftime("%m/%d/%Y %H:%M:%S"),
+        browser_type=page.context.browser.browser_type.name,
+    )
+    page.goto(f"{E2E_TEST_URI}/accounts")
 
-#     # Check to make sure that we've arrived at the next page.
-#     page.wait_for_load_state("domcontentloaded")
-#     check_axe_report(page)
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state("domcontentloaded")
+    check_axe_report(page)
 
-#     # Check to make sure that we've arrived at the next page.
-#     # Check the page title exists and matches what we expect.
-#     expect(page).to_have_title(re.compile("Choose service"))
+    # Check to make sure that we've arrived at the next page.
+    # Check the page title exists and matches what we expect.
+    expect(page).to_have_title(re.compile("Choose service"))
 
-#     # Check for the sign in heading.
-#     sign_in_heading = page.get_by_role("heading", name="Choose service")
-#     expect(sign_in_heading).to_be_visible()
+    # Check for the sign in heading.
+    sign_in_heading = page.get_by_role("heading", name="Choose service")
+    expect(sign_in_heading).to_be_visible()
 
-#     # Retrieve some prominent elements on the page for testing.
-#     add_service_button = page.get_by_role(
-#         "button", name=re.compile("Add a new service")
-#     )
+    # Retrieve some prominent elements on the page for testing.
+    add_service_button = page.get_by_role(
+        "button", name=re.compile("Add a new service")
+    )
 
-#     expect(add_service_button).to_be_visible()
+    expect(add_service_button).to_be_visible()
 
-#     existing_service_link = page.get_by_role("link", name=new_service_name)
+    existing_service_link = page.get_by_role("link", name=new_service_name)
 
-#     # Check to see if the service was already created - if so, we should fail.
-#     # TODO:  Figure out how to make this truly isolated, and/or work in a
-#     #        delete service workflow.
-#     expect(existing_service_link).to_have_count(0)
+    # Check to see if the service was already created - if so, we should fail.
+    # TODO:  Figure out how to make this truly isolated, and/or work in a
+    #        delete service workflow.
+    expect(existing_service_link).to_have_count(0)
 
-#     # Click on add a new service.
-#     add_service_button.click()
+    # Click on add a new service.
+    add_service_button.click()
 
-#     # Check to make sure that we've arrived at the next page.
-#     page.wait_for_load_state("domcontentloaded")
-#     check_axe_report(page)
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state("domcontentloaded")
+    check_axe_report(page)
 
-#     # Check for the sign in heading.
-#     about_heading = page.get_by_role("heading", name="About your service")
-#     expect(about_heading).to_be_visible()
+    # Check for the sign in heading.
+    about_heading = page.get_by_role("heading", name="About your service")
+    expect(about_heading).to_be_visible()
 
-#     # Retrieve some prominent elements on the page for testing.
-#     service_name_input = page.locator('xpath=//input[@name="name"]')
-#     add_service_button = page.get_by_role("button", name=re.compile("Add service"))
+    # Retrieve some prominent elements on the page for testing.
+    service_name_input = page.locator('xpath=//input[@name="name"]')
+    add_service_button = page.get_by_role("button", name=re.compile("Add service"))
 
-#     expect(service_name_input).to_be_visible()
-#     expect(add_service_button).to_be_visible()
+    expect(service_name_input).to_be_visible()
+    expect(add_service_button).to_be_visible()
 
-#     # Fill in the form.
-#     service_name_input.fill(new_service_name)
+    # Fill in the form.
+    service_name_input.fill(new_service_name)
 
-#     # Click on add service.
-#     add_service_button.click()
+    # Click on add service.
+    add_service_button.click()
 
-#     # Check to make sure that we've arrived at the next page.
-#     page.wait_for_load_state("domcontentloaded")
-#     check_axe_report(page)
+    # Check to make sure that we've arrived at the next page.
+    page.wait_for_load_state("domcontentloaded")
+    check_axe_report(page)
 
-#     # TODO this fails on staging due to duplicate results on 'get_by_text'
-#     # Check for the service name title and heading.
-#     # service_heading = page.get_by_text(new_service_name, exact=True)
-#     # expect(service_heading).to_be_visible()
+    # TODO this fails on staging due to duplicate results on 'get_by_text'
+    # Check for the service name title and heading.
+    # service_heading = page.get_by_text(new_service_name, exact=True)
+    # expect(service_heading).to_be_visible()
 
-#     expect(page).to_have_title(re.compile(new_service_name))
+    expect(page).to_have_title(re.compile(new_service_name))
 
-#     create_new_template(page)
+    create_new_template(page)
 
-#     _teardown(page)
+    _teardown(page)
 
 
 def _teardown(page):

--- a/tests/end_to_end/test_create_new_template.py
+++ b/tests/end_to_end/test_create_new_template.py
@@ -99,7 +99,7 @@ async def create_new_template(page):
     assert "Test message for e2e test" in page.content()
 
 
-async def test_create_new_template(end_to_end_context):
+def test_create_new_template(end_to_end_context):
     page = end_to_end_context.new_page()
     page.goto(f"{E2E_TEST_URI}/sign-in")
     # Wait for the next page to fully load.


### PR DESCRIPTION
## Description

Manually roll back to python 3.12.2 due to certificate issues.

## Security Considerations

Not implementing strict checks on certificates introduced in python 3.13.2