### PR TITLE
Add missing 'finished' field

### DIFF
--- a/app/assets/javascripts/socketio.js
+++ b/app/assets/javascripts/socketio.js
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const responseTime = Date.now() - startTime;
       currentInterval = calculateBackoff(responseTime);
 
-      if (data.stop === 1 || data.finished === true) {
+      if (data.finished === true) {
         stopPolling();
       }
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -458,6 +458,7 @@ def get_job_partials(job):
             job=job,
             arrived_from_preview_page_url=arrived_from_preview_page_url,
         ),
+        "finished": job.finished_processing,
     }
 
 


### PR DESCRIPTION
Fixed the polling endpoint so it returns the finished status, users now see the final status without needing a page refresh. Also fixed the issue where polling didn’t stop after job completion.