### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -6,6 +6,9 @@ on:
     # this will run at noon UTC every day (7am EST / 8am EDT)
     - cron: '0 12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   check_staging_drift:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-demo.yml
+++ b/.github/workflows/terraform-demo.yml
@@ -5,6 +5,10 @@ on:
     branches: [ production ]
     paths: [ 'terraform/**' ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 defaults:
   run:
     working-directory: terraform/demo

--- a/.github/workflows/terraform-production.yml
+++ b/.github/workflows/terraform-production.yml
@@ -5,6 +5,10 @@ on:
     branches: [ production ]
     paths: [ 'terraform/**' ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 defaults:
   run:
     working-directory: terraform/production

--- a/.github/workflows/terraform-staging.yml
+++ b/.github/workflows/terraform-staging.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
     paths: [ 'terraform/**' ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 defaults:
   run:
     working-directory: terraform/staging


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to workflows missing token scopes:
  - `.github/workflows/drift.yml`
  - `.github/workflows/terraform-demo.yml`
  - `.github/workflows/terraform-production.yml`
  - `.github/workflows/terraform-staging.yml`
- Use least privilege by workflow behavior:
  - `contents: read` for all workflows
  - `pull-requests: write` for Terraform plan workflows that post PR comments

## Why
These workflows currently rely on implicit token defaults. Explicit scopes reduce unnecessary token access while preserving existing Terraform plan comment behavior.