### PR TITLE
See if we can destroy a specific module

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,27 +38,14 @@ jobs:
       run: terraform init
 
 
-    - name: Terraform swap providers
+    - name: Terraform see if we can destroy a specific module
       working-directory: terraform/staging
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
       run: |
-        terraform state replace-provider \
-          -state=terraform.tfstate \
-          -state-out=new-state.tfstate \
-          'registry.terraform.io/cloudfoundry-community/cloudfoundry' \
-          'registry.terraform.io/cloudfoundry/cloudfoundry' \
-          module.logo_upload_bucket
+        terraform plan -destroy -target=module.logo_upload_bucket
 
-
-    - name: Terraform show swapped providers
-      working-directory: terraform/staging
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
-      run: |
-        terraform show -json new-state.tfstate | jq '.values.root_module.child_modules[]?.provider_configs'
 
     - name: Terraform apply
       working-directory: terraform/staging


### PR DESCRIPTION
## Description

Our previous attempt to swap terraform providers on an existing module did not work, so let's see if we can just destroy the specific module and recreate it with the new provider.

This PR just runs a non-destructive 'plan'.  If it looks good, then we can destroy the module, then we will need a new PR where the module is adjusted to use the CloudFoundry provider.

## Security Considerations

N/A