### PR TITLE
try dry run terraform provider replace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,28 @@ jobs:
         terraform_version: "^1.7.5"
         terraform_wrapper: false
 
+
     - name: Terraform init
       working-directory: terraform/staging
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
       run: terraform init
+
+
+    - name: Terraform swap providers
+      working-directory: terraform/staging
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+      run: |
+        terraform state replace-provider \
+          -dry-run \
+          -state=terraform.tfstate \
+          'registry.terraform.io/cloudfoundry-community/cloudfoundry' \
+          'registry.terraform.io/cloudfoundry/cloudfoundry' \
+          module.logo_upload_bucket
+
     - name: Terraform apply
       working-directory: terraform/staging
       env:


### PR DESCRIPTION
## Description

We need to replace the terraform provider in the tfstate file, module by module.  Let's start with the logo_upload_bucket module, and let's do a dry-run during the deployment so we can analyze what would have happened if we did it for real and see if it looks safe and reasonable.

Note:  we have to actually merge this to staging to trigger it.  Also, we can flip this to run by changing "-dry-run" to "-auto-approve", but it will fail on the first run.  So we might want to disable everything after this step when we do it for real.  After it fails, we need to update the main.tf file and change the provider for the module.  Then everything should work.

## Security Considerations

N/A