### PR TITLE
Unnecessary large white space below footer

### DIFF
--- a/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
+++ b/app/assets/sass/uswds/_uswds-theme-custom-styles.scss
@@ -316,13 +316,6 @@ td.table-empty-message {
 }
 
 .js-stick-at-bottom-when-scrolling {
-  position: sticky;
-  bottom: 0;
-  background: white;
-  border-top: 1px solid color('gray-cool-10');
-  padding: units(2);
-  margin-top: units(2);
-  z-index: 10;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
@@ -554,11 +547,17 @@ td.table-empty-message {
   background-color: #a1d3ff;
 }
 
+#template-list,
+#template-list > div,
+.sticky-scroll-area {
+  position: relative;
+}
+
 #template-list {
   max-height: 500px;
   overflow-y: auto;
   padding: units(1) 0 units(1) units(1);
-  margin: units(2) 0 units(5);
+  margin: units(2) 0 units(6);
   ul {
     padding: 0;
     margin: 0;

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -59,7 +59,7 @@
 
     {{ live_search(target_selector='#template-list .template-list-item', show=show_search_box, form=search_form) }}
 
-    <div class="js-live-search-no-results" style="display: none;">
+    <div class="js-live-search-no-results js-hidden">
       <p class="usa-body margin-top-2">No templates found</p>
     </div>
 


### PR DESCRIPTION
This PR cleans up the unnecessary large white space below footer and _csp console error


![image](https://github.com/user-attachments/assets/dd1f32ad-480c-478c-a161-b1af90d8eb7e)