### PR TITLE
Updated dependabot yml to remove depecrated review assignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'pip' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: 'daily'
     assignees:
-      - "alexjanousekGSA"
-    reviewers:
-      - "alexjanousekGSA"
-  - package-ecosystem: "npm"
-    directory: "/"
+      - 'alexjanousekGSA'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     versioning-strategy: increase
     assignees:
-      - "alexjanousekGSA"
-    reviewers:
-      - "alexjanousekGSA"
+      - 'alexjanousekGSA'


### PR DESCRIPTION
Reviewers for dependabot is deprecrated - this updated still keeps dependabot PR's assigned to me. https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/