### PR TITLE
fix and update to template manage

### DIFF
--- a/app/assets/javascripts/collapsibleCheckboxes.js
+++ b/app/assets/javascripts/collapsibleCheckboxes.js
@@ -138,6 +138,7 @@
   };
   CollapsibleCheckboxes.prototype.toggleAll = function(e) {
     e.preventDefault();
+    e.stopPropagation();
     const allChecked = this.$checkboxes.filter(':checked').length === this.$checkboxes.length;
 
     if (allChecked) {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1726,11 +1726,14 @@ class TemplateFolderForm(StripWhitespaceForm):
     def __init__(self, all_service_users=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if all_service_users is not None:
-            self.users_with_permission.all_service_users = all_service_users
+            regular_users = [user for user in all_service_users if not user.platform_admin]
+            platform_admins = [user for user in all_service_users if user.platform_admin]
+
+            self.users_with_permission.all_service_users = regular_users
             self.users_with_permission.choices = [
-                (item.id, f"{item.name} (admin)" if item.platform_admin else item.name)
-                for item in all_service_users
+                (item.id, item.name) for item in regular_users
             ]
+            self.platform_admins = platform_admins
 
     users_with_permission = USWDSCollapsibleCheckboxesField(
         "Team members who can see this folder", field_label="team member"

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1728,7 +1728,8 @@ class TemplateFolderForm(StripWhitespaceForm):
         if all_service_users is not None:
             self.users_with_permission.all_service_users = all_service_users
             self.users_with_permission.choices = [
-                (item.id, item.name) for item in all_service_users
+                (item.id, f"{item.name} (admin)" if item.platform_admin else item.name)
+                for item in all_service_users
             ]
 
     users_with_permission = USWDSCollapsibleCheckboxesField(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -180,7 +180,10 @@ def process_folder_management_form(form, current_folder_id):
 
     if form.is_add_folder_op:
         new_folder_id = template_folder_api_client.create_template_folder(
-            current_service.id, name=form.get_folder_name(), parent_id=current_folder_id
+            current_service.id,
+            name=form.get_folder_name(),
+            parent_id=current_folder_id,
+            created_by_id=str(current_user.id)
         )
 
     if form.is_move_op:

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -4,8 +4,10 @@ from app.notify_client import NotifyAdminAPIClient, cache
 
 class TemplateFolderAPIClient(NotifyAdminAPIClient):
     @cache.delete("service-{service_id}-template-folders")
-    def create_template_folder(self, service_id, name, parent_id=None):
+    def create_template_folder(self, service_id, name, parent_id=None, created_by_id=None):
         data = {"name": name, "parent_id": parent_id}
+        if created_by_id:
+            data["created_by_id"] = created_by_id
         return self.post("/service/{}/template-folder".format(service_id), data)[
             "data"
         ]["id"]

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -86,13 +86,17 @@
                 </ul>
                 {% if current_service.all_template_folders %}
                   <p class="usa-body tick-cross-list-hint">
-                    {% set folder_count = user.template_folders_for_service(current_service) | length %}
-                    {% if folder_count == 0 %}
-                      Cannot see any folders
-                    {% elif folder_count != current_service.all_template_folders | length %}
-                      Can see {{ folder_count }} folder{% if folder_count > 1 %}s{% endif %}
+                    {% if user.platform_admin %}
+                      Platform admin - sees all folders
                     {% else %}
-                      Can see all folders
+                      {% set folder_count = user.template_folders_for_service(current_service) | length %}
+                      {% if folder_count == 0 %}
+                        Cannot see any folders
+                      {% elif folder_count != current_service.all_template_folders | length %}
+                        Can see {{ folder_count }} folder{% if folder_count > 1 %}s{% endif %}
+                      {% else %}
+                        Can see all folders
+                      {% endif %}
                     {% endif %}
                   </p>
                 {% endif %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -87,7 +87,7 @@
                 {% if current_service.all_template_folders %}
                   <p class="usa-body tick-cross-list-hint">
                     {% if user.platform_admin %}
-                      Platform admin - sees all folders
+                      Platform admin can see all folders
                     {% else %}
                       {% set folder_count = user.template_folders_for_service(current_service) | length %}
                       {% if folder_count == 0 %}

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -28,7 +28,7 @@
     {% if current_user.has_permissions(ServicePermission.MANAGE_SERVICE) and form.users_with_permission.all_service_users %}
       {{ form.users_with_permission }}
       {% if form.platform_admins is defined and form.platform_admins %}
-        <p class="usa-hint">Platform administrators can see all folders and cannot be removed from folders:</p>
+        <p class="usa-hint">Platform admin can see all folders:</p>
         <ul class="usa-hint usa-list">
           {% for admin in form.platform_admins %}
             <li>{{ admin.name }}</li>

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -27,6 +27,14 @@
     }) }}
     {% if current_user.has_permissions(ServicePermission.MANAGE_SERVICE) and form.users_with_permission.all_service_users %}
       {{ form.users_with_permission }}
+      {% if form.platform_admins is defined and form.platform_admins %}
+        <p class="usa-hint">Platform administrators can see all folders and cannot be removed from folders:</p>
+        <ul class="usa-hint usa-list">
+          {% for admin in form.platform_admins %}
+            <li>{{ admin.name }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
     {% endif %}
 
     {{ page_footer(

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1500,7 +1500,7 @@ def test_new_folder_is_created_if_only_new_folder_is_filled_out(
 
     assert mock_move_to_template_folder.called is False
     mock_create_template_folder.assert_called_once_with(
-        SERVICE_ONE_ID, name="new folder", parent_id=None
+        SERVICE_ONE_ID, name="new folder", parent_id=None, created_by_id="6ce466d0-fd6a-11e5-82f5-e0accb9d11a6"
     )
 
 
@@ -1538,7 +1538,7 @@ def test_should_be_able_to_move_to_new_folder(
     )
 
     mock_create_template_folder.assert_called_once_with(
-        SERVICE_ONE_ID, name="new folder", parent_id=None
+        SERVICE_ONE_ID, name="new folder", parent_id=None, created_by_id="6ce466d0-fd6a-11e5-82f5-e0accb9d11a6"
     )
     mock_move_to_template_folder.assert_called_once_with(
         service_id=SERVICE_ONE_ID,

--- a/tests/javascripts/collapsibleCheckboxes.test.js
+++ b/tests/javascripts/collapsibleCheckboxes.test.js
@@ -429,6 +429,36 @@ describe('Collapsible fieldset', () => {
       expect(toggleButton.parentElement.style.display).toEqual('none');
     });
 
+    test("clicking 'Select all' does not collapse the fieldset", () => {
+      const toggleButton = document.querySelector('.usa-button--small');
+      const doneButton = formGroup.querySelector('.selection-footer__button');
+
+      expect(helpers.element(fieldset).is('hidden')).toBe(false);
+      expect(doneButton.getAttribute('aria-expanded')).toEqual('true');
+
+      helpers.triggerEvent(toggleButton, 'click');
+
+      expect(helpers.element(fieldset).is('hidden')).toBe(false);
+      expect(doneButton.getAttribute('aria-expanded')).toEqual('true');
+      expect(doneButton.textContent.trim()).toEqual("Done choosing folders");
+    });
+
+    test("clicking 'Deselect all' does not collapse the fieldset", () => {
+      const toggleButton = document.querySelector('.usa-button--small');
+      const doneButton = formGroup.querySelector('.selection-footer__button');
+
+      helpers.triggerEvent(toggleButton, 'click');
+
+      expect(helpers.element(fieldset).is('hidden')).toBe(false);
+      expect(doneButton.getAttribute('aria-expanded')).toEqual('true');
+
+      helpers.triggerEvent(toggleButton, 'click');
+
+      expect(helpers.element(fieldset).is('hidden')).toBe(false);
+      expect(doneButton.getAttribute('aria-expanded')).toEqual('true');
+      expect(doneButton.textContent.trim()).toEqual("Done choosing folders");
+    });
+
   });
 
   describe("toggle button visibility on re-expansion", () => {


### PR DESCRIPTION
Bug: When a new template folder is added, existing users are automatically given permission to it
[#2795](https://github.com/GSA/notifications-admin/issues/2795)

- [x] Grant the parent folder permissions to just the creator and platform_admins; all other users will need to be granted access manually. Other users will be defaulted to restricted unless granted.
- [x] We also need an easier way for a user to grant folder permissions to others, rather than manually selecting each individual user. (i.e. separating regular users to admin users)
- [x] Add “(platform admin)” next to a user’s name within the template manager so we can easily identify who is an admin.
- [x] Redo the “# of folders” count so that it's calculated correctly for platform_admins.
- [x] Prevent event bubbling within the template manage form

Make it more clear who has admin and folder permissions:
<img width="450" height="293" alt="image" src="https://github.com/user-attachments/assets/9a1f86a7-cbe5-4465-b16c-2bd5cd337b2c" />

Add “(platform admin)” next to a user’s name within team page
<img width="413" height="439" alt="image" src="https://github.com/user-attachments/assets/ebcc4861-d808-4185-b4c5-059f565cd614" />
