### PR TITLE
Potential fix for code scanning alert no. 23: URL redirection from remote source

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -24,7 +24,7 @@ from app.main.views.index import error
 from app.main.views.verify import activate_user
 from app.models.user import User
 from app.utils import hide_from_search_engines
-from app.utils.login import get_id_token, is_safe_redirect_url
+from app.utils.login import get_id_token
 
 # from app.utils.time import is_less_than_days_ago
 from app.utils.user import is_gov_user
@@ -179,8 +179,12 @@ def _handle_e2e_tests(redirect_url):  # pragma: no cover
         activate_user(user["id"])
 
         # Check if the redirect URL is present and safe before proceeding further
-        if redirect_url and is_safe_redirect_url(redirect_url):
-            return redirect(redirect_url)
+        # Defensive: sanitize backslashes, check for absolute URLs
+        if redirect_url:
+            cleaned_redirect_url = redirect_url.replace("\\", "")
+            parts = urlparse(cleaned_redirect_url)
+            if not parts.netloc and not parts.scheme:
+                return redirect(cleaned_redirect_url)
 
         return redirect(
             url_for(


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/notifications-admin/security/code-scanning/23](https://github.com/GSA/notifications-admin/security/code-scanning/23)

The best fix is to replace or robustly implement the guard on the redirect URL according to the recommendations: specifically, before redirecting to any URL provided in the query string, we need to ensure it is a relative URL and does not contain a scheme (like http/https) or a host. We can use `urllib.parse.urlparse` to parse and check that `netloc` and `scheme` are empty. As shown in the examples, we should also sanitize backslashes, which browsers treat as slashes.

In app/main/views/sign_in.py, update the conditional on line 218-219 to apply a robust validation using `urlparse`, replacing or augmenting `is_safe_redirect_url`. Make sure to add the necessary import for `urlparse`. You may remove or supplement the existing check as appropriate, but avoid changing any other logic or functionality.

Add:
- `from urllib.parse import urlparse` if it isn't already imported.
- Adjust the conditional so that before redirecting to `redirect_url`, you check:
    - `redirect_url` does not contain a scheme or netloc after replacing backslashes with nothing.
    - If not, redirect to a safe default instead.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
