### PR TITLE
add two providers to other tiers

### DIFF
--- a/terraform/demo/providers.tf
+++ b/terraform/demo/providers.tf
@@ -13,7 +13,7 @@ terraform {
 
   backend "s3" {
     bucket       = "cg-6b759c13-6253-4a64-9bda-dd1f620185b0"
-    key          = "admin.tfstate.stage"
+    key          = "admin.tfstate.demo"
     encrypt      = "true"
     region       = "us-gov-west-1"
     use_lockfile = "true"

--- a/terraform/production/providers.tf
+++ b/terraform/production/providers.tf
@@ -13,7 +13,7 @@ terraform {
 
   backend "s3" {
     bucket       = "cg-6b759c13-6253-4a64-9bda-dd1f620185b0"
-    key          = "admin.tfstate.stage"
+    key          = "admin.tfstate.prod"
     encrypt      = "true"
     region       = "us-gov-west-1"
     use_lockfile = "true"

--- a/terraform/sandbox/providers.tf
+++ b/terraform/sandbox/providers.tf
@@ -13,7 +13,7 @@ terraform {
 
   backend "s3" {
     bucket       = "cg-6b759c13-6253-4a64-9bda-dd1f620185b0"
-    key          = "admin.tfstate.stage"
+    key          = "admin.tfstate.sandbox"
     encrypt      = "true"
     region       = "us-gov-west-1"
     use_lockfile = "true"


### PR DESCRIPTION
## Description

Continue the changes in terraform where we declare two providers (cloud foundry-community and CloudFoundry) to the other main tiers (sandbox, demo, production).  Ignore 'shared' and 'development' for now as they are special cases we'll handle when needed.

## Security Considerations

N/A