### PR TITLE
Attempt to debug SSL cert validation error

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -161,7 +161,7 @@
         "filename": "app/config.py",
         "hashed_secret": "577a4c667e4af8682ca431857214b3a920883efc",
         "is_verified": false,
-        "line_number": 123,
+        "line_number": 121,
         "is_secret": false
       }
     ],
@@ -634,5 +634,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-22T17:07:31Z"
+  "generated_at": "2025-07-29T21:32:59Z"
 }

--- a/app/config.py
+++ b/app/config.py
@@ -19,9 +19,7 @@ class Config(object):
     HEADER_COLOUR = (
         "#81878b"  # mix of dark-grey and mid-grey
     )
-    LOGO_CDN_DOMAIN = (
-        "static-logos.notifications.service.gov.uk"  # TODO use our own CDN
-    )
+
     ASSETS_DEBUG = False
 
     # Credentials

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -2,6 +2,8 @@ import json
 import logging
 import urllib.parse
 
+from os import getenv
+
 import requests
 
 from notifications_python_client import __version__
@@ -10,21 +12,22 @@ from notifications_python_client.errors import HTTPError, InvalidResponse
 
 logger = logging.getLogger(__name__)
 
+API_PUBLIC_URL = getenv("API_PUBLIC_URL", "localhost")
 
 class BaseAPIClient:
     """
-    Base class for GOV.UK Notify API client.
+    Base class for Notify.gov API client.
 
     This class is not thread-safe.
     """
 
     def __init__(
-        self, api_key, base_url="https://api.notifications.service.gov.uk", timeout=30
+        self, api_key, base_url=API_PUBLIC_URL, timeout=30
     ):
         """
         Initialise the client
         Error if either of base_url or secret missing
-        :param base_url - base URL of GOV.UK Notify API:
+        :param base_url - base URL of Notify.gov API:
         :param secret - application secret - used to sign the request:
         :param timeout - request timeout on the client
         :return:

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 API_PUBLIC_URL = getenv("API_PUBLIC_URL", "localhost")
 
+
 class BaseAPIClient:
     """
     Base class for Notify.gov API client.

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -49,4 +49,4 @@ def test_owasp_useful_headers_set(
         expected_sources <= actual_sources
     ), f"Missing sources in connect-src: {expected_sources - actual_sources}"
     assert search(r"style-src 'self' static\.example\.com 'nonce-.*';", csp)
-    assert search(r"img-src 'self' static\.example\.com static-logos\.test\.com", csp)
+    assert search(r"img-src 'self' static\.example\.com", csp)


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset introduces a few changes:

* Removes UK Notify Logo URL and config
* Removes UK Notify API URL and replaces with Notify.gov
* Improves the error handler for HTTPErrors to provide actual exception and stack trace information


## Security Considerations

* Removes more references to the UK Notify URLs
* Includes more information in some of our error handling; we should validate that this is a change we want to keep going forward and ensure it does not include any sensitive information as a part of our testing.

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice