### PR TITLE
more debug for invites

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -224,9 +224,9 @@ def set_up_your_profile():
 
         # activate the user
         user = user_api_client.get_user_by_uuid_or_email(user_uuid, user_email)
-        current_app.logger("#invites: going to activate user")
+        current_app.logger.info("#invites: going to activate user")
         activate_user(user["id"])
-        current_app.logger(f"#invites: activated user with user.id {user['id']}")
+        current_app.logger.info(f"#invites: activated user with user.id {user['id']}")
         usr = User.from_id(user["id"])
 
         usr.add_to_service(


### PR DESCRIPTION
## Description

We are seeing a mysterious failure on invites where new users accepting an invite get the "Service unavailable page".  The admin sends a second invite, which works.   It doesn't appear to be a case of the invites expiring.  The logs are inconclusive, but it might be an 'access denied' for some reason.   Add a bunch of debug statements in the invite section with the #invites tag to make the logs more easily searchable.

## Security Considerations

N/A