### PR TITLE
comment out module.logo_upload_bucket so it doesnt get recreated

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -55,13 +55,14 @@ data "cloudfoundry_space" "space" {
 # }
 
 
-module "logo_upload_bucket" {
-  source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
+# This is the old form which used cfcommunity as a provider
+# module "logo_upload_bucket" {
+# source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
 
-  cf_org_name   = local.cf_org_name
-  cf_space_name = local.cf_space_name
-  name          = "${local.app_name}-logo-upload-bucket-${local.env}"
-}
+# cf_org_name   = local.cf_org_name
+# cf_space_name = local.cf_space_name
+# name          = "${local.app_name}-logo-upload-bucket-${local.env}"
+# }
 
 
 module "api_network_route" {


### PR DESCRIPTION
## Description

Comment out the old version of module.logo_upload_bucket so it doesn't get immediately created after destroy when apply runs.

## Security Considerations

N/A