### PR TITLE
Allow users with manage template permission to delete templates

### DIFF
--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -58,9 +58,7 @@
       </span>
       <div>
         <a class="usa-link margin-right-3"
-        href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">
-          See previous versions
-        </a>
+        href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
       </div>
     {% endif %}
     {% if current_user.has_permissions('manage_templates') and user_has_template_permission %}


### PR DESCRIPTION
Issue: http://github.com/GSA/notifications-admin/issues/2545

This fix allows users with manage template permissions to delete templates without having to edit them first.