### PR TITLE
timeoutPopup not needed in main bundle

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,6 @@ const javascripts = () => {
 
   // Use the mainBundle as the base and append remaining non-transpiled files at the end
   return mainBundle
-    .pipe(plugins.addSrc.append(paths.src + 'javascripts/timeoutPopup.js'))
     .pipe(plugins.addSrc.append(paths.src + 'javascripts/listEntry.js'))
     .pipe(plugins.addSrc.append(paths.src + 'javascripts/stick-to-window-when-scrolling.js'))
     .pipe(plugins.addSrc.append(paths.src + 'javascripts/totalMessagesChart.js'))


### PR DESCRIPTION
Since timeoutPopup.js is already included in notifyModules2 on line 57, it's already part of the mainBundle