### PR TITLE
fixing pagination and download links along with tests

### DIFF
--- a/app/main/views/activity.py
+++ b/app/main/views/activity.py
@@ -97,10 +97,12 @@ def handle_pagination(jobs, service_id, page):
         else None
     )
     total_items = jobs.get("total", 0)
+    page_size = jobs.get("page_size", 50)
+    total_pages = (total_items + page_size - 1) // page_size
     has_next_link = jobs.get("links", {}).get("next") is not None
     next_page = (
         generate_next_dict("main.all_jobs_activity", service_id, page)
-        if has_next_link and total_items > 50
+        if has_next_link and total_items > 50 and page < total_pages
         else None
     )
     pagination = generate_pagination_pages(

--- a/app/main/views/activity.py
+++ b/app/main/views/activity.py
@@ -13,6 +13,32 @@ from app.utils.pagination import (
 from app.utils.user import user_has_permissions
 
 
+def get_download_availability(service_id):
+    """
+    Check if there are jobs available for each download time period.
+    """
+    jobs_1_day = job_api_client.get_page_of_jobs(service_id, page=1, limit_days=1)
+    jobs_3_days = job_api_client.get_page_of_jobs(service_id, page=1, limit_days=3)
+    jobs_5_days = job_api_client.get_page_of_jobs(service_id, page=1, limit_days=5)
+    jobs_7_days = job_api_client.get_immediate_jobs(service_id)
+
+    has_1_day_data = len(generate_job_dict(jobs_1_day)) > 0
+    has_3_day_data = len(generate_job_dict(jobs_3_days)) > 0
+    has_5_day_data = len(generate_job_dict(jobs_5_days)) > 0
+    has_7_day_data = len(jobs_7_days) > 0
+
+    return {
+        "has_1_day_data": has_1_day_data,
+        "has_3_day_data": has_3_day_data,
+        "has_5_day_data": has_5_day_data,
+        "has_7_day_data": has_7_day_data,
+        "has_any_download_data": has_1_day_data
+        or has_3_day_data
+        or has_5_day_data
+        or has_7_day_data,
+    }
+
+
 @main.route("/activity/services/<uuid:service_id>")
 @user_has_permissions(ServicePermission.VIEW_ACTIVITY)
 def all_jobs_activity(service_id):
@@ -22,6 +48,7 @@ def all_jobs_activity(service_id):
     all_jobs_dict = generate_job_dict(jobs)
     prev_page, next_page, pagination = handle_pagination(jobs, service_id, page)
     message_type = ("sms",)
+    download_availability = get_download_availability(service_id)
     return render_template(
         "views/activity/all-activity.html",
         all_jobs_dict=all_jobs_dict,
@@ -29,6 +56,7 @@ def all_jobs_activity(service_id):
         next_page=next_page,
         prev_page=prev_page,
         pagination=pagination,
+        **download_availability,
         download_link_one_day=url_for(
             ".download_notifications_csv",
             service_id=current_service.id,
@@ -68,9 +96,11 @@ def handle_pagination(jobs, service_id, page):
         if page > 1
         else None
     )
+    total_items = jobs.get("total", 0)
+    has_next_link = jobs.get("links", {}).get("next") is not None
     next_page = (
         generate_next_dict("main.all_jobs_activity", service_id, page)
-        if jobs.get("links", {}).get("next")
+        if has_next_link and total_items > 50
         else None
     )
     pagination = generate_pagination_pages(

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -254,10 +254,13 @@ def get_notifications(service_id, message_type, status_override=None):  # noqa
     next_page = None
 
     total_items = notifications.get("total", 0)
+    page_size = notifications.get("page_size", 50)
+    total_pages = (total_items + page_size - 1) // page_size
     if (
         "links" in notifications
         and notifications["links"].get("next", None)
         and total_items > 50
+        and page < total_pages
     ):
         next_page = generate_next_dict(
             "main.view_notifications", service_id, page, url_args

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -253,7 +253,12 @@ def get_notifications(service_id, message_type, status_override=None):  # noqa
         )
     next_page = None
 
-    if "links" in notifications and notifications["links"].get("next", None):
+    total_items = notifications.get("total", 0)
+    if (
+        "links" in notifications
+        and notifications["links"].get("next", None)
+        and total_items > 50
+    ):
         next_page = generate_next_dict(
             "main.view_notifications", service_id, page, url_args
         )

--- a/app/templates/views/activity/all-activity.html
+++ b/app/templates/views/activity/all-activity.html
@@ -126,20 +126,33 @@
     </div>
     {{show_pagination}}
     {% if current_user.has_permissions(ServicePermission.VIEW_ACTIVITY) %}
-      <h2 class="line-height-sans-2 margin-bottom-0 margin-top-4">Download recent reports</h2>
-      <p class="font-body-sm">
-        <a href="{{ download_link_one_day }}" download="download" class="usa-link">Download all data last 24 hours (<abbr title="Comma separated values">CSV</abbr>)</a>
-      </p>
-      <p class="font-body-sm">
-        <a href="{{ download_link_three_day }}" download="download" class="usa-link">Download all data last 3 days (<abbr title="Comma separated values">CSV</abbr>)</a>
-        &emsp;
-      </p>
-      <p class="font-body-sm">
-        <a href="{{ download_link_five_day }}" download="download" class="usa-link">Download all data last 5 days (<abbr title="Comma separated values">CSV</abbr>)</a>
-      </p>
-      <p class="font-body-sm">
-        <a href="{{ download_link_seven_day }}" download="download" class="usa-link">Download all data last 7 days (<abbr title="Comma separated values">CSV</abbr>)</a>
-      </p>
+      {% if has_any_download_data %}
+        <h2 class="line-height-sans-2 margin-bottom-0 margin-top-4">Download recent reports</h2>
+        {% if has_1_day_data %}
+          <p class="font-body-sm">
+            <a href="{{ download_link_one_day }}" download="download" class="usa-link">Download all data last 24 hours (<abbr title="Comma separated values">CSV</abbr>)</a>
+          </p>
+        {% endif %}
+        {% if has_3_day_data %}
+          <p class="font-body-sm">
+            <a href="{{ download_link_three_day }}" download="download" class="usa-link">Download all data last 3 days (<abbr title="Comma separated values">CSV</abbr>)</a>
+            &emsp;
+          </p>
+        {% endif %}
+        {% if has_5_day_data %}
+          <p class="font-body-sm">
+            <a href="{{ download_link_five_day }}" download="download" class="usa-link">Download all data last 5 days (<abbr title="Comma separated values">CSV</abbr>)</a>
+          </p>
+        {% endif %}
+        {% if has_7_day_data %}
+          <p class="font-body-sm">
+            <a href="{{ download_link_seven_day }}" download="download" class="usa-link">Download all data last 7 days (<abbr title="Comma separated values">CSV</abbr>)</a>
+          </p>
+        {% endif %}
+      {% else %}
+        <h2 class="line-height-sans-2 margin-bottom-0 margin-top-4">Download recent reports</h2>
+        <p class="font-body-sm">No recent activity to download. Download links will appear when jobs are available.</p>
+      {% endif %}
     {% endif %}
   </div>
 {% endblock %}

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -297,7 +297,6 @@ def test_download_links_show_when_data_available(
         "total": 1,
         "page_size": 50
     }
-    mock_jobs_empty = {"data": [], "total": 0, "page_size": 50}
 
     mocker.patch("app.job_api_client.get_page_of_jobs", return_value=mock_jobs_with_data)
     mocker.patch("app.job_api_client.get_immediate_jobs", return_value=[{"id": "job1"}])

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -562,7 +562,7 @@ def test_should_show_notifications_for_a_service_with_next_previous(
         "app.notification_api_client.get_notifications_for_service",
         return_value=notification_json(
             service_one["id"], rows=50, with_links=True
-        ) | {"total": 100},
+        ) | {"total": 150},
     )
     page = client_request.get(
         "main.view_notifications",
@@ -595,6 +595,35 @@ def test_should_show_notifications_for_a_service_with_next_previous(
     )
     assert "Previous page" in prev_page_link.text.strip()
     assert "page 1" in prev_page_link.text.strip()
+
+
+def test_doesnt_show_next_button_on_last_page(
+    client_request,
+    service_one,
+    active_user_with_permissions,
+    mock_get_service_statistics,
+    mock_get_service_data_retention,
+    mock_get_no_api_keys,
+    mocker,
+):
+    mocker.patch(
+        "app.notification_api_client.get_notifications_for_service",
+        return_value=notification_json(
+            service_one["id"], rows=50, with_links=True
+        ) | {"total": 100},
+    )
+    page = client_request.get(
+        "main.view_notifications",
+        service_id=service_one["id"],
+        message_type="sms",
+        page=2,
+    )
+
+    next_page_link = page.find("a", {"rel": "next"})
+    prev_page_link = page.find("a", {"rel": "previous"})
+
+    assert next_page_link is None
+    assert prev_page_link is not None
 
 
 def test_doesnt_show_pagination_when_50_or_fewer_items(


### PR DESCRIPTION
- [ ] Updated pagination to show "next" when there's more than 50 job items. 
- [ ] Updated download links on Activity page to display only when CSV files are available
- [ ] Fixed pagination logic to prevent infinite next button by checking if we're on the last page

tickets:
https://github.com/GSA/notifications-admin/issues/2257
https://github.com/GSA/notifications-admin/issues/2152