### PR TITLE
Fix empty table display in My activity view when user has no jobs

### DIFF
--- a/app/assets/javascripts/activityChart.js
+++ b/app/assets/javascripts/activityChart.js
@@ -316,9 +316,18 @@
                 return rowSender === currentUserName;
             });
 
-            userRows.slice(0, 5).forEach(row => {
-                row.style.display = '';
-            });
+            if (userRows.length > 0) {
+                userRows.slice(0, 5).forEach(row => {
+                    row.style.display = '';
+                });
+            } else {
+                const emptyMessageRow = Array.from(allRows).find(row => {
+                    return row.querySelector('.table-empty-message');
+                });
+                if (emptyMessageRow) {
+                    emptyMessageRow.style.display = '';
+                }
+            }
         } else {
 
             tableHeading.textContent = 'Service activity';


### PR DESCRIPTION
Ticket: https://github.com/GSA/notifications-admin/issues/2085

Fix empty table display in My activity view when user has no jobs

Error:
<img width="1119" height="625" alt="image" src="https://github.com/user-attachments/assets/afee8500-25f2-402c-ade5-567f03389fd4" />

Fixed:
<img width="944" height="371" alt="image" src="https://github.com/user-attachments/assets/0611f93a-9dd8-480a-b4d8-ad50e05f69b3" />


