### PR TITLE
replace dry-run with creating a new state file and printing out the p…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,20 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
       run: |
         terraform state replace-provider \
-          -dry-run \
           -state=terraform.tfstate \
+          -state-out=new-state.tfstate \
           'registry.terraform.io/cloudfoundry-community/cloudfoundry' \
           'registry.terraform.io/cloudfoundry/cloudfoundry' \
           module.logo_upload_bucket
+
+
+    - name: Terraform show swapped providers
+      working-directory: terraform/staging
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+      run: |
+        terraform show -json new-state.tfstate | jq '.values.root_module.child_modules[]?.provider_configs'
 
     - name: Terraform apply
       working-directory: terraform/staging


### PR DESCRIPTION
## Description

-dry-run is not a legit option for replacing providers, so let's try running the command, but outputting the new state to a throwaway file.  Then we can read the module and provider information from the file to see if it did what we wanted.

Note:  If the pinpoint attempt to only show provider and module information fails, we can fall back to just 'jq' which should print the whole state file.

## Security Considerations

N/A