### PR TITLE
Fix feature flag case sensitivity for Cloud Foundry environments

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -79,7 +79,7 @@ class Config(object):
     NOTIFY_SERVICE_ID = "d6aa2c68-a2d9-4437-ab19-3ae8eb202553"
 
     ORGANIZATION_DASHBOARD_ENABLED = (
-        getenv("ORGANIZATION_DASHBOARD_ENABLED", "False") == "True"
+        getenv("ORGANIZATION_DASHBOARD_ENABLED", "false").lower() == "true"
     )
 
     NOTIFY_BILLING_DETAILS = json.loads(getenv("NOTIFY_BILLING_DETAILS") or "null") or {
@@ -115,7 +115,7 @@ class Development(Config):
 
     # Feature Flags
     ORGANIZATION_DASHBOARD_ENABLED = (
-        getenv("ORGANIZATION_DASHBOARD_ENABLED", "True") == "True"
+        getenv("ORGANIZATION_DASHBOARD_ENABLED", "true").lower() == "true"
     )
 
     # Buckets

--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -8,4 +8,4 @@ redis_enabled: 1
 nr_agent_id: '1050708682'
 nr_app_id: '1050708682'
 API_PUBLIC_URL: https://notify-api-production.app.cloud.gov
-ORGANIZATION_DASHBOARD_ENABLED: False
+ORGANIZATION_DASHBOARD_ENABLED: false

--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -8,4 +8,4 @@ redis_enabled: 1
 nr_agent_id: '1134291385'
 nr_app_id: '1031640326'
 API_PUBLIC_URL: https://notify-api-staging.app.cloud.gov
-ORGANIZATION_DASHBOARD_ENABLED: True
+ORGANIZATION_DASHBOARD_ENABLED: true


### PR DESCRIPTION
Cloud Foundry converts YAML boolean values to lowercase strings ("true"/"false"), but the config was checking for capital "True".