### PR TITLE
Remove secure Redis protocol workaround

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -19,7 +19,7 @@ class CloudfoundryConfig:
         try:
             return self.parsed_services["aws-elasticache-redis"][0]["credentials"][
                 "uri"
-            ].replace("redis://", "rediss://")
+            ]
         except KeyError:
             return os.environ.get("REDIS_URL")
 

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -16,7 +16,7 @@ bucket_credentials = {
 @pytest.fixture
 def vcap_services():
     return {
-        "aws-elasticache-redis": [{"credentials": {"uri": "redis://xxx:6379"}}],
+        "aws-elasticache-redis": [{"credentials": {"uri": "rediss://xxx:6379"}}],
         "s3": [
             {
                 "name": "notify-api-csv-upload-bucket-test",


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset removes a workaround that has been in place to account for a small error in the Cloud.gov AWS broker that has recently been fixed.

h/t to @markdboyd for the fix here! https://github.com/cloud-gov/aws-broker/pull/440

## Security Considerations

* The workaround was in place to ensure that the secure version of the Redis protocol (`rediss://`) was being used - the Cloud.gov broker now defaults to using this.

## A11y Checks (if applicable)

* Double check work is getting picked up by the automated E2E tests 
* Conduct browser-based tests through [AxeDevTools](https://www.deque.com/axe/devtools/) and [WAVE](https://wave.webaim.org/)
* Review the [Manual Checklist](https://docs.google.com/document/d/192bBXStebdXWtYhZQ73qaWMJhGcuSB1W6c9YBXhWZvc/edit?usp=sharing)
* Make sure there are no linting errors in VSCode or other IDE of choice
