### PR TITLE
Undo recent changes related to Python upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ watch-frontend:  ## Build frontend and watch for changes
 
 .PHONY: run-flask
 run-flask:  ## Run flask
-	poetry run flask run -p 6012 --host=0.0.0.0
+	poetry run newrelic-admin run-program flask run -p 6012 --host=0.0.0.0
 
 .PHONY: run-flask-bare
 run-flask-bare:  ## Run flask without invoking poetry so we can override ENV variables in .env

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,7 +10,7 @@ import gunicorn
 # but we have an unusual configuration with a lot of cpus and not much memory
 # so adjust it.
 workers = multiprocessing.cpu_count()
-worker_class = "sync"
+worker_class = "gevent"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 disable_redirect_access_to_syslog = True
 gunicorn.SERVER_SOFTWARE = "None"

--- a/gunicorn_entry.py
+++ b/gunicorn_entry.py
@@ -1,10 +1,5 @@
-# from gevent import monkey
+from gevent import monkey
 
-# monkey.patch_all()
-
-
-import newrelic.agent  # noqa
-
-newrelic.agent.initialize("./newrelic.ini")
+monkey.patch_all()
 
 from application import application  # noqa


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset undoes the recent changes we tried after the Python 3.13 update as they had no bearing on the SSL cert validation errors.  Back to the drawing board!

NOTE: This does leave the New Relic package change in place for now.

## Security Considerations

* None, this is reverting code back to a known working state.

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice