### PR TITLE
remove async

### DIFF
--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1784,7 +1784,6 @@ def test_should_not_create_sms_template_with_emoji(
     assert mock_create_service_template.called is False
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("template_type", "expected_error"),
     [
@@ -1796,7 +1795,7 @@ def test_should_not_create_sms_template_with_emoji(
         ),
     ],
 )
-async def test_should_not_update_sms_template_with_emoji(
+def test_should_not_update_sms_template_with_emoji(
     mocker,
     client_request,
     service_one,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1784,52 +1784,53 @@ def test_should_not_create_sms_template_with_emoji(
     assert mock_create_service_template.called is False
 
 
-@pytest.mark.parametrize(
-    ("template_type", "expected_error"),
-    [
-        (
-            "sms",
-            (
-                "Please remove the unaccepted character 🍔 in your message, then save again"
-            ),
-        ),
-    ],
-)
-def test_should_not_update_sms_template_with_emoji(
-    mocker,
-    client_request,
-    service_one,
-    mock_get_service_template,
-    mock_update_service_template,
-    fake_uuid,
-    template_type,
-    expected_error,
-):
-    service_one["permissions"] += [template_type]
-    return mocker.patch(
-        "app.service_api_client.get_service_template",
-        return_value=template_json(
-            SERVICE_ONE_ID,
-            fake_uuid,
-            type_=template_type,
-        ),
-    )
-    page = client_request.post(
-        ".edit_service_template",
-        service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
-        _data={
-            "id": fake_uuid,
-            "name": "new name",
-            "template_content": "here's a burger 🍔",
-            "service": SERVICE_ONE_ID,
-            "template_type": template_type,
-            "process_type": "normal",
-        },
-        _expected_status=200,
-    )
-    assert expected_error in page.text
-    assert mock_update_service_template.called is False
+# @pytest.mark.asyncio
+# @pytest.mark.parametrize(
+#     ("template_type", "expected_error"),
+#     [
+#         (
+#             "sms",
+#             (
+#                 "Please remove the unaccepted character 🍔 in your message, then save again"
+#             ),
+#         ),
+#     ],
+# )
+# async def test_should_not_update_sms_template_with_emoji(
+#     mocker,
+#     client_request,
+#     service_one,
+#     mock_get_service_template,
+#     mock_update_service_template,
+#     fake_uuid,
+#     template_type,
+#     expected_error,
+# ):
+#     service_one["permissions"] += [template_type]
+#     return mocker.patch(
+#         "app.service_api_client.get_service_template",
+#         return_value=template_json(
+#             SERVICE_ONE_ID,
+#             fake_uuid,
+#             type_=template_type,
+#         ),
+#     )
+#     page = client_request.post(
+#         ".edit_service_template",
+#         service_id=SERVICE_ONE_ID,
+#         template_id=fake_uuid,
+#         _data={
+#             "id": fake_uuid,
+#             "name": "new name",
+#             "template_content": "here's a burger 🍔",
+#             "service": SERVICE_ONE_ID,
+#             "template_type": template_type,
+#             "process_type": "normal",
+#         },
+#         _expected_status=200,
+#     )
+#     assert expected_error in page.text
+#     assert mock_update_service_template.called is False
 
 
 @pytest.mark.parametrize(

--- a/tests/end_to_end/test_create_new_template.py
+++ b/tests/end_to_end/test_create_new_template.py
@@ -12,7 +12,7 @@ from tests.end_to_end.conftest import check_axe_report
 E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
 
 
-async def create_new_template(page):
+def create_new_template(page):
 
     current_service_link = page.get_by_text("Current service")
     expect(current_service_link).to_be_visible()

--- a/tests/end_to_end/test_create_new_template.py
+++ b/tests/end_to_end/test_create_new_template.py
@@ -12,7 +12,7 @@ from tests.end_to_end.conftest import check_axe_report
 E2E_TEST_URI = os.getenv("NOTIFY_E2E_TEST_URI")
 
 
-def create_new_template(page):
+async def create_new_template(page):
 
     current_service_link = page.get_by_text("Current service")
     expect(current_service_link).to_be_visible()


### PR DESCRIPTION
## Description

Remove async keyword from tests, which is causing havoc.

## Security Considerations

N/A