### PR TITLE
destroy modules using deprecated provider

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -34,11 +34,11 @@ resource "null_resource" "prevent_destroy" {
 # name          = "${local.app_name}-logo-upload-bucket-${local.env}"
 # }
 
-# module "api_network_route" {
-# source = "../shared/container_networking"
+module "api_network_route" {
+  source = "../shared/container_networking"
 
-# cf_org_name          = local.cf_org_name
-# cf_space_name        = local.cf_space_name
-# source_app_name      = "${local.app_name}-${local.env}"
-# destination_app_name = "notify-api-${local.env}"
-# }
+  cf_org_name          = local.cf_org_name
+  cf_space_name        = local.cf_space_name
+  source_app_name      = "${local.app_name}-${local.env}"
+  destination_app_name = "notify-api-${local.env}"
+}


### PR DESCRIPTION
## Description

See if modules get deleted just by removing them from main.tf.   This would make the upgrade path to use the new terraform provider easier.

## Security Considerations

N/A